### PR TITLE
bindata/v3.11.0/etcd: update ports and volumes

### DIFF
--- a/bindata/v3.11.0/etcd/pod.yaml
+++ b/bindata/v3.11.0/etcd/pod.yaml
@@ -21,10 +21,22 @@ spec:
         memory: 200Mi
         cpu: 100m
     ports:
-      - containerPort: 10257
+      - containerPort: 2379
+        name: client
+        protocol: TCP
+    ports:
+      - containerPort: 2380
+        name: peer
+        protocol: TCP
     volumeMounts:
-    - mountPath: /etc/kubernetes/static-pod-resources
-      name: resource-dir
+    - name: discovery
+      mountPath: /run/etcd/
+    - name: certs
+      mountPath: /etc/ssl/etcd/
+    - name: data-dir
+      mountPath: /var/lib/etcd/
+    - name: resource-dir
+      mountPath: /etc/kubernetes/static-pod-resources
 #    livenessProbe:
 #      httpGet:
 #        scheme: HTTPS
@@ -44,7 +56,15 @@ spec:
   tolerations:
   - operator: "Exists"
   volumes:
-  - hostPath:
+  - name: resource-dir
+    hostPath:
       path: /etc/kubernetes/static-pod-resources/etcd-pod-REVISION
-    name: resource-dir
-
+  - name: certs
+    hostPath:
+      path: /etc/kubernetes/static-pod-resources/etcd-member
+  - name: discovery
+    hostPath:
+      path: /run/etcd
+  - name: data-dir
+    hostPath:
+      path: /var/lib/etcd

--- a/bindata/v3.11.0/etcd/svc.yaml
+++ b/bindata/v3.11.0/etcd/svc.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     etcd: "true"
   ports:
-  - name: https
-    port: 443
-    targetPort: 10257
+  - name: client
+    port: 2379
+  - name: peer
+    port: 2380


### PR DESCRIPTION
This PR updates ports to use etcd defaults for client and peer. I also adjusted the volumes to consume what is being created by [machine-config-operator]( https://github.com/openshift/machine-config-operator/blob/71ace53d656266d73656bbccaccec2b3bb6c07c2/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml)