### PR TITLE
bindata/bootkube/config: update naming to EtcdConfig

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -1,23 +1,3 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
-kind: KubeControllerManagerConfig
+kind: EtcdConfig
 extendedArguments:
-  root-ca-file:
-  - "/etc/kubernetes/secrets/root-ca.crt"
-  service-account-private-key-file:
-  - "/etc/kubernetes/secrets/service-account.key"
-  cluster-signing-cert-file:
-  - "/etc/kubernetes/secrets/kube-ca.crt"
-  cluster-signing-key-file:
-  - "/etc/kubernetes/secrets/kube-ca.key"
-  secure-port:
-  - "10257"
-  port:
-  - "0"
-  {{if .ClusterCIDR }}
-  cluster-cidr: {{range .ClusterCIDR}}
-  - {{.}}{{end}}
-  {{end}}
-  {{if .ServiceClusterIPRange }}
-  service-cluster-ip-range: {{range .ServiceClusterIPRange}}
-  - {{.}}{{end}}
-  {{end}}

--- a/bindata/bootkube/config/config-overrides.yaml
+++ b/bindata/bootkube/config/config-overrides.yaml
@@ -1,5 +1,5 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
-kind: KubeControllerManagerConfig
+kind: EtcdConfig
 extendedArguments:
   root-ca-file:
   - "/var/run/configmaps/client-ca/ca-bundle.crt"


### PR DESCRIPTION
It appears this change is a necessary bit left over from migration from boilerplate code.