### PR TITLE
*: add ManagementState support to controllers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,4 @@ COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/bindata/b
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/cluster-etcd-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/manifests/ /manifests/
 
-#TODO uncomment below when we want to be part of CVO
-#LABEL io.openshift.release.operator true
+LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -11,5 +11,4 @@ COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/bindata/b
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/cluster-etcd-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/manifests/ /manifests/
 
-#TODO uncomment below when we want to be part of CVO 
-#LABEL io.openshift.release.operator true
+LABEL io.openshift.release.operator true

--- a/manifests/0000_12_etcd-operator_01_operator.cr.yaml
+++ b/manifests/0000_12_etcd-operator_01_operator.cr.yaml
@@ -5,4 +5,4 @@ metadata:
   annotations:
     release.openshift.io/create-only: "true"
 spec:
-  managementState: Managed
+  managementState: Unmanaged

--- a/manifests/0000_12_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_06_deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: etcd-operator
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: etcd-operator
@@ -20,7 +22,7 @@ spec:
       containers:
       - name: operator
         image: quay.io/openshift/cluster-etcd-operator:v4.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443
           name: metrics
@@ -70,5 +72,16 @@ spec:
           secretName: etcd-client
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
-      - operator: Exists 
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120

--- a/manifests/0000_12_etcd-operator_06_static_pod_demonset.yaml
+++ b/manifests/0000_12_etcd-operator_06_static_pod_demonset.yaml
@@ -45,7 +45,7 @@ spec:
         effect: NoSchedule
       containers:
       - image: "quay.io/openshift/cluster-etcd-operator:latest"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: etcd-staticpod
         command: ["/usr/bin/cluster-etcd-operator"]
         args:

--- a/manifests/0000_12_etcd-operator_06_static_sync_demonset.yaml
+++ b/manifests/0000_12_etcd-operator_06_static_sync_demonset.yaml
@@ -45,7 +45,7 @@ spec:
         effect: NoSchedule
       containers:
       - image: "quay.io/openshift/cluster-etcd-operator:latest"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: etcd-staticsync
         command: ["/usr/bin/cluster-etcd-operator"]
         args:

--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -79,6 +79,29 @@ func (c *ClusterMemberController) sync() error {
 	switch operatorSpec.ManagementState {
 	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
+		condUpgradable := operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeUpgradeable,
+			Status: operatorv1.ConditionFalse,
+		}
+		condProgressing := operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeProgressing,
+			Status: operatorv1.ConditionFalse,
+		}
+		condAvailable := operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeAvailable,
+			Status: operatorv1.ConditionTrue,
+		}
+		condDegraded := operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeDegraded,
+			Status: operatorv1.ConditionFalse,
+		}
+		if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient,
+			v1helpers.UpdateConditionFn(condUpgradable),
+			v1helpers.UpdateConditionFn(condProgressing),
+			v1helpers.UpdateConditionFn(condDegraded),
+			v1helpers.UpdateConditionFn(condAvailable)); updateError != nil {
+			return updateError
+		}
 		return nil
 	case operatorv1.Removed:
 		// TODO should we support removal?

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -52,6 +52,7 @@ func NewConfigObserver(
 
 				ResourceSync: resourceSyncer,
 				PreRunCachesSynced: append(configMapPreRunCacheSynced,
+					operatorClient.Informer().HasSynced,
 					operatorConfigInformers.Operator().V1().Etcds().Informer().HasSynced,
 
 					kubeInformersForNamespaces.InformersFor("openshift-etcd").Core().V1().Endpoints().Informer().HasSynced,

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -19,6 +19,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,6 +111,22 @@ func (c *EtcdCertSignerController) processNextWorkItem() bool {
 }
 
 func (c *EtcdCertSignerController) sync() error {
+	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
+	case operatorv1.Unmanaged:
+		return nil
+	case operatorv1.Removed:
+		// TODO should we support removal?
+		return nil
+	default:
+		c.eventRecorder.Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", operatorSpec.ManagementState)
+		return nil
+	}
+
 	// TODO: make the namespace and name constants in one of the packages
 	cm, err := c.clientset.CoreV1().ConfigMaps(etcdNamespace).Get("member-config", metav1.GetOptions{})
 	if err != nil {

--- a/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller.go
+++ b/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/clustermembercontroller"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -111,6 +112,22 @@ func (h *HostEtcdEndpointController) eventHandler() cache.ResourceEventHandler {
 }
 
 func (h *HostEtcdEndpointController) sync() error {
+	operatorSpec, _, _, err := h.operatorConfigClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
+	case operatorv1.Unmanaged:
+		return nil
+	case operatorv1.Removed:
+		// TODO should we support removal?
+		return nil
+	default:
+		h.eventRecorder.Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", operatorSpec.ManagementState)
+		return nil
+	}
+
 	ep, err := h.clientset.CoreV1().Endpoints(clustermembercontroller.EtcdEndpointNamespace).
 		Get(clustermembercontroller.EtcdHostEndpointName, v1.GetOptions{})
 	if err != nil {

--- a/pkg/operator/statuscontroller/condition.go
+++ b/pkg/operator/statuscontroller/condition.go
@@ -1,0 +1,134 @@
+package statuscontroller
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+// unionCondition returns a single cluster operator condition that is the union of multiple operator conditions.
+func unionCondition(conditionType string, defaultConditionStatus operatorv1.ConditionStatus, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
+	return internalUnionCondition(conditionType, defaultConditionStatus, false, allConditions...)
+}
+
+// unionInertialCondition returns a single cluster operator condition that is the union of multiple operator conditions,
+// but resists returning a condition with a status opposite the defaultConditionStatus.
+func unionInertialCondition(conditionType string, defaultConditionStatus operatorv1.ConditionStatus, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
+	return internalUnionCondition(conditionType, defaultConditionStatus, true, allConditions...)
+}
+
+// internalUnionCondition returns a single cluster operator condition that is the union of multiple operator conditions.
+//
+// defaultConditionStatus indicates whether you want to merge all Falses or merge all Trues.  For instance, Failures merge
+// on true, but Available merges on false.  Thing of it like an anti-default.
+//
+// If hasInertia, then resist returning a condition with a status opposite the defaultConditionStatus.
+func internalUnionCondition(conditionType string, defaultConditionStatus operatorv1.ConditionStatus, hasInertia bool, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
+	var oppositeConditionStatus operatorv1.ConditionStatus
+	if defaultConditionStatus == operatorv1.ConditionTrue {
+		oppositeConditionStatus = operatorv1.ConditionFalse
+	} else {
+		oppositeConditionStatus = operatorv1.ConditionTrue
+	}
+
+	interestingConditions := []operatorv1.OperatorCondition{}
+	badConditions := []operatorv1.OperatorCondition{}
+	for _, condition := range allConditions {
+		if strings.HasSuffix(condition.Type, conditionType) {
+			interestingConditions = append(interestingConditions, condition)
+
+			if condition.Status == oppositeConditionStatus {
+				badConditions = append(badConditions, condition)
+			}
+		}
+	}
+
+	unionedCondition := operatorv1.OperatorCondition{Type: conditionType, Status: operatorv1.ConditionUnknown}
+	if len(interestingConditions) == 0 {
+		unionedCondition.Status = operatorv1.ConditionUnknown
+		unionedCondition.Reason = "NoData"
+		return OperatorConditionToClusterOperatorCondition(unionedCondition)
+	}
+
+	oneMinuteAgo := time.Now().Add(-1 * time.Minute)
+	earliestBadConditionNotOldEnough := earliestTransitionTime(badConditions).Time.After(oneMinuteAgo)
+	if len(badConditions) == 0 || (hasInertia && earliestBadConditionNotOldEnough) {
+		unionedCondition.Status = defaultConditionStatus
+		unionedCondition.Message = unionMessage(interestingConditions)
+		unionedCondition.Reason = "AsExpected"
+		unionedCondition.LastTransitionTime = latestTransitionTime(interestingConditions)
+
+		return OperatorConditionToClusterOperatorCondition(unionedCondition)
+	}
+
+	// at this point we have bad conditions
+	unionedCondition.Status = oppositeConditionStatus
+	unionedCondition.Message = unionMessage(badConditions)
+	unionedCondition.Reason = unionReason(badConditions)
+	unionedCondition.LastTransitionTime = latestTransitionTime(badConditions)
+
+	return OperatorConditionToClusterOperatorCondition(unionedCondition)
+}
+
+func latestTransitionTime(conditions []operatorv1.OperatorCondition) metav1.Time {
+	latestTransitionTime := metav1.Time{}
+	for _, condition := range conditions {
+		if latestTransitionTime.Before(&condition.LastTransitionTime) {
+			latestTransitionTime = condition.LastTransitionTime
+		}
+	}
+	return latestTransitionTime
+}
+
+func earliestTransitionTime(conditions []operatorv1.OperatorCondition) metav1.Time {
+	earliestTransitionTime := metav1.Now()
+	for _, condition := range conditions {
+		if !earliestTransitionTime.Before(&condition.LastTransitionTime) {
+			earliestTransitionTime = condition.LastTransitionTime
+		}
+	}
+	return earliestTransitionTime
+}
+
+func uniq(s []string) []string {
+	seen := make(map[string]struct{}, len(s))
+	j := 0
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		s[j] = v
+		j++
+	}
+	return s[:j]
+}
+
+func unionMessage(conditions []operatorv1.OperatorCondition) string {
+	messages := []string{}
+	for _, condition := range conditions {
+		if len(condition.Message) == 0 {
+			continue
+		}
+		for _, message := range uniq(strings.Split(condition.Message, "\n")) {
+			messages = append(messages, fmt.Sprintf("%s: %s", condition.Type, message))
+		}
+	}
+	return strings.Join(messages, "\n")
+}
+
+func unionReason(conditions []operatorv1.OperatorCondition) string {
+	if len(conditions) == 1 {
+		if len(conditions[0].Reason) != 0 {
+			return conditions[0].Type + conditions[0].Reason
+		}
+		return conditions[0].Type
+	} else {
+		return "MultipleConditionsMatching"
+	}
+}

--- a/pkg/operator/statuscontroller/statuscontroller.go
+++ b/pkg/operator/statuscontroller/statuscontroller.go
@@ -125,8 +125,8 @@ func (c StatusSyncer) sync() error {
 	}
 	clusterOperatorObj := originalClusterOperatorObj.DeepCopy()
 
+	clusterOperatorObj.Status.RelatedObjects = c.relatedObjects
 	if detailedSpec.ManagementState == operatorv1.Unmanaged {
-		clusterOperatorObj.Status = configv1.ClusterOperatorStatus{}
 
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Reason: "Unmanaged"})
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Reason: "Unmanaged"})
@@ -153,7 +153,6 @@ func (c StatusSyncer) sync() error {
 		return nil
 	}
 
-	clusterOperatorObj.Status.RelatedObjects = c.relatedObjects
 	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionInertialCondition("Degraded", operatorv1.ConditionFalse, currentDetailedStatus.Conditions...))
 	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Progressing", operatorv1.ConditionFalse, currentDetailedStatus.Conditions...))
 	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Available", operatorv1.ConditionTrue, currentDetailedStatus.Conditions...))

--- a/pkg/operator/statuscontroller/statuscontroller.go
+++ b/pkg/operator/statuscontroller/statuscontroller.go
@@ -1,0 +1,262 @@
+package statuscontroller
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+
+	configv1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// NOTE this controller is only temporary until we merge installer changes.
+
+var workQueueKey = "instance"
+
+type VersionGetter interface {
+	// SetVersion is a way to set the version for an operand.  It must be thread-safe
+	SetVersion(operandName, version string)
+	// GetVersion is way to get the versions for all operands.  It must be thread-safe and return an object that doesn't mutate
+	GetVersions() map[string]string
+	// VersionChangedChannel is a channel that will get an item whenever SetVersion has been called
+	VersionChangedChannel() <-chan struct{}
+}
+
+type StatusSyncer struct {
+	clusterOperatorName string
+	relatedObjects      []configv1.ObjectReference
+
+	versionGetter         VersionGetter
+	operatorClient        operatorv1helpers.OperatorClient
+	clusterOperatorClient configv1client.ClusterOperatorsGetter
+	clusterOperatorLister configv1listers.ClusterOperatorLister
+
+	cachesToSync  []cache.InformerSynced
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
+}
+
+func NewClusterOperatorStatusController(
+	name string,
+	relatedObjects []configv1.ObjectReference,
+	clusterOperatorClient configv1client.ClusterOperatorsGetter,
+	clusterOperatorInformer configv1informers.ClusterOperatorInformer,
+	operatorClient operatorv1helpers.OperatorClient,
+	versionGetter VersionGetter,
+	recorder events.Recorder,
+) *StatusSyncer {
+	c := &StatusSyncer{
+		clusterOperatorName:   name,
+		relatedObjects:        relatedObjects,
+		versionGetter:         versionGetter,
+		clusterOperatorClient: clusterOperatorClient,
+		clusterOperatorLister: clusterOperatorInformer.Lister(),
+		operatorClient:        operatorClient,
+		eventRecorder:         recorder.WithComponentSuffix("status-controller"),
+
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StatusSyncer_"+strings.Replace(name, "-", "_", -1)),
+	}
+
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
+	clusterOperatorInformer.Informer().AddEventHandler(c.eventHandler())
+
+	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, clusterOperatorInformer.Informer().HasSynced)
+
+	return c
+}
+
+// sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
+// must be information that is logically "owned" by another component.
+func (c StatusSyncer) sync() error {
+	detailedSpec, currentDetailedStatus, _, err := c.operatorClient.GetOperatorState()
+	if apierrors.IsNotFound(err) {
+		c.eventRecorder.Warningf("StatusNotFound", "Unable to determine current operator status for clusteroperator/%s", c.clusterOperatorName)
+		if err := c.clusterOperatorClient.ClusterOperators().Delete(c.clusterOperatorName, nil); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	originalClusterOperatorObj, err := c.clusterOperatorLister.Get(c.clusterOperatorName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		c.eventRecorder.Warningf("StatusFailed", "Unable to get current operator status for clusteroperator/%s: %v", c.clusterOperatorName, err)
+		return err
+	}
+
+	// ensure that we have a clusteroperator resource
+	if originalClusterOperatorObj == nil || apierrors.IsNotFound(err) {
+		klog.Infof("clusteroperator/%s not found", c.clusterOperatorName)
+		var createErr error
+		originalClusterOperatorObj, createErr = c.clusterOperatorClient.ClusterOperators().Create(&configv1.ClusterOperator{
+			ObjectMeta: metav1.ObjectMeta{Name: c.clusterOperatorName},
+		})
+		if apierrors.IsNotFound(createErr) {
+			// this means that the API isn't present.  We did not fail.  Try again later
+			klog.Infof("ClusterOperator API not created")
+			c.queue.AddRateLimited(workQueueKey)
+			return nil
+		}
+		if createErr != nil {
+			c.eventRecorder.Warningf("StatusCreateFailed", "Failed to create operator status: %v", err)
+			return createErr
+		}
+	}
+	clusterOperatorObj := originalClusterOperatorObj.DeepCopy()
+
+	if detailedSpec.ManagementState == operatorv1.Unmanaged {
+		clusterOperatorObj.Status = configv1.ClusterOperatorStatus{}
+
+		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Reason: "Unmanaged"})
+		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Reason: "Unmanaged"})
+		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse, Reason: "Unmanaged"})
+		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorUpgradeable, Status: configv1.ConditionTrue, Reason: "Unmanaged"})
+
+		versions := c.versionGetter.GetVersions()
+		for operand, version := range versions {
+			previousVersion := operatorv1helpers.SetOperandVersion(&clusterOperatorObj.Status.Versions, configv1.OperandVersion{Name: operand, Version: version})
+			if previousVersion != version {
+				// having this message will give us a marker in events when the operator updated compared to when the operand is updated
+				c.eventRecorder.Eventf("OperatorVersionChanged", "clusteroperator/%s version %q changed from %q to %q", c.clusterOperatorName, operand, previousVersion, version)
+			}
+		}
+
+		if equality.Semantic.DeepEqual(clusterOperatorObj, originalClusterOperatorObj) {
+			return nil
+		}
+		if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(clusterOperatorObj); err != nil {
+			return updateErr
+		}
+
+		c.eventRecorder.Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+		return nil
+	}
+
+	clusterOperatorObj.Status.RelatedObjects = c.relatedObjects
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionInertialCondition("Degraded", operatorv1.ConditionFalse, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Progressing", operatorv1.ConditionFalse, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Available", operatorv1.ConditionTrue, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Upgradeable", operatorv1.ConditionTrue, currentDetailedStatus.Conditions...))
+
+	// TODO work out removal.  We don't always know the existing value, so removing early seems like a bad idea.  Perhaps a remove flag.
+	versions := c.versionGetter.GetVersions()
+	for operand, version := range versions {
+		previousVersion := operatorv1helpers.SetOperandVersion(&clusterOperatorObj.Status.Versions, configv1.OperandVersion{Name: operand, Version: version})
+		if previousVersion != version {
+			// having this message will give us a marker in events when the operator updated compared to when the operand is updated
+			c.eventRecorder.Eventf("OperatorVersionChanged", "clusteroperator/%s version %q changed from %q to %q", c.clusterOperatorName, operand, previousVersion, version)
+		}
+	}
+
+	// if we have no diff, just return
+	if equality.Semantic.DeepEqual(clusterOperatorObj, originalClusterOperatorObj) {
+		return nil
+	}
+	klog.V(2).Infof("clusteroperator/%s diff %v", c.clusterOperatorName, resourceapply.JSONPatch(originalClusterOperatorObj, clusterOperatorObj))
+
+	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(clusterOperatorObj); err != nil {
+		return updateErr
+	}
+	c.eventRecorder.Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+	return nil
+}
+
+func OperatorConditionToClusterOperatorCondition(condition operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
+	return configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.ClusterStatusConditionType(condition.Type),
+		Status:             configv1.ConditionStatus(condition.Status),
+		LastTransitionTime: condition.LastTransitionTime,
+		Reason:             condition.Reason,
+		Message:            condition.Message,
+	}
+}
+
+func (c *StatusSyncer) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting StatusSyncer-" + c.clusterOperatorName)
+	defer klog.Infof("Shutting down StatusSyncer-" + c.clusterOperatorName)
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
+		return
+	}
+
+	// start watching for version changes
+	go c.watchVersionGetter(stopCh)
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *StatusSyncer) watchVersionGetter(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+
+	versionCh := c.versionGetter.VersionChangedChannel()
+	// always kick at least once
+	c.queue.Add(workQueueKey)
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-versionCh:
+			c.queue.Add(workQueueKey)
+		}
+	}
+}
+
+func (c *StatusSyncer) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *StatusSyncer) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+// eventHandler queues the operator to check spec and status
+func (c *StatusSyncer) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
+	}
+}


### PR DESCRIPTION
This PR adds `cluster-etcd-operator` to CVO in an Unmanaged state. This is a temporary state until the installer changes can merge and then allows us to test scale with operator with one PR against this repo changing the `Managed` with the addition of a PR to MCO.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>