### PR TITLE
manifests: Make cluster-etcd-operator Managed

### DIFF
--- a/manifests/0000_12_etcd-operator_01_operator.cr.yaml
+++ b/manifests/0000_12_etcd-operator_01_operator.cr.yaml
@@ -5,4 +5,4 @@ metadata:
   annotations:
     release.openshift.io/create-only: "true"
 spec:
-  managementState: Unmanaged
+  managementState: Managed


### PR DESCRIPTION
With the latest checkins on MCO, CEO, and installer, we are in a position to turn cluster-etcd-operator as `Managed` in 4.3.