### PR TITLE
pkg/cmd/*: fix openshift operator clients and host-endpoint-controller

### DIFF
--- a/pkg/cmd/staticpodcontroller/staticpodcontroller.go
+++ b/pkg/cmd/staticpodcontroller/staticpodcontroller.go
@@ -10,6 +10,9 @@ import (
 	"os"
 	"time"
 
+	etcdv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	ceoapi "github.com/openshift/cluster-etcd-operator/pkg/operator/api"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/version"
@@ -27,7 +30,6 @@ import (
 	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -35,7 +37,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
-	corev1informer "k8s.io/client-go/informers/core/v1"
 	corev1client "k8s.io/client-go/kubernetes"
 )
 
@@ -127,8 +128,19 @@ func (s *podOpts) Run() error {
 
 	eventRecorder := events.NewKubeRecorder(clientset.CoreV1().Events(etcdNamespace), "static-pod-controller-"+localEtcdName, controllerRef)
 
+	etcdInformer, err := operatorClient.Informers.ForResource(schema.GroupVersionResource{
+		Group:    "operator.openshift.io",
+		Version:  "v1",
+		Resource: "etcds",
+	})
+	if err != nil {
+		klog.Errorf("error getting etcd informer %#v\n", err)
+		return err
+	}
+
 	staticPodController := NewStaticPodController(
-		operatorClient,
+		operatorClient.Client.Etcds(),
+		etcdInformer,
 		kubeInformerFactory,
 		clientset,
 		clientmc,
@@ -145,9 +157,9 @@ func (s *podOpts) Run() error {
 }
 
 type StaticPodController struct {
-	operatorConfigClient                   v1helpers.OperatorClient
-	podInformer                            corev1informer.SecretInformer
-	kubeInformersForOpenshiftEtcdNamespace cache.SharedIndexInformer
+	etcdKubeClient                         etcdv1.EtcdInterface
+	etcdInformer                           informers.GenericInformer
+	kubeInformersForOpenshiftEtcdNamespace informers.SharedInformerFactory
 	clientset                              corev1client.Interface
 	clientmc                               mcfgclientset.Interface
 	localEtcdName                          string
@@ -158,7 +170,8 @@ type StaticPodController struct {
 }
 
 func NewStaticPodController(
-	operatorConfigClient v1helpers.OperatorClient,
+	etcdKubeClient etcdv1.EtcdInterface,
+	etcdInformer informers.GenericInformer,
 	kubeInformersForOpenshiftEtcdNamespace informers.SharedInformerFactory,
 	clientset corev1client.Interface,
 	clientmc mcfgclientset.Interface,
@@ -166,26 +179,30 @@ func NewStaticPodController(
 	eventRecorder events.Recorder,
 ) *StaticPodController {
 	c := &StaticPodController{
-		operatorConfigClient: operatorConfigClient,
-		eventRecorder:        eventRecorder.WithComponentSuffix("static-pod-controller-" + localEtcdName),
-		clientset:            clientset,
-		clientmc:             clientmc,
-		localEtcdName:        localEtcdName,
+		etcdKubeClient:                         etcdKubeClient,
+		etcdInformer:                           etcdInformer,
+		eventRecorder:                          eventRecorder.WithComponentSuffix("static-pod-controller-" + localEtcdName),
+		kubeInformersForOpenshiftEtcdNamespace: kubeInformersForOpenshiftEtcdNamespace,
+		clientset:                              clientset,
+		clientmc:                               clientmc,
+		localEtcdName:                          localEtcdName,
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StaticPodController"),
 	}
 	kubeInformersForOpenshiftEtcdNamespace.Core().V1().Pods().Informer().AddEventHandler(c.eventHandler())
+	etcdInformer.Informer().AddEventHandler(c.eventHandler())
 	// kubeInformersForOpenshiftEtcdNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 
 	return c
 }
 
 func (c *StaticPodController) sync() error {
-	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
+	etcd, err := c.etcdKubeClient.Get("cluster", metav1.GetOptions{})
 	if err != nil {
+		klog.Errorf("error getting etcd cr: %#v", err)
 		return err
 	}
-	switch operatorSpec.ManagementState {
+	switch etcd.Spec.ManagementState {
 	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
@@ -193,7 +210,7 @@ func (c *StaticPodController) sync() error {
 		// TODO should we support removal?
 		return nil
 	default:
-		c.eventRecorder.Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", operatorSpec.ManagementState)
+		c.eventRecorder.Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", etcd.Spec.ManagementState)
 		return nil
 	}
 	pod, err := c.clientset.CoreV1().Pods(etcdNamespace).Get(c.localEtcdName, metav1.GetOptions{})
@@ -258,13 +275,14 @@ func (c *StaticPodController) IsMemberRemove(name string) bool {
 
 func (c *StaticPodController) PendingMemberList() ([]ceoapi.Member, error) {
 	configPath := []string{"cluster", "pending"}
-	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
+	etcd, err := c.etcdKubeClient.Get("cluster", metav1.GetOptions{})
 	if err != nil {
+		fmt.Printf("error getting etcd cr: %#v", err)
 		return nil, err
 	}
 
 	config := map[string]interface{}{}
-	if err := json.NewDecoder(bytes.NewBuffer(operatorSpec.ObservedConfig.Raw)).Decode(&config); err != nil {
+	if err := json.NewDecoder(bytes.NewBuffer(etcd.Spec.ObservedConfig.Raw)).Decode(&config); err != nil {
 		klog.V(4).Infof("decode of existing config failed with error: %v", err)
 	}
 	data, exists, err := unstructured.NestedSlice(config, configPath...)
@@ -319,6 +337,15 @@ func (c *StaticPodController) PendingMemberList() ([]ceoapi.Member, error) {
 func (c *StaticPodController) Run(stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
+
+	klog.Infof("Waiting for Cache to sync staticpodcontroller")
+	if !cache.WaitForCacheSync(stopCh,
+		c.kubeInformersForOpenshiftEtcdNamespace.Core().V1().Pods().Informer().HasSynced,
+		c.etcdInformer.Informer().HasSynced,
+	) {
+		klog.Errorf("error syncing cache")
+		return
+	}
 
 	klog.Infof("Starting staticpodcontroller")
 	defer klog.Infof("Shutting down staticpodcontroller")

--- a/pkg/cmd/staticpodcontroller/staticpodcontroller.go
+++ b/pkg/cmd/staticpodcontroller/staticpodcontroller.go
@@ -10,34 +10,30 @@ import (
 	"os"
 	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
 	etcdv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
+	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
 	ceoapi "github.com/openshift/cluster-etcd-operator/pkg/operator/api"
-
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-etcd-operator/pkg/version"
 	"github.com/openshift/library-go/pkg/operator/events"
+	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/vincent-petithory/dataurl"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
-
-	operatorv1 "github.com/openshift/api/operator/v1"
-	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
-	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
-	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
-	corev1client "k8s.io/client-go/kubernetes"
 )
 
 const (

--- a/pkg/cmd/staticsynccontroller/staticsynccontroller.go
+++ b/pkg/cmd/staticsynccontroller/staticsynccontroller.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
 	etcdv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
@@ -19,15 +17,15 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
-
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
 )
 
 const (

--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -543,6 +543,10 @@ func (c *ClusterMemberController) RemoveBootstrapFromEndpoint() error {
 		return nil
 	}
 
+	if len(hostEndpoint.Subsets[subsetIndex].Addresses) <= 1 {
+		return fmt.Errorf("only etcd-bootstrap endpoint observed, try again")
+	}
+
 	hostEndpoint.Subsets[subsetIndex].Addresses = append(hostEndpoint.Subsets[subsetIndex].Addresses[0:bootstrapIndex], hostEndpoint.Subsets[subsetIndex].Addresses[bootstrapIndex+1:]...)
 
 	_, err = c.clientset.CoreV1().Endpoints(EtcdEndpointNamespace).Update(hostEndpoint)
@@ -550,6 +554,7 @@ func (c *ClusterMemberController) RemoveBootstrapFromEndpoint() error {
 		klog.Errorf("error updating endpoint: %#v\n", err)
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -9,24 +9,21 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/transport"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	ceoapi "github.com/openshift/cluster-etcd-operator/pkg/operator/api"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/retry"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
-
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/client-go/informers"
 	corev1client "k8s.io/client-go/kubernetes"
-
-	ceoapi "github.com/openshift/cluster-etcd-operator/pkg/operator/api"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
 )
 
 const (
@@ -526,9 +523,12 @@ func (c *ClusterMemberController) RemoveBootstrapFromEndpoint() error {
 		klog.Errorf("error getting endpoint: %#v\n", err)
 		return err
 	}
+
+	hostEndpointCopy := hostEndpoint.DeepCopy()
+
 	subsetIndex := -1
 	bootstrapIndex := -1
-	for sI, s := range hostEndpoint.Subsets {
+	for sI, s := range hostEndpointCopy.Subsets {
 		for i, s := range s.Addresses {
 			if s.Hostname == "etcd-bootstrap" {
 				bootstrapIndex = i
@@ -543,13 +543,13 @@ func (c *ClusterMemberController) RemoveBootstrapFromEndpoint() error {
 		return nil
 	}
 
-	if len(hostEndpoint.Subsets[subsetIndex].Addresses) <= 1 {
+	if len(hostEndpointCopy.Subsets[subsetIndex].Addresses) <= 1 {
 		return fmt.Errorf("only etcd-bootstrap endpoint observed, try again")
 	}
 
-	hostEndpoint.Subsets[subsetIndex].Addresses = append(hostEndpoint.Subsets[subsetIndex].Addresses[0:bootstrapIndex], hostEndpoint.Subsets[subsetIndex].Addresses[bootstrapIndex+1:]...)
+	hostEndpointCopy.Subsets[subsetIndex].Addresses = append(hostEndpointCopy.Subsets[subsetIndex].Addresses[0:bootstrapIndex], hostEndpointCopy.Subsets[subsetIndex].Addresses[bootstrapIndex+1:]...)
 
-	_, err = c.clientset.CoreV1().Endpoints(EtcdEndpointNamespace).Update(hostEndpoint)
+	_, err = c.clientset.CoreV1().Endpoints(EtcdEndpointNamespace).Update(hostEndpointCopy)
 	if err != nil {
 		klog.Errorf("error updating endpoint: %#v\n", err)
 		return err

--- a/pkg/operator/configobservation/etcd/observe_etcd.go
+++ b/pkg/operator/configobservation/etcd/observe_etcd.go
@@ -201,11 +201,11 @@ func isPendingReady(bucket string, podName string, scalingName string, podLister
 		klog.Infof("isPendingReady: waiting for init cert containers to pass")
 		return false
 	}
-	if pod.Status.InitContainerStatuses[1].State.Terminated != nil && pod.Status.InitContainerStatuses[1].State.Terminated.ExitCode == 0 {
-		if pod.Status.ContainerStatuses[0].State.Waiting == nil {
-			klog.Info("isPendingReady: the container is either running/crashlooping")
-			return false
-		}
+	if pod.Status.InitContainerStatuses[1].State.Terminated != nil && pod.Status.InitContainerStatuses[1].State.Terminated.ExitCode == 0 && pod.Status.InitContainerStatuses[2].State.Running != nil {
+		return true
+	}
+
+	if pod.Status.Phase == corev1.PodRunning {
 		return true
 	}
 

--- a/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller.go
+++ b/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller.go
@@ -143,13 +143,15 @@ func (h *HostEtcdEndpointController) sync() error {
 		return fmt.Errorf("unexpected length of host endpoint subset")
 	}
 
-	newSubset, err := h.getNewAddressSubset(ep.Subsets[0].Addresses)
+	newEP := ep.DeepCopy()
+
+	newSubset, err := h.getNewAddressSubset(newEP.Subsets[0].Addresses)
 	if err != nil {
 		klog.Errorf("error getting new address subset: %#v", err)
 	}
 
-	ep.Subsets[0].Addresses = newSubset
-	_, err = h.clientset.CoreV1().Endpoints(clustermembercontroller.EtcdEndpointNamespace).Update(ep)
+	newEP.Subsets[0].Addresses = newSubset
+	_, err = h.clientset.CoreV1().Endpoints(clustermembercontroller.EtcdEndpointNamespace).Update(newEP)
 	return err
 }
 

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -2,8 +2,9 @@ package operator
 
 import (
 	"fmt"
-	"github.com/openshift/library-go/pkg/operator/status"
 	"time"
+
+	"github.com/openshift/library-go/pkg/operator/status"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/hostetcdendpointcontroller"
 
@@ -151,7 +152,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	go configObserver.Run(1, ctx.Done())
 	go clusterMemberController.Run(ctx.Done())
 	go func() {
-		err := bootstrapteardown.TearDownBootstrap(ctx.KubeConfig, clusterMemberController, operatorClient)
+		err := bootstrapteardown.TearDownBootstrap(ctx.KubeConfig, clusterMemberController, operatorClient.Client.Etcds())
 		if err != nil {
 			klog.Fatalf("Error tearing down bootstrap: %#v", err)
 		}


### PR DESCRIPTION
This fix:

- uses a dynamic informer for etcds.operator.openshift.io GVR
- a bug where etcd members were staying in Unknown state even 
after pod transitions in Running state
- creates a copy of hostendpoint before updating so there are no
 side effects of using the cache.