### PR TITLE
*: add support for IP based bootstrap endpoint

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: bootstrap-etcd-member
+  name: etcd-bootstrap-member
   namespace: openshift-etcd
   labels:
     k8s-app: etcd
@@ -24,6 +24,10 @@ spec:
     - name: data-dir
       mountPath: /var/lib/etcd/
     env:
+    - name: ETCD_IPV4_ADDRESS
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
     - name: ETCD_DATA_DIR
       value: "/var/lib/etcd"
     - name: ETCD_NAME
@@ -39,37 +43,37 @@ spec:
 
       source /run/etcd/environment
 
-      [ -e /etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.crt -a \
-        -e /etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.key ] || \
+      [ -e /etc/ssl/etcd/system:etcd-server:${ETCD_IPV4_ADDRESS}.crt -a \
+        -e /etc/ssl/etcd/system:etcd-server:${ETCD_IPV4_ADDRESS}.key ] || \
         kube-client-agent \
           request \
             --kubeconfig=/etc/kubernetes/kubeconfig \
             --orgname=system:etcd-servers \
             --assetsdir=/etc/ssl/etcd \
             --dnsnames={{.EtcdServerCertDNSNames}} \
-            --commonname=system:etcd-server:${ETCD_DNS_NAME} \
+            --commonname=system:etcd-server:${ETCD_IPV4_ADDRESS} \
             --ipaddrs=${ETCD_IPV4_ADDRESS},127.0.0.1 \
 
-      [ -e /etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.crt -a \
-        -e /etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.key ] || \
+      [ -e /etc/ssl/etcd/system:etcd-peer:${ETCD_IPV4_ADDRESS}.crt -a \
+        -e /etc/ssl/etcd/system:etcd-peer:${ETCD_IPV4_ADDRESS}.key ] || \
         kube-client-agent \
           request \
             --kubeconfig=/etc/kubernetes/kubeconfig \
             --orgname=system:etcd-peers \
             --assetsdir=/etc/ssl/etcd \
             --dnsnames={{.EtcdPeerCertDNSNames}} \
-            --commonname=system:etcd-peer:${ETCD_DNS_NAME} \
+            --commonname=system:etcd-peer:${ETCD_IPV4_ADDRESS} \
             --ipaddrs=${ETCD_IPV4_ADDRESS} \
 
-      [ -e /etc/ssl/etcd/system:etcd-metric:${ETCD_DNS_NAME}.crt -a \
-        -e /etc/ssl/etcd/system:etcd-metric:${ETCD_DNS_NAME}.key ] || \
+      [ -e /etc/ssl/etcd/system:etcd-metric:${ETCD_IPV4_ADDRESS}.crt -a \
+        -e /etc/ssl/etcd/system:etcd-metric:${ETCD_IPV4_ADDRESS}.key ] || \
         kube-client-agent \
           request \
             --kubeconfig=/etc/kubernetes/kubeconfig \
             --orgname=system:etcd-metrics \
             --assetsdir=/etc/ssl/etcd \
             --dnsnames={{.EtcdServerCertDNSNames}} \
-            --commonname=system:etcd-metric:${ETCD_DNS_NAME} \
+            --commonname=system:etcd-metric:${ETCD_IPV4_ADDRESS} \
             --ipaddrs=${ETCD_IPV4_ADDRESS} \
     terminationMessagePolicy: FallbackToLogsOnError
     securityContext:
@@ -98,13 +102,13 @@ spec:
       set +a
 
       exec etcd \
-        --initial-advertise-peer-urls=https://${ETCD_DNS_NAME}:2380 \
-        --cert-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.crt \
-        --key-file=/etc/ssl/etcd/system:etcd-server:${ETCD_DNS_NAME}.key \
+        --initial-advertise-peer-urls=https://${ETCD_IPV4_ADDRESS}:2380 \
+        --cert-file=/etc/ssl/etcd/system:etcd-server:${ETCD_IPV4_ADDRESS}.crt \
+        --key-file=/etc/ssl/etcd/system:etcd-server:${ETCD_IPV4_ADDRESS}.key \
         --trusted-ca-file=/etc/ssl/etcd/ca.crt \
         --client-cert-auth=true \
-        --peer-cert-file=/etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.crt \
-        --peer-key-file=/etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.key \
+        --peer-cert-file=/etc/ssl/etcd/system:etcd-peer:${ETCD_IPV4_ADDRESS}.crt \
+        --peer-key-file=/etc/ssl/etcd/system:etcd-peer:${ETCD_IPV4_ADDRESS}.key \
         --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
         --peer-client-cert-auth=true \
         --advertise-client-urls=https://${ETCD_IPV4_ADDRESS}:2379 \
@@ -152,13 +156,13 @@ spec:
       source /run/etcd/environment
 
       exec etcd grpc-proxy start \
-        --endpoints https://${ETCD_DNS_NAME}:9978 \
+        --endpoints https://${ETCD_IPV4_ADDRESS}:9978 \
         --metrics-addr https://0.0.0.0:9979 \
         --listen-addr 127.0.0.1:9977 \
-        --key /etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.key \
-        --key-file /etc/ssl/etcd/system:etcd-metric:${ETCD_DNS_NAME}.key \
-        --cert /etc/ssl/etcd/system:etcd-peer:${ETCD_DNS_NAME}.crt \
-        --cert-file /etc/ssl/etcd/system:etcd-metric:${ETCD_DNS_NAME}.crt \
+        --key /etc/ssl/etcd/system:etcd-peer:${ETCD_IPV4_ADDRESS}.key \
+        --key-file /etc/ssl/etcd/system:etcd-metric:${ETCD_IPV4_ADDRESS}.key \
+        --cert /etc/ssl/etcd/system:etcd-peer:${ETCD_IPV4_ADDRESS}.crt \
+        --cert-file /etc/ssl/etcd/system:etcd-metric:${ETCD_IPV4_ADDRESS}.crt \
         --cacert /etc/ssl/etcd/ca.crt \
         --trusted-ca-file /etc/ssl/etcd/metric-ca.crt \
     terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -165,10 +165,8 @@ func (r *renderOpts) Run() error {
 			"etcd.kube-system.svc.cluster.local",
 			"etcd.openshift-etcd.svc",
 			"etcd.openshift-etcd.svc.cluster.local",
-			"${ETCD_DNS_NAME}",
 		}, ","),
 		EtcdPeerCertDNSNames: strings.Join([]string{
-			"${ETCD_DNS_NAME}",
 			r.etcdDiscoveryDomain,
 		}, ","),
 	}

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -61,7 +61,8 @@ func NewConfigObserver(
 					kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes().Informer().HasSynced,
 				),
 			},
-			etcd.ObserveStorageURLs,
+			//TODO enable after migratation from KAO
+			//etcd.ObserveStorageURLs,
 			etcd.ObserveClusterMembers,
 			etcd.ObservePendingClusterMembers,
 		),

--- a/pkg/operator/configobservation/etcd/observe_etcd.go
+++ b/pkg/operator/configobservation/etcd/observe_etcd.go
@@ -168,7 +168,6 @@ func ObservePendingClusterMembers(genericListers configobserver.Listers, recorde
 
 	if len(observer.ObservedPending) > 0 {
 		if err := unstructured.SetNestedField(observedConfig, observer.ObservedPending, observer.pendingPath...); err != nil {
-			klog.Errorf("etcdURLs > 0 ERRRPRRRRRR: %v", errs)
 			return existingConfig, append(errs, err)
 		}
 	}
@@ -369,9 +368,9 @@ func (e *etcdObserver) setBootstrapMember() error {
 	for _, subset := range endpoints.Subsets {
 		for _, address := range subset.Addresses {
 			if address.Hostname == "etcd-bootstrap" {
-				name := address.Hostname
-				peerURLs := fmt.Sprintf("https://%s.%s:2380", name, e.ClusterDomain)
-				clusterMember, err := setMember(name, []string{peerURLs}, ceoapi.MemberUnknown)
+				ip := address.IP
+				peerURLs := fmt.Sprintf("https://%s:2380", ip)
+				clusterMember, err := setMember(ip, []string{peerURLs}, ceoapi.MemberUnknown)
 				if err != nil {
 					return err
 				}

--- a/pkg/operator/hostetcdendpointcontroller/members_test.go
+++ b/pkg/operator/hostetcdendpointcontroller/members_test.go
@@ -18,25 +18,42 @@ func Test_getHostname(t *testing.T) {
 		peerURLs []string
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name    string
+		args    args
+		want    string
+		wantErr bool
 	}{
 		{
 			name: "valid test case for etcd member",
-			args: args{peerURLs: []string{"https://etcd-0.foouser.tests.com"}},
+			args: args{peerURLs: []string{"https://etcd-0.foouser.tests.com:2380"}},
 			want: "etcd-0",
 		},
 		{
 			name: "valid test case for etcd bootstrap node",
-			args: args{peerURLs: []string{"https://etcd-bootstrap.foouser.tests.com"}},
+			args: args{peerURLs: []string{"https://10.0.139.142:2380"}},
 			want: "etcd-bootstrap",
+		},
+		{
+			name:    "error case malformed IP address",
+			args:    args{peerURLs: []string{"https://10.0.139:2380"}},
+			want:    "getEtcdName: peerURL \"https://10.0.139:2380\" is not properly formatted",
+			wantErr: true,
+		},
+		{
+			name:    "error case empty peerURLs",
+			args:    args{peerURLs: []string{""}},
+			want:    "getEtcdName: peerURL is empty",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getEtcdName(tt.args.peerURLs); got != tt.want {
-				t.Errorf("getHostname() = %v, want %v", got, tt.want)
+			got, err := getEtcdName(tt.args.peerURLs[0])
+			if tt.wantErr {
+				got = err.Error()
+			}
+			if got != tt.want {
+				t.Errorf("getEtcdName() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -46,7 +63,7 @@ func Test_healthyEtcdMemberGetter_EtcdList(t *testing.T) {
 	node := "node1"
 	peerURL := "https://etcd-0.foouser.test.com:2380"
 	bootstrapNode := "etcd-bootstrap"
-	bootstrapPeerUrl := "https://etcd-bootstrap.foouser.test.com:2380"
+	bootstrapPeerUrl := "https://10.0.139.142:2380"
 	//podIP := "10.0.139.142"
 	clusterMemberPath := []string{"cluster", "members"}
 


### PR DESCRIPTION
This PR adds support for etcd-bootstrap to have a client address that is IP vs FQDN. The reason is that customers do not want to add additional DNS records as a dependency for building clusters. 