### PR TITLE
*: add subcommand wait-for-ceo

### DIFF
--- a/cmd/cluster-etcd-operator/main.go
+++ b/cmd/cluster-etcd-operator/main.go
@@ -8,17 +8,16 @@ import (
 	"time"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/mount"
-
+	"github.com/openshift/cluster-etcd-operator/pkg/cmd/operator"
+	"github.com/openshift/cluster-etcd-operator/pkg/cmd/render"
+	"github.com/openshift/cluster-etcd-operator/pkg/cmd/staticpodcontroller"
+	"github.com/openshift/cluster-etcd-operator/pkg/cmd/staticsynccontroller"
+	"github.com/openshift/cluster-etcd-operator/pkg/cmd/waitforceo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
-
-	"github.com/openshift/cluster-etcd-operator/pkg/cmd/operator"
-	"github.com/openshift/cluster-etcd-operator/pkg/cmd/render"
-	"github.com/openshift/cluster-etcd-operator/pkg/cmd/staticpodcontroller"
-	"github.com/openshift/cluster-etcd-operator/pkg/cmd/staticsynccontroller"
 )
 
 func main() {
@@ -52,6 +51,7 @@ func NewSSCSCommand() *cobra.Command {
 	cmd.AddCommand(staticsynccontroller.NewStaticSyncCommand(os.Stderr))
 	cmd.AddCommand(staticpodcontroller.NewStaticPodCommand(os.Stderr))
 	cmd.AddCommand(mount.NewMountCommand(os.Stderr))
+	cmd.AddCommand(waitforceo.NewWaitForCeoCommand(os.Stderr))
 
 	return cmd
 }

--- a/pkg/cmd/waitforceo/waitforceo.go
+++ b/pkg/cmd/waitforceo/waitforceo.go
@@ -1,0 +1,59 @@
+package waitforceo
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/bootstrapteardown"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+)
+
+type waitForCeoOpts struct {
+	errOut     io.Writer
+	kubeconfig string
+}
+
+// NewWaitForCeoCommand waits for cluster-etcd-operator to bootstrap.
+func NewWaitForCeoCommand(errOut io.Writer) *cobra.Command {
+	waitForCeoOpts := &waitForCeoOpts{
+		errOut: errOut,
+	}
+	cmd := &cobra.Command{
+		Use:   "wait-for-ceo --FLAGS",
+		Short: "waits for cluster-etcd-operator to finish bootstrap etcd cluster",
+		Long:  "This command makes sure that the cluster-etcd-operator is available before signaling bootstrap is done",
+		Run: func(cmd *cobra.Command, args []string) {
+			must := func(fn func() error) {
+				if err := fn(); err != nil {
+					if cmd.HasParent() {
+						klog.Fatal(err)
+						fmt.Fprint(waitForCeoOpts.errOut, err.Error())
+					}
+				}
+			}
+			must(waitForCeoOpts.Run)
+		},
+	}
+
+	waitForCeoOpts.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (w *waitForCeoOpts) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&w.kubeconfig, "kubeconfig", "", "kubeconfig for the cluster it is bootstrapping")
+}
+
+func (w *waitForCeoOpts) Run() error {
+	config, err := clientcmd.BuildConfigFromFlags("", w.kubeconfig)
+	if err != nil {
+		klog.Errorf("error loading kubeconfig: %#v", err)
+	}
+	if err := bootstrapteardown.WaitForEtcdBootstrap(context.TODO(), config); err != nil {
+		klog.Errorf("error waiting for cluster-etcd-operator %#v", err)
+	}
+	return nil
+}

--- a/pkg/operator/bootstrapteardown/teardown.go
+++ b/pkg/operator/bootstrapteardown/teardown.go
@@ -4,59 +4,21 @@ import (
 	"context"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	etcdv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/clustermembercontroller"
-	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
-	clientwatch "k8s.io/client-go/tools/watch"
 	"k8s.io/klog"
 )
 
 func TearDownBootstrap(config *rest.Config,
 	clusterMemberShipController *clustermembercontroller.ClusterMemberController, etcdClient etcdv1.EtcdInterface) error {
-	failing := configv1.ClusterStatusConditionType("Failing")
-	var lastError string
-
-	cc := configclient.NewForConfigOrDie(config)
-	_, err := clientwatch.UntilWithSync(
-		context.Background(),
-		cache.NewListWatchFromClient(cc.ConfigV1().RESTClient(), "clusterversions", "", fields.OneTermEqualSelector("metadata.name", "version")),
-		&configv1.ClusterVersion{},
-		nil,
-		func(event watch.Event) (bool, error) {
-			switch event.Type {
-			case watch.Added, watch.Modified:
-				cv, ok := event.Object.(*configv1.ClusterVersion)
-				if !ok {
-					klog.Warningf("Expected a ClusterVersion object but got a %q object instead", event.Object.GetObjectKind().GroupVersionKind())
-					return false, nil
-				}
-				if cov1helpers.IsStatusConditionTrue(cv.Status.Conditions, configv1.OperatorAvailable) {
-					return true, nil
-				}
-				if cov1helpers.IsStatusConditionTrue(cv.Status.Conditions, failing) {
-					lastError = cov1helpers.FindStatusCondition(cv.Status.Conditions, failing).Message
-				} else if cov1helpers.IsStatusConditionTrue(cv.Status.Conditions, configv1.OperatorProgressing) {
-					lastError = cov1helpers.FindStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing).Message
-				}
-				klog.Errorf("Still waiting for the cluster to initialize: %s", lastError)
-				return false, nil
-			}
-			klog.Infof("Still waiting for the cluster to initialize...")
-			return false, nil
-		},
-	)
-
+	err := WaitForEtcdBootstrap(context.TODO(), config)
 	if err != nil {
-		klog.Errorf("error in watching clusterversions: %#v", err)
+		klog.Errorf("WaitForEtcdBootstrap failed with: %#v", err)
 	}
 
 	err = wait.PollInfinite(5*time.Second, func() (bool, error) {

--- a/pkg/operator/bootstrapteardown/waitforceo.go
+++ b/pkg/operator/bootstrapteardown/waitforceo.go
@@ -1,0 +1,75 @@
+package bootstrapteardown
+
+import (
+	"context"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	clientwatch "k8s.io/client-go/tools/watch"
+	"k8s.io/klog"
+)
+
+func WaitForEtcdBootstrap(ctx context.Context, config *rest.Config) error {
+	operatorConfigClient, err := operatorversionedclient.NewForConfig(config)
+	if err != nil {
+		klog.Errorf("error getting operator client config: %#v", err)
+		return err
+	}
+
+	// TODO: figure out if we can timeout after 30 mins by
+	// passing a different context here
+	if err := waitForEtcdBootstrap(ctx, operatorConfigClient.OperatorV1().RESTClient()); err != nil {
+		klog.Errorf("error watching etcd: %#v", err)
+	}
+	return err
+}
+
+func waitForEtcdBootstrap(ctx context.Context, operatorRestClient rest.Interface) error {
+	_, err := clientwatch.UntilWithSync(
+		ctx,
+		cache.NewListWatchFromClient(operatorRestClient, "etcds", "", fields.OneTermEqualSelector("metadata.name", "cluster")),
+		&operatorv1.Etcd{},
+		nil,
+		func(event watch.Event) (bool, error) {
+			switch event.Type {
+			case watch.Added, watch.Modified:
+				etcd, ok := event.Object.(*operatorv1.Etcd)
+				if !ok {
+					klog.Warningf("Expected an Etcd object but got a %q object instead", event.Object.GetObjectKind().GroupVersionKind())
+					return false, nil
+				}
+				return done(etcd)
+			}
+			klog.Infof("Still waiting for the cluster-etcd-operator to bootstrap...")
+			return false, nil
+		},
+	)
+
+	if err != nil {
+		klog.Errorf("error waiting for etcd CR: %#v", err)
+		return err
+	}
+
+	klog.Infof("cluster-etcd-operator bootstrap etcd")
+	return nil
+}
+
+func done(etcd *operatorv1.Etcd) (bool, error) {
+	if etcd.Spec.ManagementState == operatorv1.Unmanaged {
+		klog.Info("Cluster etcd operator is in Unmanaged mode")
+		return true, nil
+	}
+	if operatorv1helpers.IsOperatorConditionTrue(etcd.Status.Conditions, operatorv1.OperatorStatusTypeAvailable) &&
+		operatorv1helpers.IsOperatorConditionFalse(etcd.Status.Conditions, operatorv1.OperatorStatusTypeProgressing) &&
+		operatorv1helpers.IsOperatorConditionFalse(etcd.Status.Conditions, operatorv1.OperatorStatusTypeDegraded) {
+		klog.Info("Cluster etcd operator bootstrapped successfully")
+		return true, nil
+	}
+	klog.Infof("Still waiting for the cluster-etcd-operator to bootstrap")
+	return false, nil
+}

--- a/pkg/operator/bootstrapteardown/waitforceo_test.go
+++ b/pkg/operator/bootstrapteardown/waitforceo_test.go
@@ -1,0 +1,181 @@
+package bootstrapteardown
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	v1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_wait(t *testing.T) {
+	type args struct {
+		etcd *operatorv1.Etcd
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "test unmanaged cluster",
+			args: args{
+				etcd: &v1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: v1.EtcdSpec{
+						StaticPodOperatorSpec: v1.StaticPodOperatorSpec{
+							OperatorSpec: v1.OperatorSpec{
+								ManagementState: v1.Unmanaged,
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "test managed cluster but degraded",
+			args: args{
+				etcd: &v1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: v1.EtcdSpec{
+						StaticPodOperatorSpec: v1.StaticPodOperatorSpec{
+							OperatorSpec: v1.OperatorSpec{
+								ManagementState: v1.Managed,
+							},
+						},
+					},
+					Status: v1.EtcdStatus{
+						StaticPodOperatorStatus: v1.StaticPodOperatorStatus{
+							OperatorStatus: v1.OperatorStatus{
+								Conditions: []v1.OperatorCondition{
+									{
+										Type:   v1.OperatorStatusTypeDegraded,
+										Status: v1.ConditionTrue,
+									},
+								},
+							},
+						}},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "test managed cluster but progressing",
+			args: args{
+				etcd: &v1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: v1.EtcdSpec{
+						StaticPodOperatorSpec: v1.StaticPodOperatorSpec{
+							OperatorSpec: v1.OperatorSpec{
+								ManagementState: v1.Managed,
+							},
+						},
+					},
+					Status: v1.EtcdStatus{
+						StaticPodOperatorStatus: v1.StaticPodOperatorStatus{
+							OperatorStatus: v1.OperatorStatus{
+								Conditions: []v1.OperatorCondition{
+									{
+										Type:   v1.OperatorStatusTypeProgressing,
+										Status: v1.ConditionTrue,
+									},
+								},
+							},
+						}},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "test managed cluster but unavailable",
+			args: args{
+				etcd: &v1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: v1.EtcdSpec{
+						StaticPodOperatorSpec: v1.StaticPodOperatorSpec{
+							OperatorSpec: v1.OperatorSpec{
+								ManagementState: v1.Managed,
+							},
+						},
+					},
+					Status: v1.EtcdStatus{
+						StaticPodOperatorStatus: v1.StaticPodOperatorStatus{
+							OperatorStatus: v1.OperatorStatus{
+								Conditions: []v1.OperatorCondition{
+									{
+										Type:   v1.OperatorStatusTypeAvailable,
+										Status: v1.ConditionFalse,
+									},
+								},
+							},
+						}},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "test managed cluster and done",
+			args: args{
+				etcd: &v1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: v1.EtcdSpec{
+						StaticPodOperatorSpec: v1.StaticPodOperatorSpec{
+							OperatorSpec: v1.OperatorSpec{
+								ManagementState: v1.Managed,
+							},
+						},
+					},
+					Status: v1.EtcdStatus{
+						StaticPodOperatorStatus: v1.StaticPodOperatorStatus{
+							OperatorStatus: v1.OperatorStatus{
+								Conditions: []v1.OperatorCondition{
+									{
+										Type:   v1.OperatorStatusTypeDegraded,
+										Status: v1.ConditionFalse,
+									},
+									{
+										Type:   v1.OperatorStatusTypeProgressing,
+										Status: v1.ConditionFalse,
+									},
+									{
+										Type:   v1.OperatorStatusTypeAvailable,
+										Status: v1.ConditionTrue,
+									},
+								},
+							},
+						}},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := done(tt.args.etcd)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("done() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("done() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This subcommand will be used in bootkube.sh to signal it is 
safe to destroy bootstrap vm and related resources.

It re-organises the teardown logic to reuse the same function
for removing etcd-bootstrap from etcd-membership