### PR TITLE
*: add wait-for-kube command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ VERSION_OVERRIDE:=$(shell git describe --abbrev=8 --dirty --always)
 HASH:=$(shell git rev-parse --verify 'HEAD^{commit}')
 BUILD_DATE:=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 GLDFLAGS=-X $(REPO)/pkg/version.versionFromGit=$(VERSION_OVERRIDE) -X $(REPO)/pkg/version.commitFromGit=$(HASH) -X $(REPO)/pkg/version.buildDate=$(BUILD_DATE)
-GOFALGS=
 
 all: build
 .PHONY: all
@@ -18,7 +17,7 @@ build: bin/cluster-etcd-operator
 
 bin/cluster-etcd-operator: $(GOFILES) 
 	@echo Building $@
-	@go build $(GOFLAGS) -ldflags "$(GLDFLAGS)" -o $(ROOT_DIR)/$@ github.com/openshift/cluster-etcd-operator/cmd/cluster-etcd-operator
+	@go build -ldflags "$(GLDFLAGS)" -o $(ROOT_DIR)/$@ github.com/openshift/cluster-etcd-operator/cmd/cluster-etcd-operator
 
 test-unit:
 	@go test -v ./...

--- a/cmd/cluster-etcd-operator/main.go
+++ b/cmd/cluster-etcd-operator/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/staticpodcontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/staticsynccontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/waitforceo"
+	"github.com/openshift/cluster-etcd-operator/pkg/cmd/waitforkube"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -52,6 +53,7 @@ func NewSSCSCommand() *cobra.Command {
 	cmd.AddCommand(staticpodcontroller.NewStaticPodCommand(os.Stderr))
 	cmd.AddCommand(mount.NewMountCommand(os.Stderr))
 	cmd.AddCommand(waitforceo.NewWaitForCeoCommand(os.Stderr))
+	cmd.AddCommand(waitforkube.NewWaitForKubeCommand(os.Stderr))
 
 	return cmd
 }

--- a/pkg/cmd/waitforkube/waitforkube.go
+++ b/pkg/cmd/waitforkube/waitforkube.go
@@ -1,0 +1,68 @@
+package waitforkube
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+)
+
+const (
+	retryDuration = 10 * time.Second
+	saTokenPath   = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+)
+
+type waitForKubeOpts struct {
+	errOut io.Writer
+}
+
+// NewWaitForKubeCommand waits for kube to come up before continuing to start the rest of the containers.
+func NewWaitForKubeCommand(errOut io.Writer) *cobra.Command {
+	waitForKubeOpts := &waitForKubeOpts{
+		errOut: errOut,
+	}
+	cmd := &cobra.Command{
+		Use:   "wait-for-kube",
+		Short: "wait for kube service account to exist",
+		Long:  "This command makes sure that the kube is available before starting the rest of the containers in the pod.",
+		Run: func(cmd *cobra.Command, args []string) {
+			must := func(fn func() error) {
+				if err := fn(); err != nil {
+					if cmd.HasParent() {
+						klog.Fatal(err)
+						fmt.Fprint(waitForKubeOpts.errOut, err.Error())
+					}
+				}
+			}
+			must(waitForKubeOpts.Run)
+		},
+	}
+
+	return cmd
+}
+
+func (w *waitForKubeOpts) Run() error {
+	wait.PollInfinite(retryDuration, func() (bool, error) {
+		if _, err := os.Stat(saTokenPath); os.IsNotExist(err) {
+			klog.Infof("waiting for kube service account resources to sync: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if !inCluster() {
+		return fmt.Errorf("kube env not populated")
+	}
+	return nil
+}
+
+//TODO: add to util
+func inCluster() bool {
+	if os.Getenv("KUBERNETES_SERVICE_HOST") == "" || os.Getenv("KUBERNETES_SERVICE_PORT") == "" {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
When the static pod starts we need to wait for kube until any containers that require a k8s client start. This ensures the container has been scheduled with kube and will contain required ENV for client creation.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>