### PR TITLE
*: fix identified issues for upgrading to operator enabled cluster

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -139,6 +139,10 @@ func (c *EtcdCertSignerController) sync() error {
 		// Scaling key not found in configmap, hence do nothing
 		return nil
 	}
+	if len(membershipData) == 0 {
+		// scaling value empty
+		return nil
+	}
 	err = json.Unmarshal([]byte(membershipData), scaling)
 	if err != nil {
 		klog.Infof("unable to unmarshal scaling data %#v\n", err)

--- a/pkg/operator/hostetcdendpointcontroller/members.go
+++ b/pkg/operator/hostetcdendpointcontroller/members.go
@@ -86,12 +86,12 @@ func (h *healthyEtcdMemberGetter) EtcdList(bucket string) ([]ceoapi.Member, erro
 	if err != nil {
 		return nil, err
 	}
+	members := []ceoapi.Member{}
 	if !exists {
-		return nil, fmt.Errorf("etcd cluster members not observed")
+		return members, nil
 	}
 
 	// populate current etcd members as observed.
-	var members []ceoapi.Member
 	for _, member := range data {
 		memberMap, _ := member.(map[string]interface{})
 		name, exists, err := unstructured.NestedString(memberMap, "name")


### PR DESCRIPTION
**- What did I do**

1. fix part of code which was erroring on empty configmap scaling key 
2. Add checks for init container count
3. Use typed informers instead of dynamic and start the operator informer factory

**-  How to verify**
1. Install a 4.4 cluster from CI for example, registry.svc.ci.openshift.org/ocp/release:4.4.0-0.ci-2019-12-14-210519
2. Upgrade to a cluster-etcd-operator enabled cluster

**- Addresses**
- #50 
- #49 - After adding an init container (wait-for-kube), we needed to update the observation code to fix this 

**- Depends on**
#47 