### PR TITLE
*: add cluster-etcd-operator to CVO operator payload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/bindata/b
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/cluster-etcd-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/manifests/ /manifests/
 
-# LABEL io.openshift.release.operator true
+LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -11,4 +11,4 @@ COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/bindata/b
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/cluster-etcd-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/manifests/ /manifests/
 
-# LABEL io.openshift.release.operator true
+LABEL io.openshift.release.operator true

--- a/manifests/0000_12_etcd-operator_01_operator.cr.yaml
+++ b/manifests/0000_12_etcd-operator_01_operator.cr.yaml
@@ -5,4 +5,4 @@ metadata:
   annotations:
     release.openshift.io/create-only: "true"
 spec:
-  managementState: Unmanaged
+  managementState: Managed

--- a/pkg/cmd/staticsynccontroller/staticsynccontroller.go
+++ b/pkg/cmd/staticsynccontroller/staticsynccontroller.go
@@ -7,25 +7,27 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
 	etcdv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
-	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-etcd-operator/pkg/version"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
 )
 
 const (
@@ -105,6 +107,11 @@ func (s *syncOpts) Run() error {
 
 	kubeInformerFactory := informers.NewFilteredSharedInformerFactory(clientset, 0, etcdNamespace, nil)
 
+	etcdInformer, err := operatorClient.Informers.ForResource(schema.GroupVersionResource{
+		Group:    "operator.openshift.io",
+		Version:  "v1",
+		Resource: "etcds",
+	})
 	if err != nil {
 		klog.Errorf("error getting etcd informer %#v", err)
 		return err
@@ -112,13 +119,12 @@ func (s *syncOpts) Run() error {
 
 	staticSyncController := NewStaticSyncController(
 		operatorClient.Client.Etcds(),
-		operatorConfigInformers.Operator().V1().Etcds(),
+		etcdInformer,
 		kubeInformerFactory,
 		eventRecorder,
 	)
 
 	kubeInformerFactory.Start(ctx.Done())
-	operatorConfigInformers.Start(ctx.Done())
 
 	go staticSyncController.Run(ctx.Done())
 
@@ -128,7 +134,7 @@ func (s *syncOpts) Run() error {
 
 type StaticSyncController struct {
 	etcdKubeClient                         etcdv1.EtcdInterface
-	etcdInformer                           operatorinformers.EtcdInformer
+	etcdInformer                           informers.GenericInformer
 	secretInformer                         cache.SharedIndexInformer
 	kubeInformersForOpenshiftEtcdNamespace informers.SharedInformerFactory
 
@@ -139,7 +145,7 @@ type StaticSyncController struct {
 
 func NewStaticSyncController(
 	etcdKubeClient etcdv1.EtcdInterface,
-	etcdInformer operatorinformers.EtcdInformer,
+	etcdInformer informers.GenericInformer,
 	kubeInformersForOpenshiftEtcdNamespace informers.SharedInformerFactory,
 	eventRecorder events.Recorder,
 ) *StaticSyncController {
@@ -217,7 +223,6 @@ func (c *StaticSyncController) Run(stopCh <-chan struct{}) {
 
 	if !cache.WaitForCacheSync(stopCh,
 		c.secretInformer.HasSynced,
-		c.etcdInformer.Informer().HasSynced,
 	) {
 		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
 		return


### PR DESCRIPTION
This PR effectively adds the `cluster-etcd-operator` to the CVO operator payload and set it to a Managed state.

We also are reverting the static-sync controller to utilize a generic operator informer and remove it from `WaitForCacheSync`. This is only a short term precaution as we observed a failure case in testing where WaitForCacheSync appeared to be blocking the actions of the controller which are vital to the bootstrapping process.

