### PR TITLE
Bug 1796965: *: reduce the bootstrap time by fixing implementation details

### DIFF
--- a/pkg/cmd/staticsynccontroller/staticsynccontroller.go
+++ b/pkg/cmd/staticsynccontroller/staticsynccontroller.go
@@ -2,6 +2,7 @@ package staticsynccontroller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -180,17 +181,22 @@ func (c *StaticSyncController) sync() error {
 		return nil
 	}
 	// if anything changes we copy
-	assets := [4]string{
+	assets := [3]string{
 		"namespace",
 		"ca.crt",
-		"service-ca.crt",
 		"token",
 	}
+	errs := []error{}
 	for _, file := range assets {
 		if err := Copy(fmt.Sprintf("%s/%s", srcDir, file), fmt.Sprintf("%s/%s", destDir, file)); err != nil {
-			return err
+			klog.Errorf("error copying file %s: %#v", file, err)
+			errs = append(errs, err)
 		}
 	}
+	if len(errs) != 0 {
+		return errors.New(fmt.Sprintf("error copying resources: %#v", errs))
+	}
+	klog.Info("resources synced successfully")
 	return nil
 }
 


### PR DESCRIPTION
The `rest.InClusterConfig()`[1] in discovery init-container only uses
`token` and `ca.crt`[2].

It was observed that `service-ca.crt` was the last file to be synced.
Since the sync loop would error out at not finding that file, it would take
 a long time for the `token` to be synced as well, which is the true 
dependency of the discovery init container. [3]

Apply the same logic to sync loop of waiting for KAS to have valid config,
hopefully another step forward in reducing the waiting time.

This is expected to significantly reduce the bootstrap time.

1. https://github.com/openshift/machine-config-operator/blob/4932c47c7b741cf402e44dbdb2cb5af22c09156b/cmd/setup-etcd-environment/run.go#L336
2. https://github.com/openshift/machine-config-operator/blob/4932c47c7b741cf402e44dbdb2cb5af22c09156b/vendor/k8s.io/client-go/rest/config.go#L453
3. https://github.com/openshift/machine-config-operator/blob/4932c47c7b741cf402e44dbdb2cb5af22c09156b/cmd/setup-etcd-environment/run.go#L32