### PR TITLE
Bug 1797122: add hack for KAS rollouts, make cmc chattier

### DIFF
--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -64,6 +64,8 @@ func NewClusterMemberController(
 	}
 	kubeInformersForOpenshiftEtcdNamespace.Core().V1().Pods().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForOpenshiftEtcdNamespace.Core().V1().Endpoints().Informer().AddEventHandler(c.eventHandler())
+	kubeInformersForOpenshiftEtcdNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
+	operatorConfigClient.Informer().AddEventHandler(c.eventHandler())
 
 	return c
 }
@@ -465,7 +467,9 @@ func (c *ClusterMemberController) Run(stopCh <-chan struct{}) {
 
 	if !cache.WaitForCacheSync(stopCh,
 		c.kubeInformersForOpenshiftEtcdNamespace.Core().V1().Pods().Informer().HasSynced,
-		c.kubeInformersForOpenshiftEtcdNamespace.Core().V1().Endpoints().Informer().HasSynced) {
+		c.kubeInformersForOpenshiftEtcdNamespace.Core().V1().Endpoints().Informer().HasSynced,
+		c.kubeInformersForOpenshiftEtcdNamespace.Core().V1().ConfigMaps().Informer().HasSynced,
+		c.operatorConfigClient.Informer().HasSynced) {
 		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
 		return
 	}

--- a/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller.go
+++ b/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller.go
@@ -227,6 +227,14 @@ func pickUniqueIPAddress(assignedIPAddresses []string, newIPAddressNeeded int) [
 }
 
 func diff(hostnames, healthyMembers []string) (add, remove []string) {
+	// todo: temporary hack to make sure kube-apiserver
+	// is always started with 2 urls
+	// currently, it is taking a lot of time for KAS to
+	// roll out new config. this leverages the client
+	// load balancer
+	if in(hostnames, "etcd-bootstrap") {
+		return
+	}
 	for _, h := range hostnames {
 		if ok := in(healthyMembers, h); !ok {
 			if h == "etcd-bootstrap" {

--- a/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller_test.go
+++ b/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller_test.go
@@ -18,6 +18,8 @@ func Test_diff(t *testing.T) {
 		wantAdd    []string
 		wantRemove []string
 	}{
+		// if etcd-bootstrap is in healthy member, it needs to have
+		// etcd-1 in healthy member, temporary hack for KAS
 		{
 			name: "only etcd-bootstrap",
 			args: args{
@@ -31,9 +33,9 @@ func Test_diff(t *testing.T) {
 			name: "scaling: add a member after etcd-bootstrap",
 			args: args{
 				hostnames:      []string{"etcd-bootstrap"},
-				healthyMembers: []string{"etcd-bootstrap", "etcd-0"},
+				healthyMembers: []string{"etcd-bootstrap", "etcd-1"},
 			},
-			wantAdd:    []string{"etcd-0"},
+			wantAdd:    nil,
 			wantRemove: nil,
 		},
 		{
@@ -42,7 +44,7 @@ func Test_diff(t *testing.T) {
 				hostnames:      []string{"etcd-bootstrap", "etcd-0"},
 				healthyMembers: []string{"etcd-bootstrap", "etcd-0", "etcd-1"},
 			},
-			wantAdd:    []string{"etcd-1"},
+			wantAdd:    nil,
 			wantRemove: nil,
 		},
 		{
@@ -60,7 +62,7 @@ func Test_diff(t *testing.T) {
 				hostnames:      []string{"etcd-bootstrap", "etcd-0", "etcd-1"},
 				healthyMembers: []string{"etcd-0", "etcd-1", "etcd-2"},
 			},
-			wantAdd:    []string{"etcd-2"},
+			wantAdd:    nil,
 			wantRemove: nil,
 		},
 	}


### PR DESCRIPTION
With #66, it was seen that for some clusters it takes quite a long
time for the updated etcd storage URLs to be reflected in kube-
apiserver config. This fix adds a temporary relief by starting the KAS 
rollouts with all the 4 endpoints. We leverage the etcd client load
balancer to bounce to other endpoints if an endpoint is not working

This PR also adds more informers to clustermembercontroller.go,
making the sync loop on it run more frequently.