### PR TITLE
Bug 1797491: manifests: Drop Deprecated etcd metrics

### DIFF
--- a/manifests/0000_90_etcd-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_etcd-operator_03_servicemonitor.yaml
@@ -12,6 +12,10 @@ spec:
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__
+    - action: drop
+      regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+      sourceLabels:
+      - __name__
     port: https
     scheme: https
     tlsConfig:


### PR DESCRIPTION
These metrics were Deprecated in kubernetes v1.14.

See changelog -> https://github.com/kubernetes/kubernetes/blob/5e0f36705ef785a80955bd2b6412d9d227ff60da/CHANGELOG-1.14.md#deprecated-metrics