### PR TITLE
Bug 1797897: pkg/cmd/waitforkube: don't wait if etcd has previously been initialed as member

### DIFF
--- a/pkg/cmd/waitforkube/waitforkube.go
+++ b/pkg/cmd/waitforkube/waitforkube.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -14,15 +15,17 @@ import (
 const (
 	retryDuration = 10 * time.Second
 	saTokenPath   = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	dataDir       = "/var/lib/etcd" //TODO should be flag or ENV
+	dbPath        = "member/snap/db"
 )
 
-type waitForKubeOpts struct {
+type waitForKube struct {
 	errOut io.Writer
 }
 
 // NewWaitForKubeCommand waits for kube to come up before continuing to start the rest of the containers.
 func NewWaitForKubeCommand(errOut io.Writer) *cobra.Command {
-	waitForKubeOpts := &waitForKubeOpts{
+	waitForKube := &waitForKube{
 		errOut: errOut,
 	}
 	cmd := &cobra.Command{
@@ -34,29 +37,51 @@ func NewWaitForKubeCommand(errOut io.Writer) *cobra.Command {
 				if err := fn(); err != nil {
 					if cmd.HasParent() {
 						klog.Fatal(err)
-						fmt.Fprint(waitForKubeOpts.errOut, err.Error())
+						fmt.Fprint(waitForKube.errOut, err.Error())
 					}
 				}
 			}
-			must(waitForKubeOpts.Run)
+			must(waitForKube.Run)
 		},
 	}
 
 	return cmd
 }
 
-func (w *waitForKubeOpts) Run() error {
+func (w *waitForKube) Run() error {
+	dataFilePath := filepath.Join(dataDir, dbPath)
+	if CheckEtcdDataFileExists(dataFilePath) {
+		klog.Infof("etcd has previously been initialized as a member")
+		return nil
+	}
 	wait.PollInfinite(retryDuration, func() (bool, error) {
 		if _, err := os.Stat(saTokenPath); os.IsNotExist(err) {
 			klog.Infof("waiting for kube service account resources to sync: %v", err)
 			return false, nil
 		}
+		klog.Infof("kube dependencies verified, service account resources found")
 		return true, nil
 	})
 	if !inCluster() {
-		return fmt.Errorf("kube env not populated")
+		return fmt.Errorf("container missing required env KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT")
 	}
 	return nil
+}
+
+// CheckEtcdDataFileExists checks for the existance of an etcd db file. If the db exists we can assume this etcd
+// has previously started or is currently being recovered. If true we can not assume kube exists yet or will
+// during the life of this container. For example disaster recovery.
+// TODO organize into a general util
+func CheckEtcdDataFileExists(dataFilePath string) bool {
+	if _, err := os.Stat(dataFilePath); err != nil {
+		if os.IsNotExist(err) {
+			klog.Infof("CheckEtcdDataFileExists(): %s does not exist, waiting for kube", dataFilePath)
+			return false
+		}
+		// print error for debug but technically we can't say the file does not exist
+		klog.Errorf("CheckEtcdDataFileExists(): %v", err)
+	}
+	return true
 }
 
 //TODO: add to util


### PR DESCRIPTION
When we added `wait-for-kube` we made poor assumptions that we always want to wait. In certain circumstances such as disaster recovery or lights-out situations where all master nodes go down kube will never be available before etcd starts.

This PR resolves this chicken and egg by not waiting if an etcd datafile exists. In this case we can assume that etcd has been previously initialized. Thus we no longer should depend on kube to start.

blocks https://github.com/openshift/machine-config-operator/pull/1428