### PR TITLE
bug 1800313: add env vars

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -14,6 +14,8 @@ spec:
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["sleep"]
+    env:
+${COMPUTED_ENV_VARS}
     args:
     - "7200"
     resources:

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -13,11 +13,37 @@ spec:
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: ["sleep"]
+    command:
+      - /bin/sh
+      - -c
+      - |
+        #!/bin/sh
+        set -euo pipefail
+
+        echo "NODE__NAME=NODE_NAME"
+        echo "NODE__ENVVAR_NAME=NODE_ENVVAR_NAME"
+        echo "NODE_NODE__ENVVAR_NAME_ETCD_DNS_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}"
+        echo "NODE_NODE__ENVVAR_NAME_ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}"
+        echo "NODE_NODE__ENVVAR_NAME_IP=${NODE_NODE_ENVVAR_NAME_IP}"
+
+        sleep 24h
+
+        # exec etcd \
+        #        --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
+        #        --cert-file=/etc/ssl/etcd/system:etcd-server:${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}.crt \
+        #        --key-file=/etc/ssl/etcd/system:etcd-server:${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}.key \
+        #        --trusted-ca-file=/etc/ssl/etcd/ca.crt \
+        #        --client-cert-auth=true \
+        #        --peer-cert-file=/etc/ssl/etcd/system:etcd-peer:${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}.crt \
+        #        --peer-key-file=/etc/ssl/etcd/system:etcd-peer:${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}.key \
+        #        --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
+        #        --peer-client-cert-auth=true \
+        #        --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
+        #        --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379 \
+        #        --listen-peer-urls=https://${LISTEN_ON_ALL_IPS}:2380 \
+        #        --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978 \
     env:
 ${COMPUTED_ENV_VARS}
-    args:
-    - "7200"
     resources:
       requests:
         memory: 200Mi
@@ -27,6 +53,14 @@ ${COMPUTED_ENV_VARS}
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
+    - mountPath: /run/etcd/
+      name: discovery
+    - mountPath: /etc/ssl/etcd/
+      name: certs
+    - mountPath: /var/lib/etcd/
+      name: data-dir
+    - mountPath: /etc/etcd/
+      name: conf
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -38,4 +72,20 @@ ${COMPUTED_ENV_VARS}
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/etcd-certs
     name: cert-dir
+  - hostPath:
+      path: /etc/kubernetes/static-pod-resources/etcd-member
+      type: ""
+    name: certs
+  - hostPath:
+      path: /run/etcd
+      type: ""
+    name: discovery
+  - hostPath:
+      path: /var/lib/etcd
+      type: ""
+    name: data-dir
+  - hostPath:
+      path: /etc/etcd
+      type: ""
+    name: conf
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20200131223221-f2a771e1a90c
 	github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
-	github.com/openshift/library-go v0.0.0-20200206082234-e7b0b487de39
+	github.com/openshift/library-go v0.0.0-20200207150939-615337e1c3aa
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73 h1:WC
 github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
-github.com/openshift/library-go v0.0.0-20200206082234-e7b0b487de39 h1:hf1ijG/qYsvBAD6gZg388G1NFwXSd/NfaGFBGlQhGu8=
-github.com/openshift/library-go v0.0.0-20200206082234-e7b0b487de39/go.mod h1:mLRZGYfPe9Kaum4pyhn6hTO3FTPjOZKFB0RxQSIxiuQ=
+github.com/openshift/library-go v0.0.0-20200207150939-615337e1c3aa h1:3/i0Kzbt8TbC+QkZ3sZ9b6M64/CzEXa2fN2IoIKzXYs=
+github.com/openshift/library-go v0.0.0-20200207150939-615337e1c3aa/go.mod h1:mLRZGYfPe9Kaum4pyhn6hTO3FTPjOZKFB0RxQSIxiuQ=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -160,11 +160,37 @@ spec:
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: ["sleep"]
+    command:
+      - /bin/sh
+      - -c
+      - |
+        #!/bin/sh
+        set -euo pipefail
+
+        echo "NODE__NAME=NODE_NAME"
+        echo "NODE__ENVVAR_NAME=NODE_ENVVAR_NAME"
+        echo "NODE_NODE__ENVVAR_NAME_ETCD_DNS_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}"
+        echo "NODE_NODE__ENVVAR_NAME_ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}"
+        echo "NODE_NODE__ENVVAR_NAME_IP=${NODE_NODE_ENVVAR_NAME_IP}"
+
+        sleep 24h
+
+        # exec etcd \
+        #        --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
+        #        --cert-file=/etc/ssl/etcd/system:etcd-server:${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}.crt \
+        #        --key-file=/etc/ssl/etcd/system:etcd-server:${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}.key \
+        #        --trusted-ca-file=/etc/ssl/etcd/ca.crt \
+        #        --client-cert-auth=true \
+        #        --peer-cert-file=/etc/ssl/etcd/system:etcd-peer:${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}.crt \
+        #        --peer-key-file=/etc/ssl/etcd/system:etcd-peer:${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}.key \
+        #        --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
+        #        --peer-client-cert-auth=true \
+        #        --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
+        #        --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379 \
+        #        --listen-peer-urls=https://${LISTEN_ON_ALL_IPS}:2380 \
+        #        --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978 \
     env:
 ${COMPUTED_ENV_VARS}
-    args:
-    - "7200"
     resources:
       requests:
         memory: 200Mi
@@ -174,6 +200,14 @@ ${COMPUTED_ENV_VARS}
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
+    - mountPath: /run/etcd/
+      name: discovery
+    - mountPath: /etc/ssl/etcd/
+      name: certs
+    - mountPath: /var/lib/etcd/
+      name: data-dir
+    - mountPath: /etc/etcd/
+      name: conf
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -185,6 +219,22 @@ ${COMPUTED_ENV_VARS}
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/etcd-certs
     name: cert-dir
+  - hostPath:
+      path: /etc/kubernetes/static-pod-resources/etcd-member
+      type: ""
+    name: certs
+  - hostPath:
+      path: /run/etcd
+      type: ""
+    name: discovery
+  - hostPath:
+      path: /var/lib/etcd
+      type: ""
+    name: data-dir
+  - hostPath:
+      path: /etc/etcd
+      type: ""
+    name: conf
 
 `)
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -161,6 +161,8 @@ spec:
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["sleep"]
+    env:
+${COMPUTED_ENV_VARS}
     args:
     - "7200"
     resources:

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/client-go/dynamic"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
@@ -49,6 +51,10 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		return err
 	}
 	clientset, err := kubernetes.NewForConfig(controllerContext.KubeConfig)
+	if err != nil {
+		return err
+	}
+	dynamicClient, err := dynamic.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {
 		return err
 	}
@@ -108,6 +114,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorClient,
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
 		kubeInformersForNamespaces,
+		dynamicClient,
 		kubeClient,
 		controllerContext.EventRecorder,
 	)

--- a/pkg/operator/targetconfigcontroller/etcd_env.go
+++ b/pkg/operator/targetconfigcontroller/etcd_env.go
@@ -1,0 +1,190 @@
+package targetconfigcontroller
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog"
+)
+
+type envVarContext struct {
+	spec   operatorv1.StaticPodOperatorSpec
+	status operatorv1.StaticPodOperatorStatus
+
+	nodeLister    corev1listers.NodeLister
+	dynamicClient dynamic.Interface
+}
+
+type envVarFunc func(envVarContext envVarContext) (map[string]string, error)
+
+var envVarFns = []envVarFunc{
+	getEscapedIPAddress,
+	getDNSName,
+	getEtcdDataDir,
+	getEtcdctlAPI,
+	getEtcdName,
+}
+
+// getEtcdEnvVars returns the env vars that need to be set on the etcd static pods that will be rendered.
+//   ETCD_DATA_DIR
+//   ETCDCTL_API
+//   NODE_%s_IP
+//   NODE_%s_ETCD_DNS_NAME
+//   NODE_%s_ETCD_NAME
+// TODO
+//   ALL_ETCD_INITIAL_CLUSTER
+//   ETCD_INITIAL_CLUSTER_STATE
+//   ETCD_ENDPOINTS
+func getEtcdEnvVars(envVarContext envVarContext) (map[string]string, error) {
+	ret := map[string]string{}
+
+	for _, envVarFn := range envVarFns {
+		newEnvVars, err := envVarFn(envVarContext)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range newEnvVars {
+			if currV, ok := ret[k]; ok {
+				return nil, fmt.Errorf("key %q already set to %q", k, currV)
+			}
+			ret[k] = v
+		}
+	}
+
+	return ret, nil
+}
+
+func getEtcdDataDir(envVarContext envVarContext) (map[string]string, error) {
+	return map[string]string{
+		"ETCD_DATA_DIR": "/var/lib/etcd",
+	}, nil
+}
+
+func getEtcdctlAPI(envVarContext envVarContext) (map[string]string, error) {
+	return map[string]string{
+		"ETCDCTL_API": "3",
+	}, nil
+}
+
+func getEtcdName(envVarContext envVarContext) (map[string]string, error) {
+	ret := map[string]string{}
+
+	for _, nodeInfo := range envVarContext.status.NodeStatuses {
+		dnsName, err := getInternalIPDNSNodeName(envVarContext, nodeInfo.NodeName)
+		if err != nil {
+			return nil, err
+		}
+		ret[fmt.Sprintf("NODE_%s_ETCD_NAME", nodeInfo.NodeName)] = fmt.Sprintf("etcd-member-%s", dnsName)
+	}
+
+	return ret, nil
+}
+
+func getEscapedIPAddress(envVarContext envVarContext) (map[string]string, error) {
+	ret := map[string]string{}
+	for _, nodeInfo := range envVarContext.status.NodeStatuses {
+		address, err := getInternalIPAddressForNodeName(envVarContext, nodeInfo.NodeName)
+		if err != nil {
+			return nil, err
+		}
+		ret[fmt.Sprintf("NODE_%s_IP", nodeInfo.NodeName)] = address
+	}
+
+	return ret, nil
+}
+
+func getInternalIPAddressForNodeName(envVarContext envVarContext, nodeName string) (string, error) {
+	node, err := envVarContext.nodeLister.Get(nodeName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, currAddress := range node.Status.Addresses {
+		if currAddress.Type == corev1.NodeInternalIP {
+			return currAddress.Address, nil
+		}
+	}
+	return "", fmt.Errorf("node/%s missing %s", node.Name, corev1.NodeInternalIP)
+}
+
+func getInternalIPDNSNodeName(envVarContext envVarContext, nodeName string) (string, error) {
+	node, err := envVarContext.nodeLister.Get(nodeName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, currAddress := range node.Status.Addresses {
+		if currAddress.Type == corev1.NodeInternalDNS {
+			return currAddress.Address, nil
+		}
+	}
+	return "", fmt.Errorf("node/%s missing %s", node.Name, corev1.NodeInternalDNS)
+}
+
+func getDNSName(envVarContext envVarContext) (map[string]string, error) {
+	ret := map[string]string{}
+
+	controllerConfig, err := envVarContext.dynamicClient.
+		Resource(schema.GroupVersionResource{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "controllerconfigs"}).
+		Get("machine-config-controller", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	etcdDiscoveryDomain, ok, err := unstructured.NestedString(controllerConfig.Object, "spec", "etcdDiscoveryDomain")
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("controllerconfigs/machine-config-controller missing .spec.etcdDiscoveryDomain")
+	}
+
+	for _, nodeInfo := range envVarContext.status.NodeStatuses {
+		ip, err := getInternalIPAddressForNodeName(envVarContext, nodeInfo.NodeName)
+		if err != nil {
+			return nil, err
+		}
+
+		dnsName, err := reverseLookup("etcd-server-ssl", "tcp", etcdDiscoveryDomain, ip)
+		if err != nil {
+			return nil, err
+		}
+		ret[fmt.Sprintf("NODE_%s_ETCD_DNS_NAME", nodeInfo.NodeName)] = dnsName
+	}
+
+	return ret, nil
+}
+
+// returns the target from the SRV record that resolves to ip.
+func reverseLookup(service, proto, name, ip string) (string, error) {
+	_, srvs, err := net.LookupSRV(service, proto, name)
+	if err != nil {
+		return "", err
+	}
+	selfTarget := ""
+	for _, srv := range srvs {
+		klog.V(4).Infof("checking against %s", srv.Target)
+		addrs, err := net.LookupHost(srv.Target)
+		if err != nil {
+			return "", fmt.Errorf("could not resolve member %q", srv.Target)
+		}
+
+		for _, addr := range addrs {
+			if addr == ip {
+				selfTarget = strings.Trim(srv.Target, ".")
+				break
+			}
+		}
+	}
+	if selfTarget == "" {
+		return "", fmt.Errorf("could not find self")
+	}
+	return selfTarget, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/bindata/bindata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/bindata/bindata.go
@@ -69,6 +69,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
         - mountPath: /etc/kubernetes/
@@ -87,7 +91,8 @@ spec:
   volumes:
     - hostPath:
         path: /etc/kubernetes/
-      name: kubelet-dir`)
+      name: kubelet-dir
+`)
 
 func pkgOperatorStaticpodControllerInstallerManifestsInstallerPodYamlBytes() ([]byte, error) {
 	return _pkgOperatorStaticpodControllerInstallerManifestsInstallerPodYaml, nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -32,6 +32,7 @@ type InstallOptions struct {
 	KubeClient kubernetes.Interface
 
 	Revision  string
+	NodeName  string
 	Namespace string
 
 	PodConfigMapNamePrefix        string
@@ -131,12 +132,19 @@ func (o *InstallOptions) Complete() error {
 	if err != nil {
 		return err
 	}
+
+	// set via downward API
+	o.NodeName = os.Getenv("NODE_NAME")
+
 	return nil
 }
 
 func (o *InstallOptions) Validate() error {
 	if len(o.Revision) == 0 {
 		return fmt.Errorf("--revision is required")
+	}
+	if len(o.NodeName) == 0 {
+		return fmt.Errorf("env var NODE_NAME is required")
 	}
 	if len(o.Namespace) == 0 {
 		return fmt.Errorf("--namespace is required")
@@ -294,7 +302,9 @@ func (o *InstallOptions) copyContent(ctx context.Context) error {
 		if !exists {
 			return true, fmt.Errorf("required 'pod.yaml' key does not exist in configmap")
 		}
-		podContent = strings.Replace(podData, "REVISION", o.Revision, -1)
+		podContent = strings.ReplaceAll(podData, "REVISION", o.Revision)
+		podContent = strings.ReplaceAll(podContent, "NODE_NAME", o.NodeName)
+		podContent = strings.ReplaceAll(podContent, "NODE_ENVVAR_NAME", strings.ReplaceAll(strings.ReplaceAll(o.NodeName, "-", "_"), ".", "_"))
 		return true, nil
 	})
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20200206082234-e7b0b487de39
+# github.com/openshift/library-go v0.0.0-20200207150939-615337e1c3aa
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/config/client
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers


### PR DESCRIPTION
```yaml
  containers:
  - command:
    - /bin/sh
    - -c
    - |
      #!/bin/sh
      set -euo pipefail

      echo "NODE__NAME=ip-10-0-156-14.ec2.internal"
      echo "NODE__ENVVAR_NAME=ip_10_0_156_14_ec2_internal"
      echo "NODE_NODE__ENVVAR_NAME_ETCD_DNS_NAME=${NODE_ip_10_0_156_14_ec2_internal_ETCD_DNS_NAME}"
      echo "NODE_NODE__ENVVAR_NAME_ETCD_NAME=${NODE_ip_10_0_156_14_ec2_internal_ETCD_NAME}"
      echo "NODE_NODE__ENVVAR_NAME_IP=${NODE_ip_10_0_156_14_ec2_internal_IP}"

      sleep 24h

      # exec etcd \
      #        --initial-advertise-peer-urls=https://${NODE_ip_10_0_156_14_ec2_internal_IP}:2380 \
      #        --cert-file=/etc/ssl/etcd/system:etcd-server:${NODE_ip_10_0_156_14_ec2_internal_ETCD_DNS_NAME}.crt \
      #        --key-file=/etc/ssl/etcd/system:etcd-server:${NODE_ip_10_0_156_14_ec2_internal_ETCD_DNS_NAME}.key \
      #        --trusted-ca-file=/etc/ssl/etcd/ca.crt \
      #        --client-cert-auth=true \
      #        --peer-cert-file=/etc/ssl/etcd/system:etcd-peer:${NODE_ip_10_0_156_14_ec2_internal_ETCD_DNS_NAME}.crt \
      #        --peer-key-file=/etc/ssl/etcd/system:etcd-peer:${NODE_ip_10_0_156_14_ec2_internal_ETCD_DNS_NAME}.key \
      #        --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
      #        --peer-client-cert-auth=true \
      #        --advertise-client-urls=https://${NODE_ip_10_0_156_14_ec2_internal_IP}:2379 \
      #        --listen-client-urls=https://0.0.0.0:2379 \
      #        --listen-peer-urls=https://0.0.0.0:2380 \
      #        --listen-metrics-urls=https://0.0.0.0:9978 \

```
```
NODE__NAME=ip-10-0-156-14.ec2.internal
NODE__ENVVAR_NAME=ip_10_0_156_14_ec2_internal
NODE_NODE__ENVVAR_NAME_ETCD_DNS_NAME=etcd-1.test02051.devcluster.openshift.com
NODE_NODE__ENVVAR_NAME_ETCD_NAME=etcd-member-ip-10-0-156-14.ec2.internal
NODE_NODE__ENVVAR_NAME_IP=10.0.156.14

```

proof of node selection