### PR TITLE
Bug 1801299: go.mod: bump go version 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-etcd-operator
 
-go 1.12
+go 1.13
 
 require (
 	github.com/cloudflare/cfssl v1.4.1


### PR DESCRIPTION
I just noticed we dif not bump go version. If CI is building testing and shipping in 1.13 so should we.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>