### PR TITLE
Bug 1801344: vendor: bump build-machinery-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/mux v0.0.0-20191024121256-f395758b854c
 	github.com/jteeuwen/go-bindata v3.0.8-0.20151023091102-a0ff2567cfb7+incompatible
 	github.com/openshift/api v0.0.0-20200131223221-f2a771e1a90c
-	github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73
+	github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
 	github.com/openshift/library-go v0.0.0-20200207150939-615337e1c3aa
 	github.com/prometheus/client_golang v1.1.0
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
+	google.golang.org/grpc v1.23.1
 	k8s.io/api v0.17.1
 	k8s.io/apimachinery v0.17.1
 	k8s.io/client-go v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,8 @@ github.com/openshift/api v0.0.0-20200131223221-f2a771e1a90c h1:6kb8UZix0DNEfZbys
 github.com/openshift/api v0.0.0-20200131223221-f2a771e1a90c/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73 h1:WCvABw620V2FqeNoRJWeuAATqGjsrzb0UQ3tL0RHcXw=
 github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
+github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e h1:qlMmBDqBavn7p4Y22teVEkJCnU9YAwhABHeXanAirWE=
+github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
 github.com/openshift/library-go v0.0.0-20200207150939-615337e1c3aa h1:3/i0Kzbt8TbC+QkZ3sZ9b6M64/CzEXa2fN2IoIKzXYs=

--- a/vendor/github.com/openshift/build-machinery-go/OWNERS
+++ b/vendor/github.com/openshift/build-machinery-go/OWNERS
@@ -1,4 +1,10 @@
 reviewers:
-  - tnozicka 
+  - tnozicka
+  - sttts
+  - mfojtik
+  - soltysh
 approvers:
-  - tnozicka 
+  - tnozicka
+  - sttts
+  - mfojtik
+  - soltysh

--- a/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
@@ -17,7 +17,7 @@ GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
 go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
-GO_REQUIRED_MIN_VERSION ?=1.13.5
+GO_REQUIRED_MIN_VERSION ?=1.13.4
 ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))
 endif

--- a/vendor/github.com/openshift/build-machinery-go/make/lib/version.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/version.mk
@@ -1,7 +1,7 @@
 # $1 - required version
 # $2 - current version
 define is_equal_or_higher_version
-$(strip $(filter $(2),$(firstword $(shell set -euo pipefail && echo -e '$(1)\n$(2)' | sort -V -r -b))))
+$(strip $(filter $(2),$(firstword $(shell set -euo pipefail && printf '%s\n%s' '$(1)' '$(2)' | sort -V -r -b))))
 endef
 
 # $1 - program name

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,7 +161,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73
+# github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib


### PR DESCRIPTION
builds are failing which are resolved by this bump.

>vendor/github.com/openshift/build-machinery-go/make/targets/golang/../../lib/golang.mk:22: *** `go` is required with minimal version "1.13.5", detected version "1.13.4". You can override this check by using `make GO_REQUIRED_MIN_VERSION:=`.  Stop.


https://github.com/openshift/cluster-etcd-operator/pull/109/files#diff-17442a53a3318d07cc4c974c17dce448R20
