### PR TITLE
Remove MemberRemove from ConfigObserver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
+	google.golang.org/grpc v1.23.1
 	k8s.io/api v0.17.1
 	k8s.io/apimachinery v0.17.1
 	k8s.io/client-go v0.17.1


### PR DESCRIPTION
Removing code for setting status to MemberRemove (ceoapi.MemberRemove). When a node is not available or Pod is crash looping, it needs Disaster Recovery procedures to recover.