### PR TITLE
bug 1801877: simplify the bootstrapteardown controller

### DIFF
--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
@@ -1,6 +1,7 @@
 package bootstrapteardown
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -9,10 +10,13 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
 	operatorv1listers "github.com/openshift/client-go/operator/listers/operator/v1"
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/clustermembercontroller"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/pkg/transport"
+	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -23,56 +27,57 @@ import (
 )
 
 const (
-	workQueueKey  = "key"
-	configMapName = "config"
-	configMapKey  = "config.yaml"
+	workQueueKey              = "key"
+	configMapName             = "config"
+	configMapKey              = "config.yaml"
+	conditionBootstrapRemoved = "BootstrapRemoved"
 )
 
 type BootstrapTeardownController struct {
-	operatorConfigClient        v1helpers.OperatorClient
-	clusterMemberShipController *clustermembercontroller.ClusterMemberController
+	operatorClient v1helpers.OperatorClient
 
-	etcdOperatorLister  operatorv1listers.EtcdLister
 	kubeAPIServerLister operatorv1listers.KubeAPIServerLister
 	configMapLister     corev1listers.ConfigMapLister
+	endpointLister      corev1listers.EndpointsLister
 
 	cachesToSync  []cache.InformerSynced
 	queue         workqueue.RateLimitingInterface
 	eventRecorder events.Recorder
 }
 
-// TODO wire a triggering lister
 func NewBootstrapTeardownController(
-	operatorConfigClient v1helpers.OperatorClient,
-	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
-	clusterMemberShipController *clustermembercontroller.ClusterMemberController,
+	operatorClient v1helpers.OperatorClient,
 
+	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	operatorInformers operatorv1informers.SharedInformerFactory,
 
 	eventRecorder events.Recorder,
 ) *BootstrapTeardownController {
 	openshiftKubeAPIServerNamespacedInformers := kubeInformersForNamespaces.InformersFor("openshift-kube-apiserver")
 	c := &BootstrapTeardownController{
-		operatorConfigClient:        operatorConfigClient,
-		clusterMemberShipController: clusterMemberShipController,
+		operatorClient: operatorClient,
 
-		etcdOperatorLister:  operatorInformers.Operator().V1().Etcds().Lister(),
 		kubeAPIServerLister: operatorInformers.Operator().V1().KubeAPIServers().Lister(),
 		configMapLister:     openshiftKubeAPIServerNamespacedInformers.Core().V1().ConfigMaps().Lister(),
+		endpointLister:      kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Lister(),
 
 		cachesToSync: []cache.InformerSynced{
-			operatorConfigClient.Informer().HasSynced,
+			operatorClient.Informer().HasSynced,
 			operatorInformers.Operator().V1().Etcds().Informer().HasSynced,
 			operatorInformers.Operator().V1().KubeAPIServers().Informer().HasSynced,
 			openshiftKubeAPIServerNamespacedInformers.Core().V1().ConfigMaps().Informer().HasSynced,
+			openshiftKubeAPIServerNamespacedInformers.Core().V1().Endpoints().Informer().HasSynced,
+			kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Informer().HasSynced,
 		},
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "BootstrapTeardownController"),
 		eventRecorder: eventRecorder.WithComponentSuffix("bootstrap-teardown-controller"),
 	}
+
 	operatorInformers.Operator().V1().KubeAPIServers().Informer().AddEventHandler(c.eventHandler())
-	operatorInformers.Operator().V1().Etcds().Informer().AddEventHandler(c.eventHandler())
 	openshiftKubeAPIServerNamespacedInformers.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
-	operatorConfigClient.Informer().AddEventHandler(c.eventHandler())
+	openshiftKubeAPIServerNamespacedInformers.Core().V1().Endpoints().Informer().AddEventHandler(c.eventHandler())
+	kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Informer().AddEventHandler(c.eventHandler())
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
 
 	return c
 }
@@ -80,7 +85,7 @@ func NewBootstrapTeardownController(
 func (c *BootstrapTeardownController) sync() error {
 	err := c.removeBootstrap()
 	if err != nil {
-		_, _, updateErr := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+		_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    "BootstrapTeardownDegraded",
 			Status:  operatorv1.ConditionTrue,
 			Reason:  "Error",
@@ -92,7 +97,7 @@ func (c *BootstrapTeardownController) sync() error {
 		return err
 	}
 
-	_, _, updateErr := v1helpers.UpdateStatus(c.operatorConfigClient,
+	_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient,
 		v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:   "BootstrapTeardownDegraded",
 			Status: operatorv1.ConditionFalse,
@@ -102,14 +107,42 @@ func (c *BootstrapTeardownController) sync() error {
 }
 
 func (c *BootstrapTeardownController) removeBootstrap() error {
-	currentEtcdOperator, err := c.etcdOperatorLister.Get("cluster")
+	// checks the actual etcd cluster membership API if etcd-bootstrap exists
+	etcdMemberExists, err := c.isEtcdMember("etcd-bootstrap")
 	if err != nil {
 		return err
 	}
+	if !etcdMemberExists {
+		// set bootstrap removed condition
+		_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+			Type:    conditionBootstrapRemoved,
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "BootstrapNodeRemoved",
+			Message: "Etcd operator has scaled",
+		}))
+		if updateErr != nil {
+			c.eventRecorder.Warning("BootstrapTeardownErrorUpdatingStatus", updateErr.Error())
+			return updateErr
+		}
+		// return because no work left to do
+		return nil
 
-	etcdReady := c.isEtcdAvailable(currentEtcdOperator)
-	if !etcdReady {
-		c.eventRecorder.Event("EtcdIsNotReady", "Still waiting for the cluster-etcd-operator to bootstrap")
+	} else {
+		_, _, _ = v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+			Type:    conditionBootstrapRemoved,
+			Status:  operatorv1.ConditionFalse,
+			Reason:  "BootstrapNodeNotRemoved",
+			Message: fmt.Sprintf("Bootstrap node is not removed yet: etcdMemberExists %t", etcdMemberExists),
+		}))
+		// fall through because it might be time to remove it
+	}
+
+	hasMoreThanTwoEtcdMembers, err := c.hasMoreThanTwoEtcdMembers()
+	if err != nil {
+		return err
+	}
+	if !hasMoreThanTwoEtcdMembers {
+		c.eventRecorder.Event("NotEnoughEtcdMembers", "Still waiting for three etcd members")
 		return nil
 	}
 
@@ -126,43 +159,150 @@ func (c *BootstrapTeardownController) removeBootstrap() error {
 		return nil
 	}
 
-	etcdEndpointExists := c.clusterMemberShipController.IsMember("etcd-bootstrap")
-	// checks the actual etcd cluster membership API if etcd-bootstrap exists
-	etcdMemberExists := c.clusterMemberShipController.IsEtcdMember("etcd-bootstrap")
-	if !etcdEndpointExists && !etcdMemberExists {
-		// set bootstrap removed condition
-		_, _, updateErr := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-			Type:    clustermembercontroller.ConditionBootstrapRemoved,
-			Status:  operatorv1.ConditionTrue,
-			Reason:  "BootstrapNodeRemoved",
-			Message: "Etcd operator has scaled",
-		}))
-		if updateErr != nil {
-			c.eventRecorder.Warning("BootstrapTeardownErrorUpdatingStatus", updateErr.Error())
-			return updateErr
-		}
-		// return because no work left to do
-		return nil
-	} else {
-		_, _, _ = v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-			Type:    clustermembercontroller.ConditionBootstrapRemoved,
-			Status:  operatorv1.ConditionFalse,
-			Reason:  "BootstrapNodeNotRemoved",
-			Message: fmt.Sprintf("Bootstrap node is not removed yet: etcdEndpointExists: %t etcdMemberExists %t", etcdEndpointExists, etcdMemberExists),
-		}))
-	}
-
 	c.eventRecorder.Event("BootstrapTeardownController", "safe to remove bootstrap")
-
-	if err := c.clusterMemberShipController.RemoveBootstrapFromEndpoint(); err != nil {
-		return err
-	}
-
-	if err := c.clusterMemberShipController.EtcdMemberRemove("etcd-bootstrap"); err != nil {
+	if err := c.etcdMemberRemove("etcd-bootstrap"); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (c *BootstrapTeardownController) isEtcdMember(name string) (bool, error) {
+	cli, err := c.getEtcdClient()
+	if err != nil {
+		return false, err
+	}
+	defer cli.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	l, err := cli.MemberList(ctx)
+	cancel()
+	if err != nil {
+		return false, err
+	}
+	for _, m := range l.Members {
+		if m.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (c *BootstrapTeardownController) etcdMemberRemove(name string) error {
+	cli, err := c.getEtcdClient()
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	l, err := cli.MemberList(ctx)
+	cancel()
+	if err != nil {
+		return err
+	}
+	for _, member := range l.Members {
+		if member.Name == name {
+			resp, err := cli.MemberRemove(context.Background(), member.ID)
+			if err != nil {
+				return err
+			}
+			klog.Infof("Members left %#v", resp.Members)
+		}
+	}
+	return nil
+}
+
+func (c *BootstrapTeardownController) getEtcdClient() (*clientv3.Client, error) {
+	endpoints, err := c.directEtcdEndpoints()
+	if err != nil {
+		return nil, err
+	}
+
+	dialOptions := []grpc.DialOption{
+		grpc.WithBlock(), // block until the underlying connection is up
+	}
+
+	tlsInfo := transport.TLSInfo{
+		CertFile:      "/var/run/secrets/etcd-client/tls.crt",
+		KeyFile:       "/var/run/secrets/etcd-client/tls.key",
+		TrustedCAFile: "/var/run/configmaps/etcd-ca/ca-bundle.crt",
+	}
+	tlsConfig, err := tlsInfo.ClientConfig()
+
+	cfg := &clientv3.Config{
+		DialOptions: dialOptions,
+		Endpoints:   endpoints,
+		DialTimeout: 5 * time.Second,
+		TLS:         tlsConfig,
+	}
+
+	cli, err := clientv3.New(*cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cli, err
+}
+
+func (c *BootstrapTeardownController) directEtcdEndpoints() ([]string, error) {
+	hostEtcd, err := c.endpointLister.Endpoints(operatorclient.TargetNamespace).Get("host-etcd")
+	if err != nil {
+		return []string{}, err
+	}
+	if len(hostEtcd.Subsets) == 0 {
+		return []string{}, fmt.Errorf("could not find etcd address in host-etcd")
+	}
+
+	etcdDiscoveryDomain := hostEtcd.Annotations["alpha.installer.openshift.io/dns-suffix"]
+	var endpoints []string
+	for _, endpointAddress := range hostEtcd.Subsets[0].Addresses {
+		if endpointAddress.Hostname == "etcd-bootstrap" { // this one has a valid IP, use it
+			endpoints = append(endpoints, "https://"+endpointAddress.IP+":2379")
+			continue
+		}
+		endpoints = append(endpoints, fmt.Sprintf("https://%s.%s:2379", endpointAddress.Hostname, etcdDiscoveryDomain))
+	}
+
+	return endpoints, nil
+}
+
+func (c *BootstrapTeardownController) hasMoreThanTwoEtcdMembers() (bool, error) {
+	cli, err := c.getEtcdClient()
+	if err != nil {
+		return false, err
+	}
+	defer cli.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	l, err := cli.MemberList(ctx)
+	cancel()
+	if err != nil {
+		return false, err
+	}
+
+	if len(l.Members) <= 3 {
+		return false, nil
+	}
+
+	unreadyMember := false
+	for _, m := range l.Members {
+		if len(m.ClientURLs) == 0 {
+			c.eventRecorder.Warningf("EtcdMemberNotHealthy", "member %s has no clientURLs", m.Name)
+			unreadyMember = true
+			continue
+		}
+
+		statusResp, err := cli.Status(context.Background(), m.ClientURLs[0])
+		if err != nil {
+			c.eventRecorder.Warningf("EtcdMemberNotHealthy", "member %s is not healthy", m.Name)
+			unreadyMember = true
+		}
+		klog.V(4).Infof("member %s is healtly with %d index", m.Name, statusResp.RaftIndex)
+	}
+	if unreadyMember {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (c *BootstrapTeardownController) isKASConfigValid(kasOperator *operatorv1.KubeAPIServer, configMapLister corev1listers.ConfigMapLister) (bool, error) {
@@ -234,6 +374,7 @@ func (c *BootstrapTeardownController) Run(stopCh <-chan struct{}) {
 	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
 		return
 	}
+	klog.V(2).Infof("caches synced BootstrapTeardownController")
 
 	go wait.Until(c.runWorker, time.Second, stopCh)
 
@@ -244,17 +385,6 @@ func (c *BootstrapTeardownController) Run(stopCh <-chan struct{}) {
 	}, stopCh)
 
 	<-stopCh
-}
-
-// this function checks if etcd has scaled the initial bootstrap cluster
-// with all 3 masters
-func (c *BootstrapTeardownController) isEtcdAvailable(currentEtcdOperator *operatorv1.Etcd) bool {
-	if operatorv1helpers.IsOperatorConditionTrue(currentEtcdOperator.Status.Conditions, clustermembercontroller.ConditionBootstrapSafeToRemove) {
-		klog.V(2).Info("etcd is available, bootstrap complete")
-		return true
-	}
-	c.eventRecorder.Eventf("WaitingForEtcdToBeAvailable", "waiting for %s to be true", clustermembercontroller.ConditionBootstrapSafeToRemove)
-	return false
 }
 
 func (c *BootstrapTeardownController) runWorker() {

--- a/pkg/operator/bootstrapteardown/waitforceo.go
+++ b/pkg/operator/bootstrapteardown/waitforceo.go
@@ -5,7 +5,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/clustermembercontroller"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
@@ -61,10 +60,10 @@ func waitForEtcdBootstrap(ctx context.Context, operatorRestClient rest.Interface
 }
 
 func done(etcd *operatorv1.Etcd) (bool, error) {
-	if operatorv1helpers.IsOperatorConditionTrue(etcd.Status.Conditions, clustermembercontroller.ConditionBootstrapRemoved) {
+	if operatorv1helpers.IsOperatorConditionTrue(etcd.Status.Conditions, conditionBootstrapRemoved) {
 		klog.Info("Cluster etcd operator bootstrapped successfully")
 		return true, nil
 	}
-	klog.Infof("waiting on condition %s in etcd CR %s/%s to be True.", clustermembercontroller.ConditionBootstrapRemoved, etcd.Namespace, etcd.Name)
+	klog.Infof("waiting on condition %s in etcd CR %s/%s to be True.", conditionBootstrapRemoved, etcd.Namespace, etcd.Name)
 	return false, nil
 }

--- a/pkg/operator/bootstrapteardown/waitforceo_test.go
+++ b/pkg/operator/bootstrapteardown/waitforceo_test.go
@@ -3,98 +3,15 @@ package bootstrapteardown
 import (
 	"testing"
 
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/clustermembercontroller"
 	"github.com/openshift/library-go/pkg/operator/events"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
-	v1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewFakeController() *BootstrapTeardownController {
 	r := events.NewInMemoryRecorder("Test_isEtcdAvailable")
 	return &BootstrapTeardownController{
 		eventRecorder: r,
-	}
-}
-
-func Test_isEtcdAvailable(t *testing.T) {
-	c := NewFakeController()
-	type args struct {
-		etcd *operatorv1.Etcd
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "test managed cluster and safe to remove",
-			args: args{
-				etcd: &v1.Etcd{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster",
-					},
-					Spec: v1.EtcdSpec{
-						StaticPodOperatorSpec: v1.StaticPodOperatorSpec{
-							OperatorSpec: v1.OperatorSpec{
-								ManagementState: v1.Managed,
-							},
-						},
-					},
-					Status: v1.EtcdStatus{
-						StaticPodOperatorStatus: v1.StaticPodOperatorStatus{
-							OperatorStatus: v1.OperatorStatus{
-								Conditions: []v1.OperatorCondition{
-									{
-										Type:   clustermembercontroller.ConditionBootstrapSafeToRemove,
-										Status: v1.ConditionTrue,
-									},
-								},
-							},
-						}},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "test managed cluster and unsafe to remove",
-			args: args{
-				etcd: &v1.Etcd{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster",
-					},
-					Spec: v1.EtcdSpec{
-						StaticPodOperatorSpec: v1.StaticPodOperatorSpec{
-							OperatorSpec: v1.OperatorSpec{
-								ManagementState: v1.Managed,
-							},
-						},
-					},
-					Status: v1.EtcdStatus{
-						StaticPodOperatorStatus: v1.StaticPodOperatorStatus{
-							OperatorStatus: v1.OperatorStatus{
-								Conditions: []v1.OperatorCondition{
-									{
-										Type:   clustermembercontroller.ConditionBootstrapSafeToRemove,
-										Status: v1.ConditionFalse,
-									},
-								},
-							},
-						}},
-				},
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := c.isEtcdAvailable(tt.args.etcd)
-			if got != tt.want {
-				t.Errorf("doneEtcd() got = %v, want %v", got, tt.want)
-			}
-		})
 	}
 }
 

--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -29,17 +29,15 @@ import (
 )
 
 const (
-	workQueueKey                   = "key"
-	EtcdScalingAnnotationKey       = "etcd.operator.openshift.io/scale"
-	etcdCertFile                   = "/var/run/secrets/etcd-client/tls.crt"
-	etcdKeyFile                    = "/var/run/secrets/etcd-client/tls.key"
-	etcdTrustedCAFile              = "/var/run/configmaps/etcd-ca/ca-bundle.crt"
-	EtcdEndpointNamespace          = "openshift-etcd"
-	EtcdHostEndpointName           = "host-etcd"
-	EtcdEndpointName               = "etcd"
-	ConditionBootstrapSafeToRemove = "BootstrapSafeToRemove"
-	ConditionBootstrapRemoved      = "BootstrapRemoved"
-	dialTimeout                    = 20 * time.Second
+	workQueueKey             = "key"
+	EtcdScalingAnnotationKey = "etcd.operator.openshift.io/scale"
+	etcdCertFile             = "/var/run/secrets/etcd-client/tls.crt"
+	etcdKeyFile              = "/var/run/secrets/etcd-client/tls.key"
+	etcdTrustedCAFile        = "/var/run/configmaps/etcd-ca/ca-bundle.crt"
+	EtcdEndpointNamespace    = "openshift-etcd"
+	EtcdHostEndpointName     = "host-etcd"
+	EtcdEndpointName         = "etcd"
+	dialTimeout              = 20 * time.Second
 )
 
 type ClusterMemberController struct {
@@ -236,31 +234,7 @@ func (c *ClusterMemberController) sync() error {
 			return updateError
 		}
 		klog.V(2).Info("scaling complete, etcd-bootstrap is safe to remove")
-		_, _, updateErr := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(
-			operatorv1.OperatorCondition{
-				Type:    ConditionBootstrapSafeToRemove,
-				Status:  operatorv1.ConditionTrue,
-				Reason:  "ScalingComplete",
-				Message: "cluster-etcd-operator has scaled, etcd-bootstrap safe to remove",
-			}))
-		if updateErr != nil {
-			klog.Errorf("clustermembercontroller:sync: error updating status: %#v", updateErr)
-			return updateErr
-		}
 		return nil
-	} else {
-		klog.V(2).Info("scaling incomplete, etcd-bootstrap is not safe to remove")
-		_, _, updateErr := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(
-			operatorv1.OperatorCondition{
-				Type:    ConditionBootstrapSafeToRemove,
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "ScalingIncomplete",
-				Message: "cluster-etcd-operator is scaling, etcd-bootstrap is not safe to remove",
-			}))
-		if updateErr != nil {
-			klog.Errorf("clustermembercontroller:sync: error updating status: %#v", updateErr)
-			return updateErr
-		}
 	}
 	klog.Infof("Wait for cluster-etcd-operator to get ready")
 	return nil

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -196,7 +196,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	bootstrapTeardownController := bootstrapteardown.NewBootstrapTeardownController(
 		operatorClient,
 		kubeInformersForNamespaces,
-		clusterMemberController,
 		operatorConfigInformers,
 		controllerContext.EventRecorder,
 	)


### PR DESCRIPTION
Make the bootstrap teardown controller stand on it's own without relying on the clustermember controller