### PR TITLE
bug 1801938: add host-etcd-2 which will never list the bootstrap etcd as an endpoi…

### DIFF
--- a/bindata/bootkube/manifests/00_etcd-host-service-endpoints.yaml
+++ b/bindata/bootkube/manifests/00_etcd-host-service-endpoints.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: host-etcd-2
+  namespace: openshift-etcd
+  annotations:
+    alpha.installer.openshift.io/etcd-bootstrap: {{ .BootstrapIP }}

--- a/bindata/bootkube/manifests/00_etcd-host-service.yaml
+++ b/bindata/bootkube/manifests/00_etcd-host-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: host-etcd-2
+  namespace: openshift-etcd
+  labels:
+    # this label is used to indicate that it should be scraped by prometheus
+    k8s-app: etcd
+spec:
+  clusterIP: None
+  ports:
+  - name: etcd
+    port: 2379
+    protocol: TCP

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -36,6 +36,7 @@ type renderOpts struct {
 	setupEtcdEnvImage        string
 	kubeClientAgentImage     string
 	clusterConfigFile        string
+	bootstrapIP              string
 }
 
 // NewRenderCommand creates a render command.
@@ -81,6 +82,7 @@ func (r *renderOpts) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&r.setupEtcdEnvImage, "manifest-setup-etcd-env-image", r.setupEtcdEnvImage, "setup-etcd-env manifest image")
 	fs.StringVar(&r.etcdDiscoveryDomain, "etcd-discovery-domain", r.etcdDiscoveryDomain, "etcd discovery domain")
 	fs.StringVar(&r.clusterConfigFile, "cluster-config-file", r.clusterConfigFile, "Openshift Cluster API Config file.")
+	fs.StringVar(&r.bootstrapIP, "bootstrap-ip", r.bootstrapIP, "bootstrap IP used to indicate where to find the first etcd endpoint")
 }
 
 // Validate verifies the inputs.
@@ -149,6 +151,8 @@ type TemplateData struct {
 
 	// Hostname as reported by the kernel
 	Hostname string
+
+	BootstrapIP string
 }
 
 type StaticFile struct {

--- a/pkg/operator/hostendpointscontroller2/host_endpoints_controller.go
+++ b/pkg/operator/hostendpointscontroller2/host_endpoints_controller.go
@@ -1,0 +1,295 @@
+package hostendpointscontroller2
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/mergepatch"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+)
+
+const (
+	workQueueKey = "key"
+)
+
+// HostEndpoints2Controller maintains an Endpoints resource with
+// IP addresses for etcd.  It should never depend on DNS directly or transitively.
+// in 4.4, we will abandon the old resource in etcd.
+type HostEndpoints2Controller struct {
+	operatorClient  v1helpers.OperatorClient
+	nodeLister      corev1listers.NodeLister
+	endpointsLister corev1listers.EndpointsLister
+	endpointsClient corev1client.EndpointsGetter
+
+	eventRecorder events.Recorder
+	queue         workqueue.RateLimitingInterface
+	cachesToSync  []cache.InformerSynced
+}
+
+func NewHostEndpoints2Controller(
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+	kubeClient kubernetes.Interface,
+	kubeInformers operatorv1helpers.KubeInformersForNamespaces,
+) *HostEndpoints2Controller {
+	kubeInformersForTargetNamespace := kubeInformers.InformersFor(operatorclient.TargetNamespace)
+	endpointsInformer := kubeInformersForTargetNamespace.Core().V1().Endpoints()
+	kubeInformersForCluster := kubeInformers.InformersFor("")
+	nodeInformer := kubeInformersForCluster.Core().V1().Nodes()
+
+	c := &HostEndpoints2Controller{
+		eventRecorder: eventRecorder.WithComponentSuffix("host-etcd-2-endpoints-controller2"),
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "HostEndpoints2Controller"),
+		cachesToSync: []cache.InformerSynced{
+			operatorClient.Informer().HasSynced,
+			endpointsInformer.Informer().HasSynced,
+			nodeInformer.Informer().HasSynced,
+		},
+		operatorClient:  operatorClient,
+		nodeLister:      nodeInformer.Lister(),
+		endpointsLister: endpointsInformer.Lister(),
+		endpointsClient: kubeClient.CoreV1(),
+	}
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
+	endpointsInformer.Informer().AddEventHandler(c.eventHandler())
+	nodeInformer.Informer().AddEventHandler(c.eventHandler())
+	return c
+}
+
+func (c *HostEndpoints2Controller) sync() error {
+	err := c.syncHostEndpoints2()
+
+	if err != nil {
+		_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+			Type:    "HostEndpoints2Degraded",
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "ErrorUpdatingHostEndpoints2",
+			Message: err.Error(),
+		}))
+		if updateErr != nil {
+			c.eventRecorder.Warning("HostEndpoints2ErrorUpdatingStatus", updateErr.Error())
+		}
+		return err
+	}
+
+	_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+		Type:   "HostEndpoints2Degraded",
+		Status: operatorv1.ConditionFalse,
+		Reason: "HostEndpoints2Updated",
+	}))
+	if updateErr != nil {
+		c.eventRecorder.Warning("HostEndpoints2ErrorUpdatingStatus", updateErr.Error())
+		return updateErr
+	}
+	return nil
+}
+
+func (c *HostEndpoints2Controller) syncHostEndpoints2() error {
+	required := hostEndpointsAsset()
+
+	// create endpoint addresses for each node
+	nodes, err := c.nodeLister.List(labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector())
+	if err != nil {
+		return fmt.Errorf("unable to list expected etcd member nodes: %v", err)
+	}
+	endpointAddresses := []corev1.EndpointAddress{}
+	for _, node := range nodes {
+		var nodeInternalIP string
+		for _, nodeAddress := range node.Status.Addresses {
+			if nodeAddress.Type == corev1.NodeInternalIP {
+				nodeInternalIP = nodeAddress.Address
+				break
+			}
+		}
+		if len(nodeInternalIP) == 0 {
+			return fmt.Errorf("unable to determine internal ip address for node %s", node.Name)
+		}
+
+		endpointAddresses = append(endpointAddresses, corev1.EndpointAddress{
+			IP:       nodeInternalIP,
+			NodeName: &node.Name,
+		})
+	}
+
+	required.Subsets[0].Addresses = endpointAddresses
+	if len(required.Subsets[0].Addresses) == 0 {
+		return fmt.Errorf("no master nodes are present")
+	}
+
+	return c.applyEndpoints(required)
+}
+
+func hostEndpointsAsset() *corev1.Endpoints {
+	return &corev1.Endpoints{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "host-etcd-2",
+			Namespace: operatorclient.TargetNamespace,
+		},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Ports: []corev1.EndpointPort{
+					{
+						Name:     "etcd",
+						Port:     2379,
+						Protocol: "TCP",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *HostEndpoints2Controller) applyEndpoints(required *corev1.Endpoints) error {
+	existing, err := c.endpointsLister.Endpoints(operatorclient.TargetNamespace).Get("host-etcd-2")
+	if errors.IsNotFound(err) {
+		_, err := c.endpointsClient.Endpoints(operatorclient.TargetNamespace).Create(required)
+		if err != nil {
+			c.eventRecorder.Warningf("EndpointsCreateFailed", "Failed to create endpoints/%s -n %s: %v", required.Name, required.Namespace, err)
+			return err
+		}
+		c.eventRecorder.Warningf("EndpointsCreated", "Created endpoints/%s -n %s because it was missing", required.Name, required.Namespace)
+	}
+	if err != nil {
+		return err
+	}
+	modified := resourcemerge.BoolPtr(false)
+	toWrite := existing.DeepCopy()
+	resourcemerge.EnsureObjectMeta(modified, &toWrite.ObjectMeta, required.ObjectMeta)
+	if !endpointsSubsetsEqual(existing.Subsets, required.Subsets) {
+		toWrite.Subsets = make([]corev1.EndpointSubset, len(required.Subsets))
+		for i := range required.Subsets {
+			required.Subsets[i].DeepCopyInto(&(toWrite.Subsets)[i])
+		}
+		*modified = true
+	}
+	if !*modified {
+		// no update needed
+		return nil
+	}
+	jsonPatch := resourceapply.JSONPatchNoError(existing, toWrite)
+	if klog.V(4) {
+		klog.Infof("Endpoints %q changes: %v", required.Namespace+"/"+required.Name, jsonPatch)
+	}
+	updated, err := c.endpointsClient.Endpoints(operatorclient.TargetNamespace).Update(toWrite)
+	if err != nil {
+		c.eventRecorder.Warningf("EndpointsUpdateFailed", "Failed to update endpoints/%s -n %s: %v", required.Name, required.Namespace, err)
+		return err
+	}
+	klog.Infof("toWrite: \n%v", mergepatch.ToYAMLOrError(updated.Subsets))
+	c.eventRecorder.Warningf("EndpointsUpdated", "Updated endpoints/%s -n %s because it changed: %v", required.Name, required.Namespace, jsonPatch)
+	return nil
+}
+
+func endpointsSubsetsEqual(lhs, rhs []corev1.EndpointSubset) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+	for i := range lhs {
+		if !endpointSubsetEqual(lhs[i], rhs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func endpointSubsetEqual(lhs, rhs corev1.EndpointSubset) bool {
+	if len(lhs.Addresses) != len(rhs.Addresses) {
+		return false
+	}
+	if len(lhs.NotReadyAddresses) != len(rhs.NotReadyAddresses) {
+		return false
+	}
+	if len(lhs.Ports) != len(rhs.Ports) {
+		return false
+	}
+	// sorts the endpoint addresses for comparison (make copy as to not clobber originals)
+	count := len(lhs.Addresses)
+	lhsAddresses := make([]corev1.EndpointAddress, count)
+	rhsAddresses := make([]corev1.EndpointAddress, count)
+	for i := 0; i < count; i++ {
+		lhs.Addresses[i].DeepCopyInto(&lhsAddresses[i])
+		rhs.Addresses[i].DeepCopyInto(&rhsAddresses[i])
+	}
+	sort.Slice(lhsAddresses, newEndpointAddressSliceComparator(lhsAddresses))
+	sort.Slice(rhsAddresses, newEndpointAddressSliceComparator(rhsAddresses))
+	return reflect.DeepEqual(lhsAddresses, rhsAddresses)
+}
+
+func newEndpointAddressSliceComparator(endpointAddresses []corev1.EndpointAddress) func(int, int) bool {
+	return func(i, j int) bool {
+		switch {
+		case endpointAddresses[i].IP != endpointAddresses[j].IP:
+			return endpointAddresses[i].IP < endpointAddresses[j].IP
+		case endpointAddresses[i].Hostname != endpointAddresses[j].Hostname:
+			return endpointAddresses[i].Hostname < endpointAddresses[j].Hostname
+		default:
+			return *endpointAddresses[i].NodeName < *endpointAddresses[j].NodeName
+		}
+	}
+}
+
+func (c *HostEndpoints2Controller) Run(ctx context.Context, workers int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+	klog.Infof("Starting HostEtcdEndpointsController")
+	defer klog.Infof("Shutting down HostEtcdEndpointsController")
+	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
+		return
+	}
+	go wait.Until(c.runWorker, time.Second, ctx.Done())
+	<-ctx.Done()
+}
+
+func (c *HostEndpoints2Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *HostEndpoints2Controller) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+func (c *HostEndpoints2Controller) eventHandler() cache.ResourceEventHandler {
+	// eventHandler queues the operator to check spec and status
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcdmemberscontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/guardbudget"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/hostendpointscontroller"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/hostendpointscontroller2"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/targetconfigcontroller"
@@ -172,6 +173,12 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		kubeInformersForNamespaces,
 		configInformers.Config().V1().Infrastructures(),
 	)
+	hostEtcdEndpointController2 := hostendpointscontroller2.NewHostEndpoints2Controller(
+		operatorClient,
+		controllerContext.EventRecorder,
+		coreClient,
+		kubeInformersForNamespaces,
+	)
 
 	clusterMemberController := clustermembercontroller.NewClusterMemberController(
 		operatorClient,
@@ -212,6 +219,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	go targetConfigReconciler.Run(1, ctx.Done())
 	go etcdCertSignerController.Run(1, ctx.Done())
 	go hostEtcdEndpointController.Run(ctx, 1)
+	go hostEtcdEndpointController2.Run(ctx, 1)
 	go resourceSyncController.Run(ctx, 1)
 	go statusController.Run(ctx, 1)
 	go configObserver.Run(ctx, 1)


### PR DESCRIPTION
…nt and never have valid hostnames

This eliminates the possibility of dns dependence downstream. It requires an update to the installer to pass the bootstrap IP to be a complete replacement, but they have to have the ability to pass the arg first.

