### PR TITLE
Bug 1802748: old clustermembercontroller: use EtcdClient interface

### DIFF
--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -115,8 +115,9 @@ func (g *etcdClientGetter) MemberAdd(peerURL string) error {
 	defer cli.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	membersResp, err := cli.MemberList(ctx)
-	cancel()
 	if err != nil {
 		return err
 	}
@@ -143,8 +144,9 @@ func (g *etcdClientGetter) MemberRemove(member string) error {
 	defer cli.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	membersResp, err := cli.MemberList(ctx)
-	cancel()
 	if err != nil {
 		return nil
 	}
@@ -152,8 +154,9 @@ func (g *etcdClientGetter) MemberRemove(member string) error {
 	for _, m := range membersResp.Members {
 		if m.Name == member {
 			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			_, err = cli.MemberRemove(ctx, m.ID)
-			cancel()
 			if err != nil {
 				return err
 			}
@@ -172,8 +175,9 @@ func (g *etcdClientGetter) MemberList() ([]*etcdserverpb.Member, error) {
 	defer cli.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	membersResp, err := cli.MemberList(ctx)
-	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -189,8 +193,9 @@ func (g *etcdClientGetter) UnhealthyMembers() ([]*etcdserverpb.Member, error) {
 	defer cli.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	membersResp, err := cli.MemberList(ctx)
-	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -201,8 +206,9 @@ func (g *etcdClientGetter) UnhealthyMembers() ([]*etcdserverpb.Member, error) {
 			unhealthyMembers = append(unhealthyMembers, member)
 		}
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		_, err := cli.Status(ctx, member.ClientURLs[0])
-		cancel()
 		if err != nil {
 			unhealthyMembers = append(unhealthyMembers, member)
 		}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -186,6 +186,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	clusterMemberController := clustermembercontroller.NewClusterMemberController(
 		coreClient,
 		operatorClient,
+		etcdClient,
 		kubeInformersForNamespaces.InformersFor("openshift-etcd"),
 		controllerContext.EventRecorder,
 		etcdDiscoveryDomain,


### PR DESCRIPTION
This PR 
- refactors the clustermembercontroller to use EtcdClient
interface.
- it also fixes the etcd client prematurely cancelling context  