### PR TITLE
wait for cluster-bootstrap to finish before removing bootstrap etcd

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -193,6 +193,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	)
 	bootstrapTeardownController := bootstrapteardown.NewBootstrapTeardownController(
 		operatorClient,
+		kubeClient,
 		kubeInformersForNamespaces,
 		operatorConfigInformers,
 		etcdClient,


### PR DESCRIPTION
after https://github.com/openshift/cluster-bootstrap/pull/31 merges, this will make the teardown more reliable.