### PR TITLE
Bug 1804960: Revert: render: fix listening addresses in IPv6 case

### DIFF
--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -230,8 +230,8 @@ func (t *TemplateData) setEtcdAddress() {
 
 	// IPv6
 	if t.SingleStackIPv6 {
-		allAddresses = "::"
-		localhost = "::1"
+		allAddresses = "[::]"
+		localhost = "[::1]"
 	}
 
 	etcdAddress := options.EtcdAddress{

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -209,7 +209,7 @@ func TestTemplateDataSingleStack(t *testing.T) {
 	want := TemplateData{
 		ManifestConfig: options.ManifestConfig{
 			EtcdAddress: options.EtcdAddress{
-				LocalHost: "::1",
+				LocalHost: "[::1]",
 			},
 		},
 		ClusterCIDR:     []string{"10.128.0.0/14"},


### PR DESCRIPTION
Reverts openshift/cluster-etcd-operator#147