### PR TITLE
Bug 1804921: Exclude etcd operator from hosted control plane deployments

### DIFF
--- a/manifests/0000_12_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_06_deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   namespace: openshift-etcd-operator
   name: etcd-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     app: etcd-operator
 spec:

--- a/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
+++ b/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: etcd
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec: {}
 status:
   versions:


### PR DESCRIPTION
Prevents cvo from instantiating this operator in a hosted control plane deployment. See https://github.com/openshift/enhancements/pull/202