### PR TITLE
pkg/cmd/render: populate bootstrapIP from local interfaces

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -25,7 +25,7 @@ spec:
             --assetsdir=/etc/ssl/etcd \
             --dnsnames={{.EtcdServerCertDNSNames}} \
             --commonname=system:etcd-server:{{ .Hostname }} \
-            --ipaddrs={{ .EtcdAddress.BootstrapIP }},{{ .EtcdAddress.LocalHost }} \
+            --ipaddrs={{ .EtcdAddress.EscapedBootstrapIP }},{{ .EtcdAddress.LocalHost }} \
 
       [ -e /etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.crt -a \
         -e /etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.key ] || \
@@ -36,7 +36,7 @@ spec:
             --assetsdir=/etc/ssl/etcd \
             --dnsnames={{.EtcdPeerCertDNSNames}} \
             --commonname=system:etcd-peer:{{ .Hostname }} \
-            --ipaddrs={{ .EtcdAddress.BootstrapIP }} \
+            --ipaddrs={{ .EtcdAddress.EscapedBootstrapIP }} \
 
       [ -e /etc/ssl/etcd/system:etcd-metric:{{ .Hostname }}.crt -a \
         -e /etc/ssl/etcd/system:etcd-metric:{{ .Hostname }}.key ] || \
@@ -47,7 +47,7 @@ spec:
             --assetsdir=/etc/ssl/etcd \
             --dnsnames={{.EtcdServerCertDNSNames}} \
             --commonname=system:etcd-metric:{{ .Hostname }} \
-            --ipaddrs={{ .EtcdAddress.BootstrapIP }} \
+            --ipaddrs={{ .EtcdAddress.EscapedBootstrapIP }} \
     terminationMessagePolicy: FallbackToLogsOnError
     securityContext:
       privileged: true
@@ -69,7 +69,7 @@ spec:
       set -euo pipefail
 
       exec etcd \
-        --initial-advertise-peer-urls=https://{{ .EtcdAddress.BootstrapIP }}:2380 \
+        --initial-advertise-peer-urls=https://{{ .EtcdAddress.EscapedBootstrapIP }}:2380 \
         --cert-file=/etc/ssl/etcd/system:etcd-server:{{ .Hostname }}.crt \
         --key-file=/etc/ssl/etcd/system:etcd-server:{{ .Hostname }}.key \
         --trusted-ca-file=/etc/ssl/etcd/ca.crt \
@@ -78,7 +78,7 @@ spec:
         --peer-key-file=/etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.key \
         --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
         --peer-client-cert-auth=true \
-        --advertise-client-urls=https://{{ .EtcdAddress.BootstrapIP }}:2379 \
+        --advertise-client-urls=https://{{ .EtcdAddress.EscapedBootstrapIP }}:2379 \
         --listen-client-urls=https://{{ .EtcdAddress.ListenClient }} \
         --listen-peer-urls=https://{{ .EtcdAddress.ListenPeer }} \
         --listen-metrics-urls=https://{{ .EtcdAddress.ListenMetricServer }} \
@@ -121,7 +121,7 @@ spec:
       set -euo pipefail
 
       exec etcd grpc-proxy start \
-        --endpoints https://{{ .EtcdAddress.BootstrapIP }}:9978 \
+        --endpoints https://{{ .EtcdAddress.EscapedBootstrapIP }}:9978 \
         --metrics-addr https://{{ .EtcdAddress.ListenMetricProxy }}\
         --listen-addr {{ .EtcdAddress.LocalHost }}:9977 \
         --key /etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.key \

--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -7,31 +7,6 @@ metadata:
     k8s-app: etcd
 spec:
   initContainers:
-  - name: discovery
-    image: "{{.Images.SetupEtcdEnv}}"
-    command: ["/usr/bin/setup-etcd-environment"]
-    args:
-    - "run"
-    - "--discovery-srv={{.EtcdDiscoveryDomain}}"
-    - "--output-file=/run/etcd/environment"
-    - "--bootstrap-srv=false"
-    - "--v=4"
-    securityContext:
-      privileged: true
-    volumeMounts:
-    - name: discovery
-      mountPath: /run/etcd/
-    - name: data-dir
-      mountPath: /var/lib/etcd/
-    env:
-    - name: ETCD_IPV4_ADDRESS
-      valueFrom:
-        fieldRef:
-          fieldPath: status.hostIP
-    - name: ETCD_DATA_DIR
-      value: "/var/lib/etcd"
-    - name: ETCD_NAME
-      value: "etcd-bootstrap"
   - name: certs
     image: "{{.Images.KubeClientAgent}}"
     command:
@@ -40,8 +15,6 @@ spec:
     - |
       #!/bin/sh
       set -euxo pipefail
-
-      source /run/etcd/environment
 
       [ -e /etc/ssl/etcd/system:etcd-server:{{ .Hostname }}.crt -a \
         -e /etc/ssl/etcd/system:etcd-server:{{ .Hostname }}.key ] || \
@@ -52,7 +25,7 @@ spec:
             --assetsdir=/etc/ssl/etcd \
             --dnsnames={{.EtcdServerCertDNSNames}} \
             --commonname=system:etcd-server:{{ .Hostname }} \
-            --ipaddrs=${ETCD_ESCAPED_IP_ADDRESS},{{ .EtcdAddress.LocalHost }} \
+            --ipaddrs={{ .EtcdAddress.BootstrapIP }},{{ .EtcdAddress.LocalHost }} \
 
       [ -e /etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.crt -a \
         -e /etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.key ] || \
@@ -63,7 +36,7 @@ spec:
             --assetsdir=/etc/ssl/etcd \
             --dnsnames={{.EtcdPeerCertDNSNames}} \
             --commonname=system:etcd-peer:{{ .Hostname }} \
-            --ipaddrs=${ETCD_ESCAPED_IP_ADDRESS} \
+            --ipaddrs={{ .EtcdAddress.BootstrapIP }} \
 
       [ -e /etc/ssl/etcd/system:etcd-metric:{{ .Hostname }}.crt -a \
         -e /etc/ssl/etcd/system:etcd-metric:{{ .Hostname }}.key ] || \
@@ -74,7 +47,7 @@ spec:
             --assetsdir=/etc/ssl/etcd \
             --dnsnames={{.EtcdServerCertDNSNames}} \
             --commonname=system:etcd-metric:{{ .Hostname }} \
-            --ipaddrs=${ETCD_ESCAPED_IP_ADDRESS} \
+            --ipaddrs={{ .EtcdAddress.BootstrapIP }} \
     terminationMessagePolicy: FallbackToLogsOnError
     securityContext:
       privileged: true
@@ -95,10 +68,8 @@ spec:
       #!/bin/sh
       set -euo pipefail
 
-      source /run/etcd/environment
-
       exec etcd \
-        --initial-advertise-peer-urls=https://${ETCD_ESCAPED_IP_ADDRESS}:2380 \
+        --initial-advertise-peer-urls=https://{{ .EtcdAddress.BootstrapIP }}:2380 \
         --cert-file=/etc/ssl/etcd/system:etcd-server:{{ .Hostname }}.crt \
         --key-file=/etc/ssl/etcd/system:etcd-server:{{ .Hostname }}.key \
         --trusted-ca-file=/etc/ssl/etcd/ca.crt \
@@ -107,7 +78,7 @@ spec:
         --peer-key-file=/etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.key \
         --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
         --peer-client-cert-auth=true \
-        --advertise-client-urls=https://${ETCD_ESCAPED_IP_ADDRESS}:2379 \
+        --advertise-client-urls=https://{{ .EtcdAddress.BootstrapIP }}:2379 \
         --listen-client-urls=https://{{ .EtcdAddress.ListenClient }} \
         --listen-peer-urls=https://{{ .EtcdAddress.ListenPeer }} \
         --listen-metrics-urls=https://{{ .EtcdAddress.ListenMetricServer }} \
@@ -149,10 +120,8 @@ spec:
       #!/bin/sh
       set -euo pipefail
 
-      source /run/etcd/environment
-
       exec etcd grpc-proxy start \
-        --endpoints https://${ETCD_ESCAPED_IP_ADDRESS}:9978 \
+        --endpoints https://{{ .EtcdAddress.BootstrapIP }}:9978 \
         --metrics-addr https://{{ .EtcdAddress.ListenMetricProxy }}\
         --listen-addr {{ .EtcdAddress.LocalHost }}:9977 \
         --key /etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.key \

--- a/pkg/cmd/render/options/config.go
+++ b/pkg/cmd/render/options/config.go
@@ -51,6 +51,7 @@ type EtcdAddress struct {
 	ListenMetricServer string
 	ListenMetricProxy  string
 	LocalHost          string
+	BootstrapIP        string
 }
 
 type TemplateData struct {

--- a/pkg/cmd/render/options/config.go
+++ b/pkg/cmd/render/options/config.go
@@ -51,7 +51,7 @@ type EtcdAddress struct {
 	ListenMetricServer string
 	ListenMetricProxy  string
 	LocalHost          string
-	BootstrapIP        string
+	EscapedBootstrapIP string
 }
 
 type TemplateData struct {

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -183,6 +183,7 @@ func newTemplateData(opts *renderOpts) (*TemplateData, error) {
 		EtcdPeerCertDNSNames: strings.Join([]string{
 			opts.etcdDiscoveryDomain,
 		}, ","),
+		BootstrapIP: opts.bootstrapIP,
 	}
 
 	if err := templateData.setClusterCIDR(opts.clusterConfigFile); err != nil {
@@ -196,6 +197,14 @@ func newTemplateData(opts *renderOpts) (*TemplateData, error) {
 	}
 	if err := templateData.setHostname(); err != nil {
 		return nil, err
+	}
+
+	// TODO installer should feed value by flag this should be removed
+	// derive bootstrapIP from local interfaces if not passed by flag
+	if templateData.BootstrapIP == "" {
+		if err := templateData.setBootstrapIP(); err != nil {
+			return nil, err
+		}
 	}
 
 	templateData.setEtcdAddress()
@@ -227,15 +236,48 @@ func (r *renderOpts) Run() error {
 	return WriteFiles(&r.generic, &templateData.FileConfig, templateData)
 }
 
+// setBootstrapIP gets a list of IPs from local interfaces and returns the first IPv4 or IPv6 address.
+func (t *TemplateData) setBootstrapIP() error {
+	var bootstrapIP string
+	ips, err := ipAddrs()
+	if err != nil {
+		return err
+	}
+
+	for _, addr := range ips {
+		ip := net.ParseIP(addr)
+
+		// IPv6
+		if t.SingleStackIPv6 && ip.To4() == nil {
+			bootstrapIP = addr
+			break
+		}
+		// IPv4
+		if !t.SingleStackIPv6 && ip.To4() != nil {
+			bootstrapIP = addr
+			break
+		}
+	}
+
+	if bootstrapIP == "" {
+		return fmt.Errorf("no IP address found for bootstrap node")
+	}
+
+	t.BootstrapIP = bootstrapIP
+	return nil
+}
+
 func (t *TemplateData) setEtcdAddress() {
 	// IPv4
 	allAddresses := "0.0.0.0"
 	localhost := "127.0.0.1"
+	bootstrapIP := t.BootstrapIP
 
 	// IPv6
 	if t.SingleStackIPv6 {
-		allAddresses = "[::]"
+		allAddresses = "::"
 		localhost = "[::1]"
+		bootstrapIP = "[" + t.BootstrapIP + "]"
 	}
 
 	etcdAddress := options.EtcdAddress{
@@ -244,6 +286,7 @@ func (t *TemplateData) setEtcdAddress() {
 		LocalHost:          localhost,
 		ListenMetricServer: net.JoinHostPort(allAddresses, "9978"),
 		ListenMetricProxy:  net.JoinHostPort(allAddresses, "9979"),
+		BootstrapIP:        bootstrapIP,
 	}
 
 	t.ManifestConfig.EtcdAddress = etcdAddress
@@ -387,4 +430,29 @@ func mustReadTemplateFile(fname string) options.Template {
 		panic(fmt.Sprintf("Failed to load %q: %v", fname, err))
 	}
 	return options.Template{FileName: fname, Content: bs}
+}
+
+func ipAddrs() ([]string, error) {
+	var ips []string
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ips, err
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip == nil {
+			continue
+		}
+		if !ip.IsGlobalUnicast() {
+			continue // we only want global unicast address
+		}
+		ips = append(ips, ip.String())
+	}
+	return ips, nil
 }

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -152,6 +152,7 @@ type TemplateData struct {
 	// Hostname as reported by the kernel
 	Hostname string
 
+	// BootstrapIP is address of the bootstrap node
 	BootstrapIP string
 }
 
@@ -246,7 +247,6 @@ func (t *TemplateData) setBootstrapIP() error {
 
 	for _, addr := range ips {
 		ip := net.ParseIP(addr)
-
 		// IPv6
 		if t.SingleStackIPv6 && ip.To4() == nil {
 			bootstrapIP = addr
@@ -286,7 +286,7 @@ func (t *TemplateData) setEtcdAddress() {
 		LocalHost:          localhost,
 		ListenMetricServer: net.JoinHostPort(allAddresses, "9978"),
 		ListenMetricProxy:  net.JoinHostPort(allAddresses, "9979"),
-		BootstrapIP:        bootstrapIP,
+		EscapedBootstrapIP: bootstrapIP,
 	}
 
 	t.ManifestConfig.EtcdAddress = etcdAddress

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -104,6 +104,7 @@ type testConfig struct {
 	t                    *testing.T
 	clusterNetworkConfig string
 	want                 TemplateData
+	bootstrapIP          string
 }
 
 func TestRenderIpv4(t *testing.T) {
@@ -215,12 +216,14 @@ func TestTemplateDataSingleStack(t *testing.T) {
 		ClusterCIDR:     []string{"10.128.0.0/14"},
 		ServiceCIDR:     []string{"2001:db8::/32"},
 		SingleStackIPv6: true,
+		BootstrapIP:     "2001:0DB8:C21A",
 	}
 
 	config := &testConfig{
 		t:                    t,
 		clusterNetworkConfig: networkConfigIPv6SingleStack,
 		want:                 want,
+		bootstrapIP:          "2001:0DB8:C21A",
 	}
 	testTemplateData(config)
 }
@@ -255,6 +258,7 @@ func testTemplateData(tc *testConfig) {
 		manifest:          *options.NewManifestOptions("etcd"),
 		errOut:            errOut,
 		clusterConfigFile: clusterConfigFile.Name(),
+		bootstrapIP:       tc.bootstrapIP,
 	}
 
 	got, err := newTemplateData(render)
@@ -275,6 +279,11 @@ func testTemplateData(tc *testConfig) {
 		tc.t.Errorf("SingleStackIPv6 want: %v got: %v", tc.want.SingleStackIPv6, got.SingleStackIPv6)
 	case got.ManifestConfig.EtcdAddress.LocalHost != tc.want.ManifestConfig.EtcdAddress.LocalHost:
 		tc.t.Errorf("LocalHost want: %q got: %q", tc.want.ManifestConfig.EtcdAddress.LocalHost, got.ManifestConfig.EtcdAddress.LocalHost)
+	case got.BootstrapIP != tc.want.BootstrapIP:
+		// if we don't say we want a specific IP we dont fail.
+		if tc.want.BootstrapIP != "" {
+			tc.t.Errorf("BootstrapIP want: %q got: %q", tc.want.BootstrapIP, got.BootstrapIP)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR removes the `discovery` init container from the bootstrap etcd instance and replaces its functionality with observations of the local systems interfaces.

We also move to etcd-host-2 service for populating endpoints for etcdcli