### PR TITLE
Skip member check in case of lights-out and upgrade

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -48,62 +48,65 @@ spec:
         #!/bin/sh
         set -euo pipefail
 
-        ETCDCTL="etcdctl --cacert=/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt \
-                           --cert=/etc/kubernetes/static-pod-resources/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt \
-                           --key=/etc/kubernetes/static-pod-resources/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key \
-                           --endpoints=${ALL_ETCD_ENDPOINTS}"
-        ${ETCDCTL} member list
-
-        echo "waiting for member ${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}..."
-        COUNT=30
-        while [ $COUNT -gt 0 ]; do
-          echo "current member list is..."
+        if [[ ! -d /var/lib/etcd/member/ ]]; then
+          ETCDCTL="etcdctl --cacert=/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt \
+                             --cert=/etc/kubernetes/static-pod-resources/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt \
+                             --key=/etc/kubernetes/static-pod-resources/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key \
+                             --endpoints=${ALL_ETCD_ENDPOINTS}"
           ${ETCDCTL} member list
-          echo ""
-          echo ""
 
-          IS_MEMBER_PRESENT=$(${ETCDCTL} member list | grep -o "${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}.*:2380" || true)
-          if [[ -n "${IS_MEMBER_PRESENT:-}" ]]; then
+          echo "waiting for member ${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}..."
+          COUNT=30
+          while [ $COUNT -gt 0 ]; do
+            echo "current member list is..."
+            ${ETCDCTL} member list
+            echo ""
+            echo ""
+
+            IS_MEMBER_PRESENT=$(${ETCDCTL} member list | grep -o "${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}.*:2380" || true)
+            if [[ -n "${IS_MEMBER_PRESENT:-}" ]]; then
+              break
+            fi
+            sleep 1
+            let COUNT=$COUNT-1
+          done
+
+          # if the member is not present after 30 seconds
+          if [ -z "$IS_MEMBER_PRESENT" ]; then
+            echo "member ${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME} is not present after 30 seconds"
+            exit 1
+          fi
+          echo "member ${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME} is present, continuing"
+
+          initial_cluster=""
+          member_output=$( ${ETCDCTL} member list | cut -d',' -f3 )
+          for endpoint_key in ${member_output}; do
+            endpoint=$(${ETCDCTL} member list | grep $endpoint_key | awk -F'[, ]' '{ print $7 }')
+            initial_cluster+="$endpoint_key=$endpoint,"
+            echo "adding $endpoint_key=$endpoint,"
+          done
+
+          # if the member isn't started, then we need to add exactly what we expect to the initial cluster for this member
+          echo "checking for unstarted"
+          ${ETCDCTL} member list | grep "${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}" | grep unstarted || true
+          IS_MEMBER_UNSTARTED=$(${ETCDCTL} member list | grep "${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}" | grep unstarted || true)
+          if [[ -n "${IS_MEMBER_UNSTARTED:-}" ]]; then
+            initial_cluster+="NODE_NAME=https://${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}:2380,"
+            echo "adding unstarted NODE_NAME=https://${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}:2380,"
             break
           fi
-          sleep 1
-          let COUNT=$COUNT-1
-        done
 
-        # if the member is not present after 30 seconds
-        if [ -z "$IS_MEMBER_PRESENT" ]; then
-          echo "member ${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME} is not present after 30 seconds"
-          exit 1
-        fi
-        echo "member ${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME} is present, continuing"
+          # trim last comma
+          initial_cluster="${initial_cluster::-1}"
+          echo $initial_cluster
 
-        initial_cluster=""
-        member_output=$( ${ETCDCTL} member list | cut -d',' -f3 )
-        for endpoint_key in ${member_output}; do
-          endpoint=$(${ETCDCTL} member list | grep $endpoint_key | awk -F'[, ]' '{ print $7 }')
-          initial_cluster+="$endpoint_key=$endpoint,"
-          echo "adding $endpoint_key=$endpoint,"
-        done
+          # at this point we know this member is added.  To support a transition, we must remove the old etcd pod.
+          # move it somewhere safe so we can retrieve it again later if something goes badly.
+          mv /etc/kubernetes/manifests/etcd-member.yaml /etc/kubernetes/etcd-backup-dir || true
 
-        # if the member isn't started, then we need to add exactly what we expect to the initial cluster for this member
-        echo "checking for unstarted"
-        ${ETCDCTL} member list | grep "${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}" | grep unstarted || true
-        IS_MEMBER_UNSTARTED=$(${ETCDCTL} member list | grep "${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}" | grep unstarted || true)
-        if [[ -n "${IS_MEMBER_UNSTARTED:-}" ]]; then
-          initial_cluster+="NODE_NAME=https://${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}:2380,"
-          echo "adding unstarted NODE_NAME=https://${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME}:2380,"
-          break
+          export ETCD_INITIAL_CLUSTER=${initial_cluster}
         fi
 
-        # trim last comma
-        initial_cluster="${initial_cluster::-1}"
-        echo $initial_cluster
-
-        # at this point we know this member is added.  To support a transition, we must remove the old etcd pod.
-        # move it somewhere safe so we can retrieve it again later if something goes badly.
-        mv /etc/kubernetes/manifests/etcd-member.yaml /etc/kubernetes/etcd-backup-dir || true
-
-        export ETCD_INITIAL_CLUSTER=${initial_cluster}
         export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
         env | grep ETCD | grep -v NODE
 


### PR DESCRIPTION
Skip the wait for the member list to show up in case the cluster is already installed.