### PR TITLE
pkg/cmd/render: use machineNetwork CIDR to validate bootstrap IP

### DIFF
--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -117,12 +117,14 @@ func TestRenderIpv4(t *testing.T) {
 		ClusterCIDR:     []string{"10.128.0.0/14"},
 		ServiceCIDR:     []string{"172.30.0.0/16"},
 		SingleStackIPv6: false,
+		BootstrapIP:     "10.128.0.12",
 	}
 
 	config := &testConfig{
 		t:                    t,
 		clusterNetworkConfig: networkConfigIpv4,
 		want:                 want,
+		bootstrapIP:          "10.128.0.12",
 	}
 
 	testRender(config)
@@ -159,6 +161,7 @@ func testRender(tc *testConfig) {
 		manifest:          *options.NewManifestOptions("etcd"),
 		errOut:            errOut,
 		clusterConfigFile: clusterConfigFile.Name(),
+		bootstrapIP:       tc.bootstrapIP,
 	}
 
 	if err := render.Run(); err != nil {
@@ -176,12 +179,14 @@ func TestTemplateDataIpv4(t *testing.T) {
 		ClusterCIDR:     []string{"10.128.0.0/14"},
 		ServiceCIDR:     []string{"172.30.0.0/16"},
 		SingleStackIPv6: false,
+		BootstrapIP:     "10.128.0.12",
 	}
 
 	config := &testConfig{
 		t:                    t,
 		clusterNetworkConfig: networkConfigIpv4,
 		want:                 want,
+		bootstrapIP:          "10.128.0.12",
 	}
 	testTemplateData(config)
 }
@@ -196,12 +201,14 @@ func TestTemplateDataMixed(t *testing.T) {
 		ClusterCIDR:     []string{"10.128.10.0/14"},
 		ServiceCIDR:     []string{"2001:db8::/32", "172.30.0.0/16"},
 		SingleStackIPv6: false,
+		BootstrapIP:     "10.128.0.12",
 	}
 
 	config := &testConfig{
 		t:                    t,
 		clusterNetworkConfig: networkConfigMixedSwap,
 		want:                 want,
+		bootstrapIP:          "10.128.0.12",
 	}
 	testTemplateData(config)
 }
@@ -216,14 +223,14 @@ func TestTemplateDataSingleStack(t *testing.T) {
 		ClusterCIDR:     []string{"10.128.0.0/14"},
 		ServiceCIDR:     []string{"2001:db8::/32"},
 		SingleStackIPv6: true,
-		BootstrapIP:     "2001:0DB8:C21A",
+		BootstrapIP:     "fe80::d66c:724c:13d4:829c",
 	}
 
 	config := &testConfig{
 		t:                    t,
 		clusterNetworkConfig: networkConfigIPv6SingleStack,
 		want:                 want,
-		bootstrapIP:          "2001:0DB8:C21A",
+		bootstrapIP:          "fe80::d66c:724c:13d4:829c",
 	}
 	testTemplateData(config)
 }

--- a/pkg/cmd/render/testdata/cluster-config-aws.yaml
+++ b/pkg/cmd/render/testdata/cluster-config-aws.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+data:
+  install-config: |
+    apiVersion: v1
+    baseDomain: devcluster.openshift.com
+    compute:
+    - architecture: amd64
+      hyperthreading: Enabled
+      name: worker
+      platform: {}
+      replicas: 3
+    controlPlane:
+      architecture: amd64
+      hyperthreading: Enabled
+      name: master
+      platform:
+        aws:
+          rootVolume:
+            iops: 0
+            size: 120
+            type: gp2
+          type: m4.xlarge
+          zones:
+          - us-east-1a
+          - us-east-1b
+          - us-east-1c
+          - us-east-1d
+          - us-east-1e
+          - us-east-1f
+      replicas: 3
+    metadata:
+      creationTimestamp: null
+      name: sbatsche-tester-2020-02-22
+    networking:
+      clusterNetwork:
+      - cidr: 10.128.0.0/14
+        hostPrefix: 23
+      machineCIDR: 10.0.0.0/16
+      machineNetwork:
+      - cidr: 10.0.0.0/16
+      networkType: OpenShiftSDN
+      serviceNetwork:
+      - 172.30.0.0/16
+    platform:
+      aws:
+        region: us-east-1
+    publish: External
+    pullSecret: ""
+    sshKey: |
+      ssh-rsa "" 
+kind: ConfigMap
+metadata:
+  name: cluster-config-v1
+  namespace: kube-system

--- a/pkg/cmd/render/testdata/network-config.yaml
+++ b/pkg/cmd/render/testdata/network-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  creationTimestamp: null
+  name: cluster
+spec:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  externalIP:
+    policy: {}
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+status: {}

--- a/pkg/cmd/render/testdata/singlestack/cluster-config-azure.yaml
+++ b/pkg/cmd/render/testdata/singlestack/cluster-config-azure.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+data:
+  install-config: |
+    apiVersion: v1
+    baseDomain: catchall.azure.devcluster.openshift.com
+    compute:
+    - architecture: amd64
+      hyperthreading: Enabled
+      name: worker
+      platform: {}
+      replicas: 3
+    controlPlane:
+      architecture: amd64
+      hyperthreading: Enabled
+      name: master
+      platform:
+        azure:
+          osDisk:
+            diskSizeGB: 1024
+          type: Standard_D8s_v3
+          zones:
+          - "2"
+          - "1"
+          - "3"
+      replicas: 3
+    metadata:
+      creationTimestamp: null
+      name: cluster-test
+    networking:
+      clusterNetwork:
+      - cidr: fd01::/48
+        hostPrefix: 64
+      machineNetwork:
+      - cidr: 10.0.0.0/16
+      - cidr: fc00::/48
+      networkType: OVNKubernetes
+      serviceNetwork:
+      - fd02::/112
+    platform:
+      azure:
+        baseDomainResourceGroupName: os4-common
+        region: eastus
+    publish: External
+    pullSecret: ""
+    sshKey: |
+      ssh-rsa ""
+kind: ConfigMap
+metadata:
+  name: cluster-config-v1
+  namespace: kube-system
+

--- a/pkg/cmd/render/testdata/singlestack/network-config.yaml
+++ b/pkg/cmd/render/testdata/singlestack/network-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  creationTimestamp: null
+  name: cluster
+spec:
+  clusterNetwork:
+  - cidr: fd01::/48
+    hostPrefix: 64
+  externalIP:
+    policy: {}
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - fd02::/112
+status: {}

--- a/pkg/dnshelpers/util.go
+++ b/pkg/dnshelpers/util.go
@@ -183,3 +183,14 @@ func reverseLookupForOneIP(discoveryDomain, ipAddress string) (string, error) {
 	}
 	return selfTarget, nil
 }
+
+func IsNetworkContainIp(network, ipAddress string) (bool, error) {
+	_, parsedNet, err := net.ParseCIDR(network)
+	if err != nil {
+		return false, err
+	}
+	if parsedNet.Contains(net.ParseIP(ipAddress)) {
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/dnshelpers/util.go
+++ b/pkg/dnshelpers/util.go
@@ -183,14 +183,3 @@ func reverseLookupForOneIP(discoveryDomain, ipAddress string) (string, error) {
 	}
 	return selfTarget, nil
 }
-
-func IsNetworkContainIp(network, ipAddress string) (bool, error) {
-	_, parsedNet, err := net.ParseCIDR(network)
-	if err != nil {
-		return false, err
-	}
-	if parsedNet.Contains(net.ParseIP(ipAddress)) {
-		return true, nil
-	}
-	return false, nil
-}

--- a/pkg/networkhelpers/util.go
+++ b/pkg/networkhelpers/util.go
@@ -1,0 +1,44 @@
+package networkhelpers
+
+import (
+	"net"
+)
+
+// IsNetworkContainIp checks if an IP adress is part of a network cidr
+func IsNetworkContainIp(network, ipAddress string) (bool, error) {
+	_, parsedNet, err := net.ParseCIDR(network)
+	if err != nil {
+		return false, err
+	}
+	if parsedNet.Contains(net.ParseIP(ipAddress)) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// IPAddrs returns a slice of string containing all IPv4 and IPv6 globsl addresses
+// on all interfaces.
+func IpAddrs() ([]string, error) {
+	var ips []string
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ips, err
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip == nil {
+			continue
+		}
+		if !ip.IsGlobalUnicast() {
+			continue // we only want global unicast address
+		}
+		ips = append(ips, ip.String())
+	}
+	return ips, nil
+}


### PR DESCRIPTION
This PR adds validation for the IPs we collect from local interfaces of bootstrap node. Instead of taking the first IPv4 address or IPv6 (single stack). We attempt to parse the MachineCIDR from installer assets. We then validate if the IP address is part of this network.

To do this we are adding a new flag  `--cluster-network-file` currently we pass the network-config 
 to the `--cluster-config` [1] This change will require installer update.

enhancements https://github.com/openshift/enhancements/pull/228

[1] https://github.com/openshift/installer/blob/98773b31eca6002e6f44375118d9eae8467cd016/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L135

