### PR TITLE
bug 1806723: use correct IP for bootstrap host env vars

### DIFF
--- a/pkg/dnshelpers/util.go
+++ b/pkg/dnshelpers/util.go
@@ -30,6 +30,18 @@ func GetEscapedPreferredInternalIPAddressForNodeName(network *configv1.Network, 
 	}
 }
 
+func GetURLHostForIP(ip string) (string, error) {
+	isIPV4, err := IsIPv4(ip)
+	if err != nil {
+		return "", err
+	}
+	if isIPV4 {
+		return ip, nil
+	}
+
+	return "[" + ip + "]", nil
+}
+
 // GetPreferredInternalIPAddressForNodeName returns the first internal ip address of the correct family and the family
 func GetPreferredInternalIPAddressForNodeName(network *configv1.Network, node *corev1.Node) (string, string, error) {
 	ipFamily, err := GetPreferredIPFamily(network)

--- a/pkg/operator/targetconfigcontroller/etcd_env.go
+++ b/pkg/operator/targetconfigcontroller/etcd_env.go
@@ -143,7 +143,7 @@ func getEscapedIPAddress(envVarContext envVarContext) (map[string]string, error)
 		if err != nil {
 			return nil, err
 		}
-		ret[fmt.Sprintf("NODE_%s_IP", envVarSafe(nodeInfo.NodeName))] = "[" + escapedIPAddress + "]"
+		ret[fmt.Sprintf("NODE_%s_IP", envVarSafe(nodeInfo.NodeName))] = escapedIPAddress
 	}
 
 	return ret, nil


### PR DESCRIPTION
before we were using the value that came from the installer, but @hexfusion's previous PR made that unreliable.