### PR TITLE
[Bug 1807054]: fix recovery of master nodes restarting at the same time

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -52,7 +52,7 @@ spec:
                            --cert=/etc/kubernetes/static-pod-resources/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt \
                            --key=/etc/kubernetes/static-pod-resources/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key \
                            --endpoints=${ALL_ETCD_ENDPOINTS}"
-        ${ETCDCTL} member list
+        ${ETCDCTL} member list || true
 
         # this has a non-zero return code if the command is non-zero.  If you use an export first, it doesn't and you
         # will succeed when you should fail.

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -199,7 +199,7 @@ spec:
                            --cert=/etc/kubernetes/static-pod-resources/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt \
                            --key=/etc/kubernetes/static-pod-resources/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key \
                            --endpoints=${ALL_ETCD_ENDPOINTS}"
-        ${ETCDCTL} member list
+        ${ETCDCTL} member list || true
 
         # this has a non-zero return code if the command is non-zero.  If you use an export first, it doesn't and you
         # will succeed when you should fail.


### PR DESCRIPTION
The ` ${ETCDCTL} member list` will fail when all the masters
are restarted at the same time. It will be good to have the 
member list, but if we don't, we should not fail and continue
to the discovery.
