### PR TITLE
[WIP]: add INITIAL_CLUSTER variable to pod env

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -87,14 +87,14 @@ ${COMPUTED_ENV_VARS}
           --data-dir=/var/lib/etcd/member \
           --target-peer-url-host=${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME} \
           --target-name=NODE_NAME)
-         export ETCD_INITIAL_CLUSTER
+          export ETCD_INITIAL_CLUSTER=$INITIAL_CLUSTER
 
         # at this point we know this member is added.  To support a transition, we must remove the old etcd pod.
         # move it somewhere safe so we can retrieve it again later if something goes badly.
         mv /etc/kubernetes/manifests/etcd-member.yaml /etc/kubernetes/etcd-backup-dir || true
 
         export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
-        env | grep ETCD | grep -v NODE
+      env | grep ETCD | grep -v NODE
 
         set -x
         exec etcd \

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -964,14 +964,14 @@ ${COMPUTED_ENV_VARS}
           --data-dir=/var/lib/etcd/member \
           --target-peer-url-host=${NODE_NODE_ENVVAR_NAME_ETCD_DNS_NAME} \
           --target-name=NODE_NAME)
-         export ETCD_INITIAL_CLUSTER
+          export ETCD_INITIAL_CLUSTER=$INITIAL_CLUSTER
 
         # at this point we know this member is added.  To support a transition, we must remove the old etcd pod.
         # move it somewhere safe so we can retrieve it again later if something goes badly.
         mv /etc/kubernetes/manifests/etcd-member.yaml /etc/kubernetes/etcd-backup-dir || true
 
         export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
-        env | grep ETCD | grep -v NODE
+      env | grep ETCD | grep -v NODE
 
         set -x
         exec etcd \

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -111,6 +111,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		os.Getenv("IMAGE"),
 		os.Getenv("OPERATOR_IMAGE"),
 		operatorClient,
+		etcdClient,
 		kubeInformersForNamespaces.InformersFor("openshift-etcd"),
 		kubeInformersForNamespaces,
 		configInformers.Config().V1().Infrastructures(),


### PR DESCRIPTION
This can be a first step in simplifying the logic in discovery-
initial-cluster, if not remove it.