### PR TITLE
waits for ports before starting etcd member

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -93,6 +93,14 @@ ${COMPUTED_ENV_VARS}
         # move it somewhere safe so we can retrieve it again later if something goes badly.
         mv /etc/kubernetes/manifests/etcd-member.yaml /etc/kubernetes/etcd-backup-dir || true
 
+        # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
+        # so we do the detection in etcd container itsefl.
+        echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
+        while [ -n "$(lsof -ni :2379)$(lsof -ni :2380)$(lsof -ni :9978)" ]; do
+          echo -n "."
+          sleep 1
+        done
+
         export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
         env | grep ETCD | grep -v NODE
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -970,6 +970,14 @@ ${COMPUTED_ENV_VARS}
         # move it somewhere safe so we can retrieve it again later if something goes badly.
         mv /etc/kubernetes/manifests/etcd-member.yaml /etc/kubernetes/etcd-backup-dir || true
 
+        # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
+        # so we do the detection in etcd container itsefl.
+        echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
+        while [ -n "$(lsof -ni :2379)$(lsof -ni :2380)$(lsof -ni :9978)" ]; do
+          echo -n "."
+          sleep 1
+        done
+
         export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
         env | grep ETCD | grep -v NODE
 


### PR DESCRIPTION

Because the port will be held by a *different* static pod during `4.3` to `4.4` upgrades, this cannot be done in an init container like the rest.  Instead, it must be embedded in the `etcd` container itself.

This PR waits for `2379`, `2380` and `9978` to be released before starting `etcd` instance