### PR TITLE
Bug 1810276: bindata/etcd: fix etcdctl trap

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -46,7 +46,7 @@ spec:
     command:
       - "/bin/bash"
       - "-c"
-      - "trap: TERM INT; sleep infinity & wait"
+      - "trap TERM INT; sleep infinity & wait"
     resources:
       requests:
         memory: 60Mi

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -10,7 +10,7 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
-    - name: etc-quorum-guard-copy
+    - name: etcd-quorum-guard-copy
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
       terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -923,7 +923,7 @@ spec:
     command:
       - "/bin/bash"
       - "-c"
-      - "trap: TERM INT; sleep infinity & wait"
+      - "trap TERM INT; sleep infinity & wait"
     resources:
       requests:
         memory: 60Mi

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -887,7 +887,7 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
-    - name: etc-quorum-guard-copy
+    - name: etcd-quorum-guard-copy
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
       terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
Fix typo `2020-03-03T20:22:53.542500839Z /bin/bash: trap:: command not found`


ref: https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/19871/artifacts/e2e-aws-upgrade/must-gather/registry-svc-ci-openshift-org-ocp-4-5-2020-03-03-190623-sha256-ee4eae4c297a6f0c80de95d12266c61f7348349a3e72d909a294644e8371e3aa/namespaces/openshift-etcd/pods/etcd-ip-10-0-159-26.us-east-2.compute.internal/etcdctl/etcdctl/logs/current.log