### PR TITLE
add events for membership changes

### DIFF
--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -250,11 +250,3 @@ func (c *ClusterMemberController) getEtcdPeerHostToScale(podToAdd *corev1.Pod) (
 
 	return dnshelpers.GetEscapedPreferredInternalIPAddressForNodeName(network, node)
 }
-
-func (c *ClusterMemberController) getNodeInternalIPs(nodeName string) ([]string, error) {
-	node, err := c.nodeLister.Get(nodeName)
-	if err != nil {
-		return nil, err
-	}
-	return dnshelpers.GetInternalIPAddressesForNodeName(node)
-}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -74,7 +74,10 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
-	etcdClient := etcdcli.NewEtcdClient(kubeInformersForNamespaces, configInformers.Config().V1().Networks())
+	etcdClient := etcdcli.NewEtcdClient(
+		kubeInformersForNamespaces,
+		configInformers.Config().V1().Networks(),
+		controllerContext.EventRecorder)
 
 	resourceSyncController, err := resourcesynccontroller.NewResourceSyncController(
 		operatorClient,


### PR DESCRIPTION
This will help figure out why on ipv6, we still see dns names

```
#### attempt 0
      member={name="etcd-bootstrap", peerURLs=[https://[fd2e:6f44:5dd8:c956::18]:2380}, clientURLs=[https://[fd2e:6f44:5dd8:c956::18]:2379]
      member={name="", peerURLs=[https://etcd-0.ostest.test.metalkube.org:2380}, clientURLs=[]
      target={name="", peerURLs=[https://etcd-0.ostest.test.metalkube.org:2380}, clientURLs=[], err=<nil>
Adding the unstarted member to the end master-0.ostest.test.metalkube.org


```