### PR TITLE
remove bootstrap annotation after bootstrapping

### DIFF
--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -76,11 +76,7 @@ func (g *etcdClientGetter) getEtcdClient() (*clientv3.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	bootstrapIP, ok := hostEtcd.Annotations[BootstrapIPAnnotationKey]
-	if !ok {
-		klog.V(2).Infof("service/host-etcd-2 is missing annotation %s", BootstrapIPAnnotationKey)
-	}
-	if bootstrapIP != "" {
+	if bootstrapIP := hostEtcd.Annotations[BootstrapIPAnnotationKey]; bootstrapIP != "" {
 		// escape if IPv6
 		if net.ParseIP(bootstrapIP).To4() == nil {
 			bootstrapIP = "[" + bootstrapIP + "]"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -177,6 +177,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	)
 	hostEtcdEndpointController2 := hostendpointscontroller2.NewHostEndpoints2Controller(
 		operatorClient,
+		etcdClient,
 		controllerContext.EventRecorder,
 		coreClient,
 		kubeInformersForNamespaces,


### PR DESCRIPTION
this cleans up the client usage in the operator and elsewhere after bootstrapping.