### PR TITLE
Bug 1810997: pkg/operator/etcdcertsigner: always include ::1 in cert SAN

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -305,6 +305,7 @@ func (c *EtcdCertSignerController) createSecretForNode(node *corev1.Node) error 
 		"etcd.openshift-etcd.svc.cluster.local",
 		"*." + etcdDiscoveryDomain,
 		"127.0.0.1",
+		"::1",
 		"0:0:0:0:0:0:0:1",
 	}, nodeInternalIPs...)
 	// TODO debt left for @hexfusion or @sanchezl


### PR DESCRIPTION
We should not worry about conditionally doing this always add.