### PR TITLE
require leader for membership list, make etcdmemberscontroller frequent

### DIFF
--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -207,7 +207,8 @@ func (g *etcdClientGetter) MemberList() ([]*etcdserverpb.Member, error) {
 	}
 	defer cli.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	// WithRequireLeader makes sure that the membership list is from the quorate cluster
+	ctx, cancel := context.WithCancel(clientv3.WithRequireLeader(context.Background()))
 	defer cancel()
 
 	membersResp, err := cli.MemberList(ctx)

--- a/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
+++ b/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
@@ -183,7 +183,7 @@ func (c *EtcdMembersController) Run(ctx context.Context, workers int) {
 	go wait.Until(c.runWorker, time.Second, ctx.Done())
 
 	// add time based trigger
-	go wait.PollImmediateUntil(time.Minute, func() (bool, error) {
+	go wait.PollImmediateUntil(time.Second, func() (bool, error) {
 		c.queue.Add(workQueueKey)
 		return false, nil
 	}, ctx.Done())


### PR DESCRIPTION
if the endpoint picked does not have a leader, it will fail and the
next call will be round robbined to a different etcd endpoint by client
load balancer