### PR TITLE
Bug 1812584: clustermembercontroller: skip if member found with hostname

### DIFF
--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -220,9 +220,21 @@ func (c *ClusterMemberController) getEtcdPodToAddToMembership() (*corev1.Pod, er
 			continue
 		}
 
+		// check to see if this member is updating from 4.3
+		etcdMember, err := c.etcdClient.GetMember("etcd-member-" + pod.Spec.NodeName)
+		switch {
+		case apierrors.IsNotFound(err):
+			// this is not an upgrade from 4.3
+		case err != nil:
+			return nil, err
+		default:
+			klog.V(4).Infof("skipping unready pod %q because it is already an etcd member: %#v with hostname: %s", pod.Name, etcdMember, pod.Spec.Hostname)
+			return nil, nil
+		}
+
 		// now check to see if this member is already part of the quorum.  This logically requires being able to map every
 		// type of member name we have ever created.  The most important for now is the nodeName.
-		etcdMember, err := c.etcdClient.GetMember(pod.Spec.NodeName)
+		etcdMember, err = c.etcdClient.GetMember(pod.Spec.NodeName)
 		switch {
 		case apierrors.IsNotFound(err):
 			return pod, nil


### PR DESCRIPTION
In 4.3 the etcd member name was in the form of etcd-member-<node-name>.
During upgrade cluster member controller should not add a member with
<node-name> if etcd-member-<node-name> is running.