### PR TITLE
Fix etcdctl env var paths

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -89,9 +89,9 @@ func getEtcdctlEnvVars(envVarContext envVarContext) (map[string]string, error) {
 	}
 	return map[string]string{
 		"ETCDCTL_API":       "3",
-		"ETCDCTL_CACERT":    "/etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-serving-ca/ca-bundle.crt",
-		"ETCDCTL_CERT":      "/etc/kubernetes/static-pod-resources/etcd-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt",
-		"ETCDCTL_KEY":       "/etc/kubernetes/static-pod-resources/etcd-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key",
+		"ETCDCTL_CACERT":    "/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt",
+		"ETCDCTL_CERT":      "/etc/kubernetes/static-pod-resources/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt",
+		"ETCDCTL_KEY":       "/etc/kubernetes/static-pod-resources/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key",
 		"ETCDCTL_ENDPOINTS": endpoints,
 		"ETCD_IMAGE":        envVarContext.targetImagePullSpec,
 	}, nil


### PR DESCRIPTION
These env vars are referencing paths that don't exist in the etcd
containers. When running etcdctl, the following error occurs:

Error: open /etc/kubernetes/static-pod-resources/etcd-certs/secrets/etcd-all-peer/etcd-peer-master-0.crt: no such file or directory

This is because the /etc/kubernetes/static-pod-resources mount in the
etcd containers is /etc/kubernetes/static-pod-resources/etcd-pod-X[0],
which contains the secrets directory with no interventing etcd-certs
directory. For example:

$ ls /etc/kubernetes/static-pod-resources/etcd-pod-3
configmaps  etcd-pod.yaml  secrets

This just removes the etcd-certs part of the path to make the env
vars point at the files as intended.

0: https://github.com/openshift/cluster-etcd-operator/blob/173b86cba63c98b2c5237cdab6e94994340957c9/bindata/etcd/pod.yaml#L202