### PR TITLE
Bug 1812583: Normalize CPU requests on masters

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -85,7 +85,7 @@ spec:
     resources:
       requests:
         memory: 600Mi
-        cpu: 300m
+        cpu: 245m
     terminationMessagePolicy: FallbackToLogsOnError
     securityContext:
       privileged: true
@@ -130,6 +130,9 @@ spec:
         --cert-file /etc/ssl/etcd/system:etcd-metric:{{ .Hostname }}.crt \
         --cacert /etc/ssl/etcd/ca.crt \
         --trusted-ca-file /etc/ssl/etcd/metric-ca.crt \
+    resources:
+      requests:
+        cpu: 5m
     terminationMessagePolicy: FallbackToLogsOnError
     securityContext:
       privileged: true


### PR DESCRIPTION
etcd uses approximately 25% of master CPU in a reasonable medium
sized workload. Given a 1 core per master baseline (since CPU is
compressible and shared), assign etcd roughly 25% of that core on
each master.

4.4 bug is 1812709