### PR TITLE
Bug 1805034: bootstrapteardown: decide bootstrap teardown based on number of masters

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -52,9 +52,12 @@ func getEtcdEnvVars(envVarContext envVarContext) (map[string]string, error) {
 	// TODO once we are past bootstrapping, this restriction shouldn't be needed anymore.
 	//   we have it because the env vars were not getting set in the pod and the static pod operator started
 	//   rolling out to another node, which caused a failure.
-	if len(envVarContext.status.NodeStatuses) < 3 {
-		return nil, fmt.Errorf("at least three nodes are required to have a valid configuration")
-	}
+	// TODO: figure out how risky is commenting the lines below
+	//  We are able to scale from 3->4->5, which means we would be abel to scale
+	//  from bootstrap node the same way.
+	//if len(envVarContext.status.NodeStatuses) < 3 {
+	//	return nil, fmt.Errorf("at least three nodes are required to have a valid configuration")
+	//}
 
 	ret := map[string]string{}
 

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -209,6 +209,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	bootstrapTeardownController := bootstrapteardown.NewBootstrapTeardownController(
 		operatorClient,
 		kubeClient,
+		kubeInformersForNamespaces,
 		etcdClient,
 		controllerContext.EventRecorder,
 	)


### PR DESCRIPTION
This removes the hard dependency of 3 nodes in cluster etcd operator.
This might be risky and give a failure for environments where nodes are
not created at the same time as indicated in the inline comments.

```
// TODO once we are past bootstrapping, this restriction shouldn't be needed anymore.
//   we have it because the env vars were not getting set in the pod and the static pod operator started
```