### PR TITLE
Copy files from etcd-scripts to /usr/local/bin for convenience

### DIFF
--- a/bindata/etcd/etcd-member-remove.sh
+++ b/bindata/etcd/etcd-member-remove.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+### Created by cluster-etcd-operator. DO NOT edit.
 set -o errexit
 set -o pipefail
 set -o errtrace

--- a/bindata/etcd/etcd-snapshot-backup.sh
+++ b/bindata/etcd/etcd-snapshot-backup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+### Created by cluster-etcd-operator. DO NOT edit.
+
 set -o errexit
 set -o pipefail
 set -o errtrace

--- a/bindata/etcd/etcd-snapshot-restore.sh
+++ b/bindata/etcd/etcd-snapshot-restore.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+### Created by cluster-etcd-operator. DO NOT edit.
+
 set -o errexit
 set -o pipefail
 set -o errtrace

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -10,7 +10,7 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
-    - name: etcd-quorum-guard-copy
+    - name: etcd-resources-copy
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
       terminationMessagePolicy: FallbackToLogsOnError
@@ -23,6 +23,9 @@ spec:
 
           cp /etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt /etc/kubernetes/etcd-backup-dir/system:etcd-peer-NODE_NAME.crt
           cp /etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key /etc/kubernetes/etcd-backup-dir/system:etcd-peer-NODE_NAME.key
+          rm -f $(grep -l '^### Created by cluster-etcd-operator' /usr/local/bin/*)
+          cp -p /etc/kubernetes/static-pod-certs/configmaps/etcd-scripts/*.sh /usr/local/bin
+
       resources:
         requests:
           memory: 60Mi
@@ -36,6 +39,8 @@ spec:
           name: resource-dir
         - mountPath: /etc/kubernetes/static-pod-certs
           name: cert-dir
+        - mountPath: /usr/local/bin
+          name: usr-local-bin
   containers:
   # The etcdctl container should always be first. It is intended to be used
   # to open a remote shell via `oc rsh` that is ready to run `etcdctl`.
@@ -208,4 +213,7 @@ ${COMPUTED_ENV_VARS}
         path: /var/lib/etcd
         type: ""
       name: data-dir
+    - hostPath:
+        path: /usr/local/bin
+      name: usr-local-bin
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -142,6 +142,7 @@ func etcdEtcdCommonTools() (*asset, error) {
 
 var _etcdEtcdMemberRemoveSh = []byte(`#!/usr/bin/env bash
 
+### Created by cluster-etcd-operator. DO NOT edit.
 set -o errexit
 set -o pipefail
 set -o errtrace
@@ -199,6 +200,8 @@ func etcdEtcdMemberRemoveSh() (*asset, error) {
 }
 
 var _etcdEtcdSnapshotBackupSh = []byte(`#!/usr/bin/env bash
+
+### Created by cluster-etcd-operator. DO NOT edit.
 
 set -o errexit
 set -o pipefail
@@ -284,6 +287,8 @@ func etcdEtcdSnapshotBackupSh() (*asset, error) {
 }
 
 var _etcdEtcdSnapshotRestoreSh = []byte(`#!/usr/bin/env bash
+
+### Created by cluster-etcd-operator. DO NOT edit.
 
 set -o errexit
 set -o pipefail
@@ -472,7 +477,7 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
-    - name: etcd-quorum-guard-copy
+    - name: etcd-resources-copy
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
       terminationMessagePolicy: FallbackToLogsOnError
@@ -485,6 +490,9 @@ spec:
 
           cp /etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt /etc/kubernetes/etcd-backup-dir/system:etcd-peer-NODE_NAME.crt
           cp /etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key /etc/kubernetes/etcd-backup-dir/system:etcd-peer-NODE_NAME.key
+          rm -f $(grep -l '^### Created by cluster-etcd-operator' /usr/local/bin/*)
+          cp -p /etc/kubernetes/static-pod-certs/configmaps/etcd-scripts/*.sh /usr/local/bin
+
       resources:
         requests:
           memory: 60Mi
@@ -498,6 +506,8 @@ spec:
           name: resource-dir
         - mountPath: /etc/kubernetes/static-pod-certs
           name: cert-dir
+        - mountPath: /usr/local/bin
+          name: usr-local-bin
   containers:
   # The etcdctl container should always be first. It is intended to be used
   # to open a remote shell via ` + "`" + `oc rsh` + "`" + ` that is ready to run ` + "`" + `etcdctl` + "`" + `.
@@ -670,6 +680,9 @@ ${COMPUTED_ENV_VARS}
         path: /var/lib/etcd
         type: ""
       name: data-dir
+    - hostPath:
+        path: /usr/local/bin
+      name: usr-local-bin
 
 `)
 


### PR DESCRIPTION
Copying the DR scripts from the unconventional etcd-scripts path to /usr/local/bin, so that the user can invoke it from anywhere.