### PR TITLE
Bug 1805034: *: allow a safe way to install with variable number of master nodes

### DIFF
--- a/pkg/operator/helpers/platform.go
+++ b/pkg/operator/helpers/platform.go
@@ -1,0 +1,46 @@
+package helpers
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog"
+)
+
+const defaultEtcdSize = 3
+
+// GetExpectedEtcdSize reads configmap kube-system/install-config-v1
+// and returns the controlPlane.replicas
+// For platforms that don't have the configmap, it will default to 3.
+func GetExpectedEtcdSize(kubeSystemConfigmapLister corev1listers.ConfigMapLister) (int, error) {
+	cm, err := kubeSystemConfigmapLister.ConfigMaps("kube-system").Get("cluster-config-v1")
+	switch {
+	case apierrors.IsNotFound(err):
+		klog.Info("configmap kube-system/cluster-config-v1 not found, defaulting control plane replicas to 3")
+		return defaultEtcdSize, nil
+	case err != nil:
+		return 0, err
+	default:
+		// handled below
+	}
+	yamlData, ok := cm.Data["install-config"]
+	if !ok {
+		return 0, fmt.Errorf("install-config key does not exist in configmap kube-system/cluster-config-v1: %#v", cm)
+	}
+	var installConfig map[string]interface{}
+	err = yaml.Unmarshal([]byte(yamlData), &installConfig)
+	if err != nil {
+		return 0, err
+	}
+	expectedSize, found, err := unstructured.NestedFloat64(installConfig, "controlPlane", "replicas")
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		return 0, fmt.Errorf("int64 not found in install-config in configmap kube-system/cluster-config-v1: %#v", cm)
+	}
+	return int(expectedSize), nil
+}

--- a/pkg/operator/helpers/platform_test.go
+++ b/pkg/operator/helpers/platform_test.go
@@ -1,0 +1,104 @@
+package helpers
+
+import (
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+type fakeConfigMapLister struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+func (f *fakeConfigMapLister) Get(name string) (*corev1.ConfigMap, error) {
+	return f.client.CoreV1().ConfigMaps("kube-system").Get(name, metav1.GetOptions{})
+}
+
+func (f *fakeConfigMapLister) List(selector labels.Selector) (ret []*corev1.ConfigMap, err error) {
+	cms, err := f.client.CoreV1().ConfigMaps(f.namespace).List(metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	ret = []*corev1.ConfigMap{}
+	for i := range cms.Items {
+		ret = append(ret, &cms.Items[i])
+	}
+	return ret, nil
+
+}
+
+var _configMapData = ` 
+apiVersion: v1
+baseDomain: devcluster.openshift.com
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform:
+	aws:
+	  rootVolume:
+		iops: 0
+		size: 120
+		type: gp2
+	  type: m4.xlarge
+	  zones:
+	  - us-west-1a
+	  - us-west-1b
+  replicas: 3
+`
+
+func (f *fakeConfigMapLister) ConfigMaps(namespace string) corev1listers.ConfigMapNamespaceLister {
+	if namespace == "kube-system" {
+		return f
+	}
+	return nil
+}
+
+func TestGetExpectedEtcdSize(t *testing.T) {
+	type args struct {
+		kubeSystemConfigmapLister corev1listers.ConfigMapLister
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "valid install-config",
+			args: args{kubeSystemConfigmapLister: &fakeConfigMapLister{
+				client: fake.NewSimpleClientset(
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "install-config-v1",
+							Namespace: "kube-system",
+						},
+						Data: map[string]string{
+							"install-config": _configMapData,
+						},
+						BinaryData: nil,
+					}),
+				namespace: "kube-system"},
+			},
+			want: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetExpectedEtcdSize(tt.args.kubeSystemConfigmapLister)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetExpectedEtcdSize() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetExpectedEtcdSize() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -67,6 +67,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorclient.GlobalMachineSpecifiedConfigNamespace,
 		operatorclient.TargetNamespace,
 		operatorclient.OperatorNamespace,
+		"kube-system",
 		"openshift-machine-config-operator", // TODO remove after quorum-guard is removed from MCO
 	)
 	configInformers := configv1informers.NewSharedInformerFactory(configClient, 10*time.Minute)
@@ -113,6 +114,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	envVarController := etcdenvvar.NewEnvVarController(
 		os.Getenv("IMAGE"),
 		operatorClient,
+		etcdClient,
 		kubeInformersForNamespaces,
 		configInformers.Config().V1().Infrastructures(),
 		configInformers.Config().V1().Networks(),
@@ -209,6 +211,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	bootstrapTeardownController := bootstrapteardown.NewBootstrapTeardownController(
 		operatorClient,
 		kubeClient,
+		kubeInformersForNamespaces,
 		etcdClient,
 		controllerContext.EventRecorder,
 	)


### PR DESCRIPTION
With this CEO will read the number of expected etcd nodes
from install config stored in configmap `kube-system/install-config-v1`.
For platforms that don't have the configmap, it will default to 3.

CEO will only use the values if the bootstrap node is around. The 
installer team has warned against using the configmap after 
bootstrapping.