### PR TITLE
Bug 1817028: *: add an init container to stop the pod with bad revision

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -10,6 +10,29 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
+    - name: etcd-ensure-env-vars
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      terminationMessagePolicy: FallbackToLogsOnError
+      command:
+        - /bin/sh
+        - -c
+        - |
+          #!/bin/sh
+          set -euo pipefail
+
+          : "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST?not set}"
+          : "${NODE_NODE_ENVVAR_NAME_ETCD_NAME?not set}"
+          : "${NODE_NODE_ENVVAR_NAME_IP?not set}"
+
+      resources:
+        requests:
+          memory: 60Mi
+          cpu: 30m
+      securityContext:
+        privileged: true
+      env:
+${COMPUTED_ENV_VARS}
     - name: etcd-resources-copy
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -25,6 +25,18 @@ spec:
           : "${NODE_NODE_ENVVAR_NAME_ETCD_NAME?not set}"
           : "${NODE_NODE_ENVVAR_NAME_IP?not set}"
 
+          if [ "${NODE_NODE_ENVVAR_NAME_IP}" != "${NODE_IP}" ]; then
+            # echo the error message to stderr
+            echo "Expected node IP to be ${NODE_IP} got ${NODE_NODE_ENVVAR_NAME_IP}" >&2
+            exit 1
+          fi
+
+          if [ "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" != "${NODE_IP}" ]; then
+            # echo the error message to stderr
+            echo "Expected etcd url host to be ${NODE_IP} got ${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" >&2
+            exit 1
+          fi
+
       resources:
         requests:
           memory: 60Mi
@@ -33,6 +45,10 @@ spec:
         privileged: true
       env:
 ${COMPUTED_ENV_VARS}
+      - name: NODE_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
     - name: etcd-resources-copy
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent

--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -208,15 +208,17 @@ func (c *ClusterMemberController) getEtcdPodToAddToMembership() (*corev1.Pod, er
 		if strings.HasPrefix(pod.Name, "etcd-member") {
 			continue
 		}
-		ready := false
+		isEtcdContainerRunning, isEtcdContainerReady := false, false
 		for _, containerStatus := range pod.Status.ContainerStatuses {
 			if containerStatus.Name != "etcd" {
 				continue
 			}
-			ready = containerStatus.Ready
+			// set running and ready flags
+			isEtcdContainerRunning = containerStatus.State.Running != nil
+			isEtcdContainerReady = containerStatus.Ready
 			break
 		}
-		if ready {
+		if !isEtcdContainerRunning || isEtcdContainerReady {
 			continue
 		}
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -428,6 +428,29 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
+    - name: etcd-ensure-env-vars
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      terminationMessagePolicy: FallbackToLogsOnError
+      command:
+        - /bin/sh
+        - -c
+        - |
+          #!/bin/sh
+          set -euo pipefail
+
+          : "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST?not set}"
+          : "${NODE_NODE_ENVVAR_NAME_ETCD_NAME?not set}"
+          : "${NODE_NODE_ENVVAR_NAME_IP?not set}"
+
+      resources:
+        requests:
+          memory: 60Mi
+          cpu: 30m
+      securityContext:
+        privileged: true
+      env:
+${COMPUTED_ENV_VARS}
     - name: etcd-resources-copy
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -443,6 +443,18 @@ spec:
           : "${NODE_NODE_ENVVAR_NAME_ETCD_NAME?not set}"
           : "${NODE_NODE_ENVVAR_NAME_IP?not set}"
 
+          if [ "${NODE_NODE_ENVVAR_NAME_IP}" != "${NODE_IP}" ]; then
+            # echo the error message to stderr
+            echo "Expected node IP to be ${NODE_IP} got ${NODE_NODE_ENVVAR_NAME_IP}" >&2
+            exit 1
+          fi
+
+          if [ "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" != "${NODE_IP}" ]; then
+            # echo the error message to stderr
+            echo "Expected etcd url host to be ${NODE_IP} got ${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" >&2
+            exit 1
+          fi
+
       resources:
         requests:
           memory: 60Mi
@@ -451,6 +463,10 @@ spec:
         privileged: true
       env:
 ${COMPUTED_ENV_VARS}
+      - name: NODE_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
     - name: etcd-resources-copy
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Add an init container that fails the pod if it has stale revision data.
This can especially occur during DR as explained in #278. 

This is a two-pronged solution:
1. Add the init container that fails on bad env data
2. Modify the clustermembercontroller to not add the member unless all 
init containers have exit 0.
