### PR TITLE
Bug 1821286: fix message reporting for etcdmemberscontroller

### DIFF
--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -153,11 +153,6 @@ func (c *ClusterMemberController) reconcileMembers() error {
 	}
 	if len(unhealthyMembers) > 0 {
 		klog.V(4).Infof("unhealthy members: %v", spew.Sdump(unhealthyMembers))
-		memberNames := []string{}
-		for _, member := range unhealthyMembers {
-			memberNames = append(memberNames, member.Name)
-		}
-		c.eventRecorder.Eventf("UnhealthyEtcdMember", "unhealthy members: %v", strings.Join(memberNames, ","))
 		return nil
 	}
 

--- a/pkg/operator/etcdmemberipmigrator/etcdmemberipmigrator.go
+++ b/pkg/operator/etcdmemberipmigrator/etcdmemberipmigrator.go
@@ -108,11 +108,6 @@ func (c *EtcdMemberIPMigrator) reconcileMembers() error {
 	}
 	if len(unhealthyMembers) > 0 {
 		klog.V(4).Infof("unhealthy members: %v", spew.Sdump(unhealthyMembers))
-		memberNames := []string{}
-		for _, member := range unhealthyMembers {
-			memberNames = append(memberNames, member.Name)
-		}
-		c.eventRecorder.Eventf("UnhealthyEtcdMember", "unhealthy members: %v", strings.Join(memberNames, ","))
 		return nil
 	}
 

--- a/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
+++ b/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -76,28 +77,27 @@ func (c *EtcdMembersController) reportEtcdMembers() error {
 		return err
 	}
 
-	availableMembers, notStartedMembers, unhealthyMembers, unknownMembers := []string{}, []string{}, []string{}, []string{}
+	availableMembers, unstartedMembers, unhealthyMembers := []string{}, []string{}, []string{}
 
 	for _, m := range etcdMembers {
 		switch c.etcdClient.MemberStatus(m) {
 		case etcdcli.EtcdMemberStatusAvailable:
 			availableMembers = append(availableMembers, m.Name)
 		case etcdcli.EtcdMemberStatusNotStarted:
-			notStartedMembers = append(notStartedMembers, m.Name)
+			unstartedMembers = append(unstartedMembers, m.Name)
 		case etcdcli.EtcdMemberStatusUnhealthy:
 			unhealthyMembers = append(unhealthyMembers, m.Name)
-		case etcdcli.EtcdMemberStatusUnknown:
-			unknownMembers = append(unknownMembers, m.Name)
 		}
 	}
 
 	updateErrors := []error{}
-	if len(unhealthyMembers) > 0 || len(unknownMembers) > 0 {
+	statusMessage := getMemberMessage(availableMembers, unhealthyMembers, unstartedMembers, etcdMembers)
+	if len(unhealthyMembers) > 0 {
 		_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    "EtcdMembersDegraded",
 			Status:  operatorv1.ConditionTrue,
 			Reason:  "UnhealthyMembers",
-			Message: fmt.Sprintf("%s members are unhealthy, %s members are unknown", strings.Join(unhealthyMembers, ","), strings.Join(unknownMembers, ",")),
+			Message: statusMessage,
 		}))
 		if updateErr != nil {
 			c.eventRecorder.Warning("EtcdMembersErrorUpdatingStatus", updateErr.Error())
@@ -116,12 +116,12 @@ func (c *EtcdMembersController) reportEtcdMembers() error {
 		}
 	}
 
-	if len(notStartedMembers) != 0 {
+	if len(unstartedMembers) > 0 {
 		_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    "EtcdMembersProgressing",
 			Status:  operatorv1.ConditionTrue,
 			Reason:  "MembersNotStarted",
-			Message: fmt.Sprintf("%s members have not started yet", strings.Join(notStartedMembers, ",")),
+			Message: statusMessage,
 		}))
 		if updateErr != nil {
 			c.eventRecorder.Warning("EtcdMembersErrorUpdatingStatus", updateErr.Error())
@@ -132,7 +132,7 @@ func (c *EtcdMembersController) reportEtcdMembers() error {
 			Type:    "EtcdMembersProgressing",
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "AsExpected",
-			Message: "all members have started",
+			Message: "No unstarted etcd members found",
 		}))
 		if updateErr != nil {
 			c.eventRecorder.Warning("EtcdMembersErrorUpdatingStatus", updateErr.Error())
@@ -145,7 +145,7 @@ func (c *EtcdMembersController) reportEtcdMembers() error {
 			Type:    "EtcdMembersAvailable",
 			Status:  operatorv1.ConditionTrue,
 			Reason:  "EtcdQuorate",
-			Message: fmt.Sprintf("%s members are available, %s have not started, %s are unhealthy, %s are unknown", strings.Join(availableMembers, ","), strings.Join(notStartedMembers, ","), strings.Join(unhealthyMembers, ","), strings.Join(unknownMembers, ",")),
+			Message: statusMessage,
 		}))
 		if updateErr != nil {
 			c.eventRecorder.Warning("EtcdMembersErrorUpdatingStatus", updateErr.Error())
@@ -159,7 +159,7 @@ func (c *EtcdMembersController) reportEtcdMembers() error {
 			Type:    "EtcdMembersAvailable",
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "No quorum",
-			Message: fmt.Sprintf("%s members are available, %s have not started, %s are unhealthy", strings.Join(availableMembers, ","), strings.Join(notStartedMembers, ","), strings.Join(unhealthyMembers, ",")),
+			Message: statusMessage,
 		}))
 		if updateErr != nil {
 			c.eventRecorder.Warning("EtcdMembersErrorUpdatingStatus", updateErr.Error())
@@ -172,6 +172,27 @@ func (c *EtcdMembersController) reportEtcdMembers() error {
 	}
 
 	return nil
+}
+
+func getMemberMessage(availableMembers, unhealthyMembers, unstartedMembers []string, allMembers []*etcdserverpb.Member) string {
+	messages := []string{}
+	if len(availableMembers) > 0 && len(availableMembers) == len(allMembers) {
+		messages = append(messages, fmt.Sprintf("%d members are available", len(availableMembers)))
+	}
+	if len(availableMembers) > 0 && len(availableMembers) != len(allMembers) {
+		messages = append(messages, fmt.Sprintf("%d of %d members are available", len(availableMembers), len(allMembers)))
+	}
+	if len(unhealthyMembers) > 0 {
+		for _, name := range unhealthyMembers {
+			messages = append(messages, fmt.Sprintf("%s is unhealthy", name))
+		}
+	}
+	if len(unstartedMembers) > 0 {
+		for _, name := range unstartedMembers {
+			messages = append(messages, fmt.Sprintf("%s has not started", name))
+		}
+	}
+	return strings.Join(messages, ", ")
 }
 
 func (c *EtcdMembersController) Run(ctx context.Context, workers int) {

--- a/pkg/operator/etcdmemberscontroller/etcdmemberscontroller_test.go
+++ b/pkg/operator/etcdmemberscontroller/etcdmemberscontroller_test.go
@@ -1,0 +1,114 @@
+package etcdmemberscontroller
+
+import (
+	"fmt"
+	"testing"
+
+	"go.etcd.io/etcd/etcdserver/etcdserverpb"
+)
+
+func Test_getMemberMessage(t *testing.T) {
+	type args struct {
+		availableMembers []string
+		unhealthyMembers []string
+		unstartedMembers []string
+		allMembers       []*etcdserverpb.Member
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test all available members",
+			args: args{
+				availableMembers: []string{"etcd-1", "etcd-2", "etcd-3"},
+				unhealthyMembers: []string{},
+				unstartedMembers: []string{},
+				allMembers: []*etcdserverpb.Member{
+					{Name: "etcd-1"},
+					{Name: "etcd-2"},
+					{Name: "etcd-3"},
+				},
+			},
+			want: fmt.Sprintf("3 members are available"),
+		},
+		{
+			name: "test an unhealthy members",
+			args: args{
+				availableMembers: []string{"etcd-1", "etcd-2"},
+				unhealthyMembers: []string{"etcd-3"},
+				unstartedMembers: []string{},
+				allMembers: []*etcdserverpb.Member{
+					{Name: "etcd-1"},
+					{Name: "etcd-2"},
+					{Name: "etcd-3"},
+				},
+			},
+			want: fmt.Sprintf("2 of 3 members are available, etcd-3 is unhealthy"),
+		},
+		{
+			name: "test an unstarted members",
+			args: args{
+				availableMembers: []string{"etcd-1", "etcd-2"},
+				unhealthyMembers: []string{},
+				unstartedMembers: []string{"etcd-3"},
+				allMembers: []*etcdserverpb.Member{
+					{Name: "etcd-1"},
+					{Name: "etcd-2"},
+					{Name: "etcd-3"},
+				},
+			},
+			want: fmt.Sprintf("2 of 3 members are available, etcd-3 has not started"),
+		},
+		{
+			name: "test an unstarted member and an unhealthy member",
+			args: args{
+				availableMembers: []string{"etcd-1"},
+				unhealthyMembers: []string{"etcd-2"},
+				unstartedMembers: []string{"etcd-3"},
+				allMembers: []*etcdserverpb.Member{
+					{Name: "etcd-1"},
+					{Name: "etcd-2"},
+					{Name: "etcd-3"},
+				},
+			},
+			want: fmt.Sprintf("1 of 3 members are available, etcd-2 is unhealthy, etcd-3 has not started"),
+		},
+		{
+			name: "test two unhealthy members",
+			args: args{
+				availableMembers: []string{"etcd-1"},
+				unhealthyMembers: []string{"etcd-2", "etcd-3"},
+				unstartedMembers: []string{},
+				allMembers: []*etcdserverpb.Member{
+					{Name: "etcd-1"},
+					{Name: "etcd-2"},
+					{Name: "etcd-3"},
+				},
+			},
+			want: fmt.Sprintf("1 of 3 members are available, etcd-2 is unhealthy, etcd-3 is unhealthy"),
+		},
+		{
+			name: "test two unstarted members",
+			args: args{
+				availableMembers: []string{"etcd-1"},
+				unhealthyMembers: []string{},
+				unstartedMembers: []string{"etcd-2", "etcd-3"},
+				allMembers: []*etcdserverpb.Member{
+					{Name: "etcd-1"},
+					{Name: "etcd-2"},
+					{Name: "etcd-3"},
+				},
+			},
+			want: fmt.Sprintf("1 of 3 members are available, etcd-2 has not started, etcd-3 has not started"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getMemberMessage(tt.args.availableMembers, tt.args.unhealthyMembers, tt.args.unstartedMembers, tt.args.allMembers); got != tt.want {
+				t.Errorf("getMemberMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR:

1. creates a standard error message format for reporting
 etcd members
2. adds specific events for unstarted members and 
unhealthy members

Since reporting available members would be at a level, 
the choice is made not report events of available members.