### PR TITLE
Bug 1822326: Add extra checks for ipv6 addresses when checking the etcd env

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -25,13 +25,15 @@ spec:
           : "${NODE_NODE_ENVVAR_NAME_ETCD_NAME?not set}"
           : "${NODE_NODE_ENVVAR_NAME_IP?not set}"
 
-          if [ "${NODE_NODE_ENVVAR_NAME_IP}" != "${NODE_IP}" ]; then
+          # check for ipv4 addresses as well as ipv6 addresses with extra square brackets
+          if [[ "${NODE_NODE_ENVVAR_NAME_IP}" != "${NODE_IP}" && "${NODE_NODE_ENVVAR_NAME_IP}" != "[${NODE_IP}]" ]]; then
             # echo the error message to stderr
             echo "Expected node IP to be ${NODE_IP} got ${NODE_NODE_ENVVAR_NAME_IP}" >&2
             exit 1
           fi
 
-          if [ "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" != "${NODE_IP}" ]; then
+          # check for ipv4 addresses as well as ipv6 addresses with extra square brackets
+          if [[ "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" != "${NODE_IP}" && "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" != "[${NODE_IP}]" ]]; then
             # echo the error message to stderr
             echo "Expected etcd url host to be ${NODE_IP} got ${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" >&2
             exit 1

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -443,13 +443,15 @@ spec:
           : "${NODE_NODE_ENVVAR_NAME_ETCD_NAME?not set}"
           : "${NODE_NODE_ENVVAR_NAME_IP?not set}"
 
-          if [ "${NODE_NODE_ENVVAR_NAME_IP}" != "${NODE_IP}" ]; then
+          # check for ipv4 addresses as well as ipv6 addresses with extra square brackets
+          if [[ "${NODE_NODE_ENVVAR_NAME_IP}" != "${NODE_IP}" && "${NODE_NODE_ENVVAR_NAME_IP}" != "[${NODE_IP}]" ]]; then
             # echo the error message to stderr
             echo "Expected node IP to be ${NODE_IP} got ${NODE_NODE_ENVVAR_NAME_IP}" >&2
             exit 1
           fi
 
-          if [ "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" != "${NODE_IP}" ]; then
+          # check for ipv4 addresses as well as ipv6 addresses with extra square brackets
+          if [[ "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" != "${NODE_IP}" && "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" != "[${NODE_IP}]" ]]; then
             # echo the error message to stderr
             echo "Expected etcd url host to be ${NODE_IP} got ${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" >&2
             exit 1


### PR DESCRIPTION
The fix for Bug 1817028 (https://bugzilla.redhat.com/show_bug.cgi?id=1817028) introduced a new init container to validate the etcd environment before firing up the etcd. However, the checks for ensuring the etcd environment rely on ipstring comparison which fail in the ipv6 environments. 

