### PR TITLE
bindata: add terminationGracePeriodSeconds to etcd static pods

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -147,6 +147,7 @@ spec:
   tolerations:
   - operator: "Exists"
   restartPolicy: Always
+  terminationGracePeriodSeconds: 60
   volumes:
   - name: certs
     hostPath:

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -142,7 +142,7 @@ ${COMPUTED_ENV_VARS}
         # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
         # so we do the detection in etcd container itsefl.
         echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
-        while [ -n "$(lsof -ni :2379)$(lsof -ni :2380)$(lsof -ni :9978)" ]; do
+        while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 or sport = 9978 )')" ]; do
           echo -n "."
           sleep 1
         done
@@ -237,6 +237,7 @@ ${COMPUTED_ENV_VARS}
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"
+  terminationGracePeriodSeconds: 60
   volumes:
     - hostPath:
         path: /etc/kubernetes/manifests

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -569,7 +569,7 @@ ${COMPUTED_ENV_VARS}
         # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
         # so we do the detection in etcd container itsefl.
         echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
-        while [ -n "$(lsof -ni :2379)$(lsof -ni :2380)$(lsof -ni :9978)" ]; do
+        while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 or sport = 9978 )')" ]; do
           echo -n "."
           sleep 1
         done
@@ -664,6 +664,7 @@ ${COMPUTED_ENV_VARS}
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"
+  terminationGracePeriodSeconds: 60
   volumes:
     - hostPath:
         path: /etc/kubernetes/manifests


### PR DESCRIPTION
For many reasons, we need etcd static pods to gracefully terminate. In some cases, etcd should have enough time to return a large request. Also graceful termination will all etcd to transfer leadership instead of causing a leader election on shutdown.