### PR TITLE
Bug 1822924: The snapshot backup must be requested from a single endpoint not multiple

### DIFF
--- a/bindata/etcd/cluster-backup.sh
+++ b/bindata/etcd/cluster-backup.sh
@@ -66,5 +66,5 @@ fi
 
 dl_etcdctl
 backup_latest_kube_static_resources "${BACKUP_RESOURCE_LIST[@]}"
-etcdctl snapshot save ${SNAPSHOT_FILE}
+ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot save ${SNAPSHOT_FILE}
 echo "snapshot db and kube resources are successfully saved to ${BACKUP_DIR}"

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -125,7 +125,7 @@ fi
 
 dl_etcdctl
 backup_latest_kube_static_resources "${BACKUP_RESOURCE_LIST[@]}"
-etcdctl snapshot save ${SNAPSHOT_FILE}
+ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot save ${SNAPSHOT_FILE}
 echo "snapshot db and kube resources are successfully saved to ${BACKUP_DIR}"
 `)
 


### PR DESCRIPTION
The snapshot backup command must be requested for a single endpoint, and not multiple endpoints. The etcd versions of 3.3.x were forgiving but bumping to etcd to 3.4.7 fails with an error when ETCDCTL_ENDPOINTS contain multiple members. 