### PR TITLE
etcdcli: refactor etcdcli package to fix known issues

### DIFF
--- a/pkg/etcdcli/interfaces.go
+++ b/pkg/etcdcli/interfaces.go
@@ -41,3 +41,9 @@ type UnhealthyMemberLister interface {
 type MemberStatusChecker interface {
 	MemberStatus(member *etcdserverpb.Member) string
 }
+
+// EtcdEndpointsGetter hides the implementation for getting etcd endpoints
+// so that custom fake endpoints can be used in tests
+type EtcdEndpointsGetter interface {
+	Get() ([]string, error)
+}


### PR DESCRIPTION
This PR:
- adds an EtcdEndpointGetter interface so that endpoints can be for
 overridden in tests
- fix the getEtcdCachedClient to check for a closed connection
- fix the bug with UnhealthyMember
- refactor the receiver to etcdClient as per Golang pattern

I plan to add test cases that can prove the stability of etcdcli code changes
as a follow-up PR.