### PR TITLE
add relatedobjects for immediate creation by CVO

### DIFF
--- a/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
+++ b/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
@@ -9,3 +9,19 @@ status:
   versions:
   - name: operator
     version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: operator.openshift.io
+      name: cluster
+      resource: etcds
+    - group: ""
+      name: openshift-config
+      resource: namespaces
+    - group: ""
+      name: openshift-config-managed
+      resource: namespaces
+    - group: ""
+      name: openshift-etcd-operator
+      resource: namespaces
+    - group: ""
+      name: openshift-etcd
+      resource: namespaces


### PR DESCRIPTION
since openshift/cluster-version-operator#318 merged we can have our relatedObjects created immediately so must-gather always works.