### PR TITLE
Bug 1823931: bindata/etcd/etcd-common-tools pass --authfile to podman create

### DIFF
--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -12,7 +12,7 @@ PATH=${PATH}:${ETCDCTL_BIN_DIR}
 # download etcdctl from upstream release assets
 function dl_etcdctl {
   local etcdimg=${ETCD_IMAGE}
-  local etcdctr=$(podman create ${etcdimg})
+  local etcdctr=$(podman create ${etcdimg} --authfile=/var/log/kubelet/config.json)
   local etcdmnt=$(podman mount "${etcdctr}")
   [ ! -d ${ETCDCTL_BIN_DIR} ] && mkdir -p ${ETCDCTL_BIN_DIR}
   cp ${etcdmnt}/bin/etcdctl ${ETCDCTL_BIN_DIR}/

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -329,7 +329,7 @@ PATH=${PATH}:${ETCDCTL_BIN_DIR}
 # download etcdctl from upstream release assets
 function dl_etcdctl {
   local etcdimg=${ETCD_IMAGE}
-  local etcdctr=$(podman create ${etcdimg})
+  local etcdctr=$(podman create ${etcdimg} --authfile=/var/log/kubelet/config.json)
   local etcdmnt=$(podman mount "${etcdctr}")
   [ ! -d ${ETCDCTL_BIN_DIR} ] && mkdir -p ${ETCDCTL_BIN_DIR}
   cp ${etcdmnt}/bin/etcdctl ${ETCDCTL_BIN_DIR}/


### PR DESCRIPTION
This PR adds --authfile flag to podman create in the off chance that the container has not been pulled. As cluster-backup is run against a running etcd this seems unlikely failure but for the sake of defensive coding, I am adding. 