### PR TITLE
Bug 1825667: pkg/cmd/render: add support for s390 and s390x arch

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -100,14 +100,7 @@ spec:
       mountPath: /etc/etcd/
 
     env:
-    - name: ETCD_DATA_DIR
-      value: "/var/lib/etcd"
-    - name: ETCD_NAME
-      value: "etcd-bootstrap"
-    - name: ETCD_HEARTBEAT_INTERVAL
-      value: {{ .EtcdHeartbeat }}
-    - name: ETCD_ELECTION_TIMEOUT
-      value: {{ .EtcdElectionTimeout }}
+{{.ComputedEnvVars }}
     ports:
     - name: peer
       containerPort: 2380

--- a/pkg/cmd/render/env.go
+++ b/pkg/cmd/render/env.go
@@ -1,0 +1,92 @@
+package render
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/etcdenvvar"
+)
+
+var envVarFns = []envVarFunc{
+	getFixedEtcdEnvVars,
+	getHeartbeatInterval,
+	getElectionTimeout,
+	getUnsupportedArch,
+	getEtcdName,
+}
+
+type envVarFunc func(platform, arch string) (map[string]string, error)
+
+func getEtcdEnv(platform, arch string) (map[string]string, error) {
+	ret := map[string]string{}
+	for _, envVarFn := range envVarFns {
+		newEnvVars, err := envVarFn(platform, arch)
+		if err != nil {
+			return nil, err
+		}
+		if newEnvVars == nil {
+			continue
+		}
+		for k, v := range newEnvVars {
+			if currV, ok := ret[k]; ok {
+				return nil, fmt.Errorf("key %q already set to %q", k, currV)
+			}
+			ret[k] = v
+		}
+	}
+	return ret, nil
+}
+
+func getFixedEtcdEnvVars(platform, arch string) (map[string]string, error) {
+	env := etcdenvvar.FixedEtcdEnvVars
+	// single member cluster needs to start with "new" (default).
+	delete(env, "ETCD_INITIAL_CLUSTER_STATE")
+	return env, nil
+}
+
+func getEtcdName(platform, arch string) (map[string]string, error) {
+	return map[string]string{
+		"ETCD_NAME": "etcd-bootstrap",
+	}, nil
+}
+
+func getHeartbeatInterval(platform, arch string) (map[string]string, error) {
+	var heartbeat string
+
+	switch platform {
+	case "Azure":
+		heartbeat = "500"
+	default:
+		heartbeat = "100"
+	}
+
+	return map[string]string{
+		"ETCD_HEARTBEAT_INTERVAL": heartbeat,
+	}, nil
+}
+
+func getElectionTimeout(platform, arch string) (map[string]string, error) {
+	var timeout string
+
+	switch platform {
+	case "Azure":
+		timeout = "2500"
+	default:
+		timeout = "1000"
+	}
+
+	return map[string]string{
+		"ETCD_ELECTION_TIMEOUT": timeout,
+	}, nil
+
+}
+
+func getUnsupportedArch(platform, arch string) (map[string]string, error) {
+	if !strings.HasPrefix(arch, "s390") {
+		// dont set unless it is defined.
+		return nil, nil
+	}
+	return map[string]string{
+		"ETCD_UNSUPPORTED_ARCH": arch,
+	}, nil
+}

--- a/pkg/cmd/render/env_test.go
+++ b/pkg/cmd/render/env_test.go
@@ -1,0 +1,21 @@
+package render
+
+import "testing"
+
+func TestEtcdEnv(t *testing.T) {
+	for _, test := range []struct {
+		platform, arch, wantKey, wantValue string
+	}{
+		{"AWS", "amd64", "ETCD_HEARTBEAT_INTERVAL", "100"},
+		{"AWS", "amd64", "ETCD_ELECTION_TIMEOUT", "1000"},
+		{"Azure", "ppc64le", "ETCD_HEARTBEAT_INTERVAL", "500"},
+		{"Azure", "amd64", "ETCD_ELECTION_TIMEOUT", "2500"},
+		{"None", "ppc64le", "ETCD_HEARTBEAT_INTERVAL", "100"},
+		{"Azure", "s390x", "ETCD_UNSUPPORTED_ARCH", "s390x"},
+	} {
+		env, _ := getEtcdEnv(test.platform, test.arch)
+		if env[test.wantKey] != test.wantValue {
+			t.Errorf("getEtcdEnv(%q, %q) =  want %q = %q got %q = %q", test.platform, test.arch, test.wantKey, test.wantValue, test.wantKey, env[test.wantKey])
+		}
+	}
+}

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -2,6 +2,7 @@ package etcdenvvar
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/dnshelpers"
@@ -24,6 +25,12 @@ type envVarContext struct {
 	targetImagePullSpec  string
 }
 
+var FixedEtcdEnvVars = map[string]string{
+	"ETCD_DATA_DIR":              "/var/lib/etcd",
+	"ETCD_QUOTA_BACKEND_BYTES":   "7516192768", // 7 gig
+	"ETCD_INITIAL_CLUSTER_STATE": "existing",
+}
+
 type envVarFunc func(envVarContext envVarContext) (map[string]string, error)
 
 var envVarFns = []envVarFunc{
@@ -35,6 +42,7 @@ var envVarFns = []envVarFunc{
 	getEtcdctlEnvVars,
 	getHeartbeatInterval,
 	getElectionTimeout,
+	getUnsupportedArch,
 }
 
 // getEtcdEnvVars returns the env vars that need to be set on the etcd static pods that will be rendered.
@@ -45,6 +53,7 @@ var envVarFns = []envVarFunc{
 //   ETCD_HEARTBEAT_INTERVAL
 //   ETCD_ELECTION_TIMEOUT
 //   ETCD_INITIAL_CLUSTER_STATE
+//   ETCD_UNSUPPORTED_ARCH
 //   NODE_%s_IP
 //   NODE_%s_ETCD_URL_HOST
 //   NODE_%s_ETCD_NAME
@@ -70,6 +79,9 @@ func getEtcdEnvVars(envVarContext envVarContext) (map[string]string, error) {
 		if err != nil {
 			return nil, err
 		}
+		if newEnvVars == nil {
+			continue
+		}
 		for k, v := range newEnvVars {
 			if currV, ok := ret[k]; ok {
 				return nil, fmt.Errorf("key %q already set to %q", k, currV)
@@ -82,11 +94,7 @@ func getEtcdEnvVars(envVarContext envVarContext) (map[string]string, error) {
 }
 
 func getFixedEtcdEnvVars(envVarContext envVarContext) (map[string]string, error) {
-	return map[string]string{
-		"ETCD_DATA_DIR":              "/var/lib/etcd",
-		"ETCD_QUOTA_BACKEND_BYTES":   "7516192768", // 7 gig
-		"ETCD_INITIAL_CLUSTER_STATE": "existing",
-	}, nil
+	return FixedEtcdEnvVars, nil
 }
 
 func getEtcdctlEnvVars(envVarContext envVarContext) (map[string]string, error) {
@@ -248,4 +256,15 @@ func getElectionTimeout(envVarContext envVarContext) (map[string]string, error) 
 
 func envVarSafe(nodeName string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(nodeName, "-", "_"), ".", "_")
+}
+
+func getUnsupportedArch(envVarContext envVarContext) (map[string]string, error) {
+	arch := runtime.GOARCH
+	if !strings.HasPrefix(arch, "s390") {
+		// dont set unless it is defined.
+		return nil, nil
+	}
+	return map[string]string{
+		"ETCD_UNSUPPORTED_ARCH": arch,
+	}, nil
 }


### PR DESCRIPTION
This PR replaces tolerance for upstream etcd unsupported architectures `s390` and `s390x`. Because `ETCD_UNSUPPORTED_ARCH` should only be set in ENV if it is defined we took the liberty of making the `env:`  section of the bootstrap static pod spec more inline with what we do with the etcdenvvar controller.

This will make future changes to runtime env's much easier to add and manage.