### PR TITLE
Bug 1821286: Unstarted members cannot be blank in the log/event messages

### DIFF
--- a/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
+++ b/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
@@ -84,7 +84,7 @@ func (c *EtcdMembersController) reportEtcdMembers() error {
 		case etcdcli.EtcdMemberStatusAvailable:
 			availableMembers = append(availableMembers, m.Name)
 		case etcdcli.EtcdMemberStatusNotStarted:
-			unstartedMembers = append(unstartedMembers, m.Name)
+			unstartedMembers = append(unstartedMembers, etcdcli.GetMemberNameOrHost(m))
 		case etcdcli.EtcdMemberStatusUnhealthy:
 			unhealthyMembers = append(unhealthyMembers, m.Name)
 		}


### PR DESCRIPTION
etcd doesn't store the name for the unstarted members. It is initialized only when the etcd is started. So, when reporting unstarted members, currently the message appears with blank name, which can be confusing. This PR attempts to fill the name with hostname (or IP address) extracted from peer URL for the unstarted members.