### PR TITLE
[wip] pkg/etcdcli: pass WithRequireLeader to Status ctx

### DIFF
--- a/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
+++ b/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
 	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 )


### PR DESCRIPTION
Status is not a linearized transaction so it does not accurately reflect the health of a peer member. This  PR adds `WithRequireLeader` to the ctx call so in the case where the peer can not report a leader its health is false.

Although health is important I reduced ResyncEvery duration to 3 seconds from 1 to see how we respond for the etcdMembersController.