### PR TITLE
Bug 1823931: Fix the path for authfile used for copying the etcdctl image

### DIFF
--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -12,7 +12,7 @@ PATH=${PATH}:${ETCDCTL_BIN_DIR}
 # download etcdctl from upstream release assets
 function dl_etcdctl {
   local etcdimg=${ETCD_IMAGE}
-  local etcdctr=$(podman create ${etcdimg} --authfile=/var/log/kubelet/config.json)
+  local etcdctr=$(podman create ${etcdimg} --authfile=/var/lib/kubelet/config.json)
   local etcdmnt=$(podman mount "${etcdctr}")
   [ ! -d ${ETCDCTL_BIN_DIR} ] && mkdir -p ${ETCDCTL_BIN_DIR}
   cp ${etcdmnt}/bin/etcdctl ${ETCDCTL_BIN_DIR}/

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -329,7 +329,7 @@ PATH=${PATH}:${ETCDCTL_BIN_DIR}
 # download etcdctl from upstream release assets
 function dl_etcdctl {
   local etcdimg=${ETCD_IMAGE}
-  local etcdctr=$(podman create ${etcdimg} --authfile=/var/log/kubelet/config.json)
+  local etcdctr=$(podman create ${etcdimg} --authfile=/var/lib/kubelet/config.json)
   local etcdmnt=$(podman mount "${etcdctr}")
   [ ! -d ${ETCDCTL_BIN_DIR} ] && mkdir -p ${ETCDCTL_BIN_DIR}
   cp ${etcdmnt}/bin/etcdctl ${ETCDCTL_BIN_DIR}/


### PR DESCRIPTION
The fix applied in PR https://github.com/openshift/cluster-etcd-operator/pull/314 had a typo in the authfile. This PR attempts to correct it.