### PR TITLE
Bug 1830505: pkg/operator/etcdcertsigner: fix DNS SAN for peer certificates

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -234,7 +234,10 @@ func (c *EtcdCertSignerController) createSecretForNode(node *corev1.Node, record
 	if err != nil {
 		return err
 	}
-	peerHostNames := append([]string{"localhost", etcdDiscoveryDomain}, nodeInternalIPs...)
+	peerHostNames := append([]string{
+		"localhost",
+		"*." + etcdDiscoveryDomain,
+	}, nodeInternalIPs...)
 	serverHostNames := append([]string{
 		"localhost",
 		"etcd.kube-system.svc",


### PR DESCRIPTION
etcd peer certs in 4.3 contained wildcard. this PR fixes a typo which only included DNS name `etcdDiscoveryDomain` vs  `"*." + etcdDiscoveryDomain`

Because peerURLs contained domains in 4.3 we can see TLS errors like below during upgrade.

```
2020-05-01T18:36:37.0791842Z 2020-05-01 18:36:37.079092 E | rafthttp: failed to dial d8027fcd63ed8f3f on stream MsgApp v2 (x509: certificate is valid for localhost, mffaz1.qe.azure.devcluster.openshift.com, 10.0.0.6, not etcd-0.mffaz1.qe.azure.devcluster.openshift.com)
```

4.4 Bug https://bugzilla.redhat.com/show_bug.cgi?id=1830510