### PR TITLE
Bug 1832901: Stop reconciling in response to global configmap events

### DIFF
--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -53,7 +53,7 @@ func NewClusterMemberController(
 	}
 	return factory.New().ResyncEvery(time.Minute).WithInformers(
 		kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().Pods().Informer(),
-		kubeInformers.InformersFor("").Core().V1().ConfigMaps().Informer(),
+		kubeInformers.InformersFor("").Core().V1().Nodes().Informer(),
 		networkInformer.Informer(),
 		operatorClient.Informer(),
 	).WithSync(c.sync).ToController("ClusterMemberController", eventRecorder.WithComponentSuffix("cluster-member-controller"))


### PR DESCRIPTION
Before this change, the ClusterMemberController performed a full sync in response
to any watch event associated with a configmap in any namespace in the cluster.
This causes (at a minimum) unnecessary etcd client traffic.

This patch changes the controller to stop reacting to configmaps entirely and instead
react to changes to nodes, which was probably the original intent.