### PR TITLE
Fix premature context cancellation

### DIFF
--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -345,7 +345,7 @@ func (g *etcdClientGetter) MemberStatus(member *etcdserverpb.Member) string {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	_, err = cli.Status(ctx, member.ClientURLs[0])
-	cancel()
+	defer cancel()
 	if err != nil {
 		klog.Errorf("error getting etcd member %s status: %#v", member.Name, err)
 		return EtcdMemberStatusUnhealthy


### PR DESCRIPTION
Before this patch, a call to clientv3.Client.Status was followed immediately
by an inline call to the returned cancel() function. Although in this case
the call is benign, it's still probably better to defer for consistency.