### PR TITLE
Bug 1832923: Forget the bootstrap etcd member IP after bootstrap is complete

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -217,6 +217,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		kubeInformersForNamespaces,
 		etcdClient,
 		controllerContext.EventRecorder,
+		kubeClient,
 	)
 
 	scriptController := scriptcontroller.NewScriptControllerController(


### PR DESCRIPTION
Before this patch, after bootstrap completes, the `host-etcd-2` endpoint still
contains an annotation pointing to the bootstrap etcd member IP, causing
operator etcd clients to permanently make futile connection attempts to the
defunct member endpoint.

This patch updates the bootstrap teardown controller to clean up the endpoint by
removing the annotation, which should eliminate the continuous failing
connection attempts to the old bootstrap member.