### PR TITLE
Bug 1830510: pkg/operator/etcdcertsigner: sign peer DNS SAN with explicit FQDN

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -1,0 +1,119 @@
+package etcdcertsigner
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"go.etcd.io/etcd/etcdserver/etcdserverpb"
+)
+
+func TestPeerDNSSubjectAlternativeNames(t *testing.T) {
+	tests := []struct {
+		etcdMembers         []*etcdserverpb.Member
+		etcdDiscoveryDomain string
+		nodeInternalIPs     []string
+		want                []string
+	}{
+		{
+			// 4.3 upgrade
+			[]*etcdserverpb.Member{
+				{
+					Name:       "etcd-member-0",
+					PeerURLs:   []string{"https://etcd-0.clustername.com:2380"},
+					ClientURLs: []string{"https://192.168.8.10:2379"},
+				},
+				{
+					Name:       "etcd-member-1",
+					PeerURLs:   []string{"https://etcd-1.clustername.com:2380"},
+					ClientURLs: []string{"https://192.168.8.11:2379"},
+				},
+				{
+					Name:       "etcd-member-2",
+					PeerURLs:   []string{"https://etcd-0.clustername.com:2380"},
+					ClientURLs: []string{""},
+				},
+			},
+			"clustername.com",
+			[]string{"172.168.16.4", "192.168.8.10"},
+			[]string{"etcd-0.clustername.com"},
+		},
+		{
+			// 4.3 upgrade in progress
+			[]*etcdserverpb.Member{
+				{
+					Name:       "etcd-member-0",
+					PeerURLs:   []string{"https://etcd-0.clustername.com:2380"},
+					ClientURLs: []string{"https://192.168.8.12:2379"},
+				},
+				{
+					Name:       "etcd-1",
+					PeerURLs:   []string{"https://192.168.8.13:2380"},
+					ClientURLs: []string{"https://192.168.8.13:2379"},
+				},
+				{
+					Name:       "etcd-member-2",
+					PeerURLs:   []string{"https://etcd-2.clustername.com:2380"},
+					ClientURLs: []string{"https://192.168.8.13:2379"},
+				},
+			},
+			"clustername.com",
+			[]string{"192.168.8.12"},
+			[]string{"etcd-0.clustername.com"},
+		},
+		{
+			// 4.4+ install
+			[]*etcdserverpb.Member{
+				{
+					Name:       "etcd-0",
+					PeerURLs:   []string{"https://192.168.8.10:2380"},
+					ClientURLs: []string{"https://192.168.8.10:2379"},
+				},
+				{
+					Name:       "etcd-1",
+					PeerURLs:   []string{"https://192.168.8.11:2380"},
+					ClientURLs: []string{"https://192.168.8.11:2379"},
+				},
+				{
+					Name:       "etcd-2",
+					PeerURLs:   []string{"https://192.168.8.12:2380"},
+					ClientURLs: []string{"https://192.168.8.12:2379"},
+				},
+			},
+			"clustername.com",
+			[]string{"192.168.8.12"},
+			nil,
+		},
+		{
+			// 4.3 upgrade ipv6
+			[]*etcdserverpb.Member{
+				{
+					Name:       "etcd-0",
+					PeerURLs:   []string{"https://[001:0db8:85a3:0000:0000:8a2e:0370:7333]:2380"},
+					ClientURLs: []string{"https://[001:0db8:85a3:0000:0000:8a2e:0370:7333]:2379"},
+				},
+				{
+					Name:       "etcd-1",
+					PeerURLs:   []string{"https://[001:0db8:85a3:0000:0000:8a2e:0370:7334]:2380"},
+					ClientURLs: []string{"https://[001:0db8:85a3:0000:0000:8a2e:0370:7334]:2379"},
+				},
+				{
+					Name:       "etcd-member-2",
+					PeerURLs:   []string{"https://etcd-2.clustername.com:2380"},
+					ClientURLs: []string{"https://[001:0db8:85a3:0000:0000:8a2e:0370:7335]:2379"},
+				},
+			},
+			"clustername.com",
+			[]string{"001:0db8:85a3:0000:0000:8a2e:0370:7335"},
+			[]string{"etcd-2.clustername.com"},
+		},
+	}
+	for _, test := range tests {
+		got, _ := getPeerDNSSubjectAlternativeNamesFromMemberList(test.etcdDiscoveryDomain, test.etcdMembers, test.nodeInternalIPs)
+		sort.Strings(test.want)
+		sort.Strings(got)
+		if reflect.DeepEqual(test.want, got) != true {
+			t.Errorf("createDNSSubjectAlternativeNamesFromMemberList() = %v, want %v", got, test.want)
+		}
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -177,6 +177,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	etcdCertSignerController := etcdcertsigner.NewEtcdCertSignerController(
 		coreClient,
 		operatorClient,
+		etcdClient,
 		kubeInformersForNamespaces,
 		configInformers.Config().V1().Infrastructures(),
 		controllerContext.EventRecorder,


### PR DESCRIPTION
Prior to 4.4 etcd was bootstrap using SRV discovery. The result was each peer used FQDN in peer <--> peer communications. In 4.4 we regressed on upgrade support due to a typo which only signed DNS SAN for `etcdDiscoveryDomain`  vs `"*."+etcdDiscoveryDomain`. Although we migrate peers to use IP addresses there is a short window where in-between upgrade to 4.4 peer TLS auth can fail.

```golang
peerHostNames := append([]string{"localhost", etcdDiscoveryDomain}, nodeInternalIPs...)
```

This PR attempts to be more mindful of a proper SAN by using data provided in the MemberList to populate the peer FQDN explicitly instead of a wildcard. In the case of failure fallback to wildcard.

## Note
This bug only affects 4.4 as we do not want or require this functionality after we upgrade for 4.3 because we drop the DNS dependency completely. 