### PR TITLE
Bug 1830505: Revert: "pkg/operator/etcdcertsigner: fix DNS SAN for peer certificates"

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -234,10 +234,7 @@ func (c *EtcdCertSignerController) createSecretForNode(node *corev1.Node, record
 	if err != nil {
 		return err
 	}
-	peerHostNames := append([]string{
-		"localhost",
-		"*." + etcdDiscoveryDomain,
-	}, nodeInternalIPs...)
+	peerHostNames := append([]string{"localhost", etcdDiscoveryDomain}, nodeInternalIPs...)
 	serverHostNames := append([]string{
 		"localhost",
 		"etcd.kube-system.svc",


### PR DESCRIPTION
Reverts openshift/cluster-etcd-operator#328

