### PR TITLE
Bug 1837103: Revert "remove dead host-etcd-2 service"

### DIFF
--- a/bindata/bootkube/manifests/00_etcd-host-service.yaml
+++ b/bindata/bootkube/manifests/00_etcd-host-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: host-etcd-2
+  namespace: openshift-etcd
+  labels:
+    # this label is used to indicate that it should be scraped by prometheus
+    k8s-app: etcd
+spec:
+  clusterIP: None
+  ports:
+  - name: etcd
+    port: 2379
+    protocol: TCP

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -7,9 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -18,7 +16,6 @@ import (
 	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
-	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/staticpod"
@@ -258,9 +255,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	go envVarController.Run(1, ctx.Done())
 	go staticPodControllers.Start(ctx)
 
-	// TODO remove in 4.6
-	ensureServiceCleanup(ctx, kubeClient, controllerContext.EventRecorder)
-
 	<-ctx.Done()
 	return nil
 }
@@ -299,23 +293,4 @@ var CertSecrets = []revision.RevisionResource{
 	{Name: "etcd-all-peer"},
 	{Name: "etcd-all-serving"},
 	{Name: "etcd-all-serving-metrics"},
-}
-
-// ensureServiceCleanup continually ensures the removal of `oc get -n openshift-etcd service/host-etcd-2`
-// can be removed in 4.6
-func ensureServiceCleanup(ctx context.Context, kubeClient *kubernetes.Clientset, eventRecorder events.Recorder) {
-	go wait.UntilWithContext(ctx, func(ctx context.Context) {
-		// Check whether the legacy daemonset exists and is not marked for deletion
-		err := kubeClient.CoreV1().Services("openshift-etcd").Delete(ctx, "host-etcd-2", metav1.DeleteOptions{})
-		switch {
-		case errors.IsNotFound(err):
-			// Done - service does not exist
-			return
-		case err != nil:
-			klog.Warningf("Error deleting service: %v", err)
-			return
-		case err == nil:
-			eventRecorder.Event("LegacyServiceCleanup", "legacy service has been removed: `oc get -n openshift-etcd service/host-etcd-2`")
-		}
-	}, 10*time.Minute)
 }


### PR DESCRIPTION
This reverts commit 7f142f69b1fe95ffb033526256d9498a6c8dadc5 (https://github.com/openshift/cluster-etcd-operator/pull/346).

https://github.com/kubernetes/kubernetes/issues/6877
https://github.com/kubernetes/kubernetes/pull/7821
https://github.com/kubernetes/kubernetes/pull/7821#issuecomment-99344889

Deleting the service subjects the host-etcd-2 endpoint to deletion by
the Kube endpoints controller at random times now or in the future.

The service must remain to protect the existence of the endpoint given
the current design of Kube.

By deleting the service, we risk bootstrap failure through information
loss when the endpoint is deleted during bootstrapping, and churning
unnecessary endpoint revisions by recreating an endpoint Kube wants
to delete.

cc @hexfusion @retroflexer @deads2k @smarterclayton please fact check (see discussion in https://github.com/openshift/cluster-etcd-operator/pull/350/files#r425419897)