### PR TITLE
Bug 1835146: Cluster restore should not stop network pods on bare-metal

### DIFF
--- a/bindata/etcd/cluster-restore.sh
+++ b/bindata/etcd/cluster-restore.sh
@@ -75,11 +75,11 @@ if [ ! -d "$MANIFEST_STOPPED_DIR" ]; then
 fi
 
 # Move static pod manifests out of MANIFEST_DIR
-find ${MANIFEST_DIR} \
-  -maxdepth 1 \
-  -type f \
-  -printf '...stopping %P\n' \
-  -exec mv {} ${MANIFEST_STOPPED_DIR} \;
+for POD_FILE_NAME in "${STATIC_POD_LIST[@]}" etcd-pod.yaml; do
+  echo "...stopping ${POD_FILE_NAME}"
+  [ ! -f "${MANIFEST_DIR}/${POD_FILE_NAME}" ] && continue
+  mv "${MANIFEST_DIR}/${POD_FILE_NAME}" "${MANIFEST_STOPPED_DIR}"
+done
 
 # wait for every static pod container to stop
 wait_for_containers_to_stop "${STATIC_POD_CONTAINERS[@]}"

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -230,11 +230,11 @@ if [ ! -d "$MANIFEST_STOPPED_DIR" ]; then
 fi
 
 # Move static pod manifests out of MANIFEST_DIR
-find ${MANIFEST_DIR} \
-  -maxdepth 1 \
-  -type f \
-  -printf '...stopping %P\n' \
-  -exec mv {} ${MANIFEST_STOPPED_DIR} \;
+for POD_FILE_NAME in "${STATIC_POD_LIST[@]}" etcd-pod.yaml; do
+  echo "...stopping ${POD_FILE_NAME}"
+  [ ! -f "${MANIFEST_DIR}/${POD_FILE_NAME}" ] && continue
+  mv "${MANIFEST_DIR}/${POD_FILE_NAME}" "${MANIFEST_STOPPED_DIR}"
+done
 
 # wait for every static pod container to stop
 wait_for_containers_to_stop "${STATIC_POD_CONTAINERS[@]}"


### PR DESCRIPTION
Currently the cluster backup script backs up static pod resources for "kube-apiserver-pod.yaml" "kube-controller-manager-pod.yaml" "kube-scheduler-pod.yaml" and "etcd-pod.yaml". However, when cluster-restore script is run, it stops all the static pods (including network pods for the bare-metal case). 

However, after the restore operation we only restore the kube static pods and etcd, but do not restore network pods (as they are not backed up originally). This results in failed cluster restore unable to scale up fully.

This PR fixes the problem by only stopping the kube static pods, leaving the network pods to continue to run.