### PR TITLE
update the operator to create a complete etcd service

### DIFF
--- a/bindata/etcd/svc.yaml
+++ b/bindata/etcd/svc.yaml
@@ -7,10 +7,16 @@ metadata:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
     prometheus.io/scrape: "true"
     prometheus.io/scheme: https
+  labels:
+    # this label is used to indicate that it should be scraped by prometheus
+    k8s-app: etcd
 spec:
   selector:
     etcd: "true"
   ports:
-  - name: https
-    port: 443
-    targetPort: 10257
+    - name: etcd
+      port: 2379
+      protocol: TCP
+    - name: etcd-metrics
+      port: 9979
+      protocol: TCP

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -932,13 +932,19 @@ metadata:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
     prometheus.io/scrape: "true"
     prometheus.io/scheme: https
+  labels:
+    # this label is used to indicate that it should be scraped by prometheus
+    k8s-app: etcd
 spec:
   selector:
     etcd: "true"
   ports:
-  - name: https
-    port: 443
-    targetPort: 10257
+    - name: etcd
+      port: 2379
+      protocol: TCP
+    - name: etcd-metrics
+      port: 9979
+      protocol: TCP
 `)
 
 func etcdSvcYamlBytes() ([]byte, error) {


### PR DESCRIPTION
remove the need for the installer to have resources like https://github.com/openshift/installer/blob/508e44b66935058f4ff7162f1d1278279ef3d383/data/data/manifests/bootkube/etcd-service.yaml and the namespace.

once this merges, we can remove the installer bits creating the same thing differently.