### PR TITLE
Bug 1836927: Replace etcd endpoint representation with configmap

### DIFF
--- a/bindata/bootkube/manifests/00_etcd-endpoints-cm.yaml
+++ b/bindata/bootkube/manifests/00_etcd-endpoints-cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-endpoints
+  namespace: openshift-etcd
+  annotations:
+    alpha.installer.openshift.io/etcd-bootstrap: {{ .BootstrapIP }}

--- a/pkg/etcdenvvar/envvarcontroller.go
+++ b/pkg/etcdenvvar/envvarcontroller.go
@@ -32,7 +32,7 @@ type EnvVarController struct {
 
 	infrastructureLister configv1listers.InfrastructureLister
 	networkLister        configv1listers.NetworkLister
-	endpointLister       corev1listers.EndpointsLister
+	configmapLister      corev1listers.ConfigMapLister
 	nodeLister           corev1listers.NodeLister
 
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
@@ -57,7 +57,7 @@ func NewEnvVarController(
 		operatorClient:       operatorClient,
 		infrastructureLister: infrastructureInformer.Lister(),
 		networkLister:        networkInformer.Lister(),
-		endpointLister:       kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Lister(),
+		configmapLister:      kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Lister(),
 		nodeLister:           kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes().Lister(),
 		targetImagePullSpec:  targetImagePullSpec,
 
@@ -132,7 +132,7 @@ func (c *EnvVarController) checkEnvVars() error {
 		targetImagePullSpec:  c.targetImagePullSpec,
 		spec:                 *operatorSpec,
 		status:               *operatorStatus,
-		endpointLister:       c.endpointLister,
+		configmapLister:      c.configmapLister,
 		nodeLister:           c.nodeLister,
 		infrastructureLister: c.infrastructureLister,
 		networkLister:        c.networkLister,

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -21,7 +21,7 @@ type envVarContext struct {
 	nodeLister           corev1listers.NodeLister
 	infrastructureLister configv1listers.InfrastructureLister
 	networkLister        configv1listers.NetworkLister
-	endpointLister       corev1listers.EndpointsLister
+	configmapLister      corev1listers.ConfigMapLister
 	targetImagePullSpec  string
 }
 
@@ -132,11 +132,11 @@ func getEtcdGrpcEndpoints(envVarContext envVarContext) (string, error) {
 		endpoints = append(endpoints, fmt.Sprintf("https://%s:2379", endpointIP))
 	}
 
-	hostEtcdEndpoints, err := envVarContext.endpointLister.Endpoints(operatorclient.TargetNamespace).Get("host-etcd-2")
+	etcdEndpoints, err := envVarContext.configmapLister.ConfigMaps(operatorclient.TargetNamespace).Get("etcd-endpoints")
 	if err != nil {
 		return "", err
 	}
-	if bootstrapIP := hostEtcdEndpoints.Annotations["alpha.installer.openshift.io/etcd-bootstrap"]; len(bootstrapIP) > 0 {
+	if bootstrapIP := etcdEndpoints.Annotations["alpha.installer.openshift.io/etcd-bootstrap"]; len(bootstrapIP) > 0 {
 		urlHost, err := dnshelpers.GetURLHostForIP(bootstrapIP)
 		if err != nil {
 			return "", err

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go
@@ -1,0 +1,126 @@
+package etcdendpointscontroller
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+)
+
+// EtcdEndpointsController maintains a configmap resource with
+// IP addresses for etcd. It should never depend on DNS directly or transitively.
+type EtcdEndpointsController struct {
+	operatorClient  v1helpers.OperatorClient
+	nodeLister      corev1listers.NodeLister
+	configmapLister corev1listers.ConfigMapLister
+	configmapClient corev1client.ConfigMapsGetter
+}
+
+func NewEtcdEndpointsController(
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+	kubeClient kubernetes.Interface,
+	kubeInformers operatorv1helpers.KubeInformersForNamespaces,
+) factory.Controller {
+	kubeInformersForTargetNamespace := kubeInformers.InformersFor(operatorclient.TargetNamespace)
+	configmapsInformer := kubeInformersForTargetNamespace.Core().V1().ConfigMaps()
+	kubeInformersForCluster := kubeInformers.InformersFor("")
+	nodeInformer := kubeInformersForCluster.Core().V1().Nodes()
+
+	c := &EtcdEndpointsController{
+		operatorClient:  operatorClient,
+		nodeLister:      nodeInformer.Lister(),
+		configmapLister: configmapsInformer.Lister(),
+		configmapClient: kubeClient.CoreV1(),
+	}
+	return factory.New().ResyncEvery(time.Minute).WithInformers(
+		operatorClient.Informer(),
+		configmapsInformer.Informer(),
+		nodeInformer.Informer(),
+	).WithSync(c.sync).ToController("EtcdEndpointsController", eventRecorder.WithComponentSuffix("etcd-endpoints-controller"))
+}
+
+func (c *EtcdEndpointsController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	err := c.syncConfigMap(ctx, syncCtx.Recorder())
+
+	if err != nil {
+		_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+			Type:    "EtcdEndpointsDegraded",
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "ErrorUpdatingEtcdEndpoints",
+			Message: err.Error(),
+		}))
+		if updateErr != nil {
+			syncCtx.Recorder().Warning("EtcdEndpointsErrorUpdatingStatus", updateErr.Error())
+		}
+		return err
+	}
+
+	_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+		Type:   "EtcdEndpointsDegraded",
+		Status: operatorv1.ConditionFalse,
+		Reason: "EtcdEndpointsUpdated",
+	}))
+	if updateErr != nil {
+		syncCtx.Recorder().Warning("EtcdEndpointsErrorUpdatingStatus", updateErr.Error())
+		return updateErr
+	}
+	return nil
+}
+
+func (c *EtcdEndpointsController) syncConfigMap(ctx context.Context, recorder events.Recorder) error {
+	required := configMapAsset()
+
+	// create endpoint addresses for each node
+	nodes, err := c.nodeLister.List(labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector())
+	if err != nil {
+		return fmt.Errorf("unable to list expected etcd member nodes: %v", err)
+	}
+	endpointAddresses := map[string]string{}
+	for _, node := range nodes {
+		var nodeInternalIP string
+		for _, nodeAddress := range node.Status.Addresses {
+			if nodeAddress.Type == corev1.NodeInternalIP {
+				nodeInternalIP = nodeAddress.Address
+				break
+			}
+		}
+		if len(nodeInternalIP) == 0 {
+			return fmt.Errorf("unable to determine internal ip address for node %s", node.Name)
+		}
+		endpointAddresses[base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(nodeInternalIP))] = nodeInternalIP
+	}
+
+	if len(endpointAddresses) == 0 {
+		return fmt.Errorf("no master nodes are present")
+	}
+
+	required.Data = endpointAddresses
+
+	_, _, err = resourceapply.ApplyConfigMap(c.configmapClient, recorder, required)
+	return err
+}
+
+func configMapAsset() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd-endpoints",
+			Namespace: operatorclient.TargetNamespace,
+		},
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/configobservation/configobservercontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcd_assets"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcdcertsigner"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcdendpointscontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcdmemberipmigrator"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcdmemberscontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/hostendpointscontroller2"
@@ -191,6 +192,12 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		coreClient,
 		kubeInformersForNamespaces,
 	)
+	etcdEndpointsController := etcdendpointscontroller.NewEtcdEndpointsController(
+		operatorClient,
+		controllerContext.EventRecorder,
+		coreClient,
+		kubeInformersForNamespaces,
+	)
 
 	clusterMemberController := clustermembercontroller.NewClusterMemberController(
 		operatorClient,
@@ -242,6 +249,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	go targetConfigReconciler.Run(ctx, 1)
 	go etcdCertSignerController.Run(ctx, 1)
 	go hostEtcdEndpointController2.Run(ctx, 1)
+	go etcdEndpointsController.Run(ctx, 1)
 	go resourceSyncController.Run(ctx, 1)
 	go statusController.Run(ctx, 1)
 	go configObserver.Run(ctx, 1)


### PR DESCRIPTION
Kube service design asserts `endpoint` resources cannot exist without a corresponding `service` resource, and Kube will actively delete the endpoint when the service is deleted or if Kube detects the endpoint is a "stray".

The operator needs to:

1.  Manage etcd endpoint state atomically.
2. Maintain exclusive ownership of the etcd endpoint state resource.

Altogether this makes the `endpoint` resource inappropriate for the task. The competition between the operator and the Kube endpoints controller to manage the endpoint has led to instability.

To resolve the problems, persist etcd endpoint state in a `configmap`.

Maintain compatibility by continuing to write the `endpoint`, and update consuming components to prefer the `configmap` over the `endpoint`.

Also requires:
https://github.com/openshift/cluster-kube-apiserver-operator/pull/859
https://github.com/openshift/cluster-openshift-apiserver-operator/pull/364