### PR TITLE
Bug 1837594: pkg/operator/etcdcertsigner: sign etcd certs for 3 years

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	EtcdCertValidity = 10 * 365 * 24 * time.Hour
+	EtcdCertValidity = 3 * 365 * 24 * time.Hour
 	peerOrg          = "system:etcd-peers"
 	serverOrg        = "system:etcd-servers"
 	metricOrg        = "system:etcd-metrics"


### PR DESCRIPTION
etcd certs are documented to be signed for 3 years, due to a typo they have been signed for 10. This PR ensures all future certs have the accurate signing period.

ref: https://github.com/openshift/openshift-docs/issues/22253