### PR TITLE
Bug 1832923: Forget bootstrap etcd member IP after bootstrap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,4 +24,5 @@ require (
 	k8s.io/client-go v0.18.3
 	k8s.io/component-base v0.18.3
 	k8s.io/klog v1.0.0
+	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 )

--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -74,7 +74,7 @@ func (g *etcdClientGetter) getEtcdClient() (*clientv3.Client, error) {
 
 	network, err := g.networkLister.Get("cluster")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list cluster network: %w", err)
 	}
 
 	etcdEndpoints := []string{}
@@ -82,20 +82,16 @@ func (g *etcdClientGetter) getEtcdClient() (*clientv3.Client, error) {
 	for _, node := range nodes {
 		internalIP, err := dnshelpers.GetEscapedPreferredInternalIPAddressForNodeName(network, node)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get internal IP for node: %w", err)
 		}
 		etcdEndpoints = append(etcdEndpoints, fmt.Sprintf("https://%s:2379", internalIP))
 	}
 
-	hostEtcd, err := g.configmapsLister.ConfigMaps(operatorclient.TargetNamespace).Get("etcd-endpoints")
+	configmap, err := g.configmapsLister.ConfigMaps(operatorclient.TargetNamespace).Get("etcd-endpoints")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list endpoints: %w", err)
 	}
-	bootstrapIP, ok := hostEtcd.Annotations[BootstrapIPAnnotationKey]
-	if !ok {
-		klog.V(2).Infof("configmaps/etcd-endpoints is missing annotation %s", BootstrapIPAnnotationKey)
-	}
-	if bootstrapIP != "" {
+	if bootstrapIP, ok := configmap.Annotations[BootstrapIPAnnotationKey]; ok && bootstrapIP != "" {
 		// escape if IPv6
 		if net.ParseIP(bootstrapIP).To4() == nil {
 			bootstrapIP = "[" + bootstrapIP + "]"
@@ -112,11 +108,11 @@ func (g *etcdClientGetter) getEtcdClient() (*clientv3.Client, error) {
 
 	c, err := getEtcdClient(etcdEndpoints)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get etcd client: %w", err)
 	}
 	if g.cachedClient != nil {
 		if err := g.cachedClient.Close(); err != nil {
-			utilruntime.HandleError(err)
+			utilruntime.HandleError(fmt.Errorf("failed to close cached client: %w", err))
 		}
 	}
 	g.cachedClient = c
@@ -146,7 +142,7 @@ func getEtcdClient(endpoints []string) (*clientv3.Client, error) {
 
 	cli, err := clientv3.New(*cfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to make etcd client for endpoints %v: %w", endpoints, err)
 	}
 	return cli, err
 }

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go
@@ -13,50 +13,50 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog"
 
+	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 )
 
 // EtcdEndpointsController maintains a configmap resource with
 // IP addresses for etcd. It should never depend on DNS directly or transitively.
 type EtcdEndpointsController struct {
-	operatorClient  v1helpers.OperatorClient
+	operatorClient  v1helpers.StaticPodOperatorClient
 	nodeLister      corev1listers.NodeLister
 	configmapLister corev1listers.ConfigMapLister
 	configmapClient corev1client.ConfigMapsGetter
 }
 
 func NewEtcdEndpointsController(
-	operatorClient v1helpers.OperatorClient,
+	operatorClient v1helpers.StaticPodOperatorClient,
 	eventRecorder events.Recorder,
 	kubeClient kubernetes.Interface,
 	kubeInformers operatorv1helpers.KubeInformersForNamespaces,
 ) factory.Controller {
-	kubeInformersForTargetNamespace := kubeInformers.InformersFor(operatorclient.TargetNamespace)
-	configmapsInformer := kubeInformersForTargetNamespace.Core().V1().ConfigMaps()
-	kubeInformersForCluster := kubeInformers.InformersFor("")
-	nodeInformer := kubeInformersForCluster.Core().V1().Nodes()
+	nodeInformer := kubeInformers.InformersFor("").Core().V1().Nodes()
 
 	c := &EtcdEndpointsController{
 		operatorClient:  operatorClient,
 		nodeLister:      nodeInformer.Lister(),
-		configmapLister: configmapsInformer.Lister(),
+		configmapLister: kubeInformers.ConfigMapLister(),
 		configmapClient: kubeClient.CoreV1(),
 	}
 	return factory.New().ResyncEvery(time.Minute).WithInformers(
 		operatorClient.Informer(),
-		configmapsInformer.Informer(),
+		kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer(),
 		nodeInformer.Informer(),
 	).WithSync(c.sync).ToController("EtcdEndpointsController", eventRecorder.WithComponentSuffix("etcd-endpoints-controller"))
 }
 
 func (c *EtcdEndpointsController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	err := c.syncConfigMap(ctx, syncCtx.Recorder())
+	err := c.syncConfigMap(syncCtx.Recorder())
 
 	if err != nil {
 		_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
@@ -83,8 +83,28 @@ func (c *EtcdEndpointsController) sync(ctx context.Context, syncCtx factory.Sync
 	return nil
 }
 
-func (c *EtcdEndpointsController) syncConfigMap(ctx context.Context, recorder events.Recorder) error {
+func (c *EtcdEndpointsController) syncConfigMap(recorder events.Recorder) error {
+	bootstrapComplete, err := isBootstrapComplete(c.configmapLister, c.operatorClient)
+	if err != nil {
+		return fmt.Errorf("couldn't determine bootstrap status: %w", err)
+	}
+
 	required := configMapAsset()
+
+	// If the bootstrap IP is present on the existing configmap, either copy it
+	// forward or remove it if possible so clients can forget about it.
+	if existing, err := c.configmapLister.ConfigMaps(operatorclient.TargetNamespace).Get("etcd-endpoints"); err == nil {
+		if existingIP, hasExistingIP := existing.Annotations[etcdcli.BootstrapIPAnnotationKey]; hasExistingIP {
+			if bootstrapComplete {
+				// remove the annotation
+				required.Annotations[etcdcli.BootstrapIPAnnotationKey+"-"] = existingIP
+			} else {
+				required.Annotations[etcdcli.BootstrapIPAnnotationKey] = existingIP
+			}
+		}
+	} else if !errors.IsNotFound(err) {
+		return fmt.Errorf("couldn't get configmap %s/%s: %w", operatorclient.TargetNamespace, "etcd-endpoints", err)
+	}
 
 	// create endpoint addresses for each node
 	nodes, err := c.nodeLister.List(labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector())
@@ -112,15 +132,60 @@ func (c *EtcdEndpointsController) syncConfigMap(ctx context.Context, recorder ev
 
 	required.Data = endpointAddresses
 
-	_, _, err = resourceapply.ApplyConfigMap(c.configmapClient, recorder, required)
-	return err
+	// Apply endpoint updates
+	if _, _, err := resourceapply.ApplyConfigMap(c.configmapClient, recorder, required); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func configMapAsset() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "etcd-endpoints",
-			Namespace: operatorclient.TargetNamespace,
+			Name:        "etcd-endpoints",
+			Namespace:   operatorclient.TargetNamespace,
+			Annotations: map[string]string{},
 		},
 	}
+}
+
+// isBootstrapComplete returns true if bootstrap has completed. This is used to
+// indicate whether it's safe for clients to forget about the bootstrap member IP.
+func isBootstrapComplete(configMapClient corev1listers.ConfigMapLister, staticPodClient v1helpers.StaticPodOperatorClient) (bool, error) {
+	// do a cheap check to see if the annotation is already gone.
+	// check to see if bootstrapping is complete
+	bootstrapFinishedConfigMap, err := configMapClient.ConfigMaps("kube-system").Get("bootstrap")
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// If the resource was deleted (e.g. by an admin) after bootstrap is actually complete,
+			// this is a false negative.
+			klog.V(4).Infof("bootstrap considered incomplete because the kube-system/bootstrap configmap wasn't found")
+			return false, nil
+		}
+		// We don't know, give up quickly.
+		return false, fmt.Errorf("failed to get configmap %s/%s: %w", "kube-system", "bootstrap", err)
+	}
+
+	if status, ok := bootstrapFinishedConfigMap.Data["status"]; !ok || status != "complete" {
+		// do nothing, not torn down
+		klog.V(4).Infof("bootstrap considered incomplete because status is %q", status)
+		return false, nil
+	}
+
+	// now run check to stability of revisions
+	_, status, _, err := staticPodClient.GetStaticPodOperatorState()
+	if err != nil {
+		return false, fmt.Errorf("failed to get static pod operator state: %w", err)
+	}
+	if status.LatestAvailableRevision == 0 {
+		return false, nil
+	}
+	for _, curr := range status.NodeStatuses {
+		if curr.CurrentRevision != status.LatestAvailableRevision {
+			klog.V(4).Infof("bootstrap considered incomplete because revision %d is still in progress", status.LatestAvailableRevision)
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
@@ -1,0 +1,364 @@
+package etcdendpointscontroller
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/diff"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+)
+
+func TestBootstrapAnnotationRemoval(t *testing.T) {
+	scenarios := []struct {
+		name            string
+		objects         []runtime.Object
+		staticPodStatus *operatorv1.StaticPodOperatorStatus
+		validateFunc    func(ts *testing.T, actions []clientgotesting.Action)
+	}{
+		{
+			// The bootstrap IP should be deleted because bootstrap reports complete
+			// and all nodes have converged on a revision.
+			name: "NewClusterBootstrapRemoval",
+			objects: []runtime.Object{
+				node("master-0", withMasterLabel(), withNodeInternalIP("10.0.0.1")),
+				node("master-1", withMasterLabel(), withNodeInternalIP("10.0.0.2")),
+				node("master-2", withMasterLabel(), withNodeInternalIP("10.0.0.3")),
+				bootstrapConfigMap(withBootstrapStatus("complete")),
+				endpointsConfigMap(
+					withBootstrapIP("192.0.2.1"),
+					withAddress("10.0.0.1"),
+					withAddress("10.0.0.2"),
+					withAddress("10.0.0.3"),
+				),
+			},
+			staticPodStatus: staticPodOperatorStatus(
+				withLatestRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+			),
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
+				wasValidated := false
+				for _, action := range actions {
+					if action.Matches("update", "configmaps") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						actual := updateAction.GetObject().(*corev1.ConfigMap)
+						expected := endpointsConfigMap(
+							withAddress("10.0.0.1"),
+							withAddress("10.0.0.2"),
+							withAddress("10.0.0.3"),
+						)
+						if !equality.Semantic.DeepEqual(actual, expected) {
+							ts.Errorf(diff.ObjectDiff(expected, actual))
+						}
+						wasValidated = true
+						break
+					}
+				}
+				if !wasValidated {
+					ts.Errorf("the endpoints configmap wasn't validated")
+				}
+			},
+		},
+		{
+			// The configmap should remain intact because although bootstrapping
+			// reports complete, the nodes are still progressing towards a revision.
+			name: "NewClusterBootstrapNodesProgressing",
+			objects: []runtime.Object{
+				node("master-0", withMasterLabel(), withNodeInternalIP("10.0.0.1")),
+				node("master-1", withMasterLabel(), withNodeInternalIP("10.0.0.2")),
+				node("master-2", withMasterLabel(), withNodeInternalIP("10.0.0.3")),
+				bootstrapConfigMap(withBootstrapStatus("complete")),
+				endpointsConfigMap(
+					withBootstrapIP("192.0.2.1"),
+					withAddress("10.0.0.1"),
+					withAddress("10.0.0.2"),
+					withAddress("10.0.0.3"),
+				),
+			},
+			staticPodStatus: staticPodOperatorStatus(
+				withLatestRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+				withNodeStatusAtCurrentRevision(2),
+				withNodeStatusAtCurrentRevision(3),
+			),
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
+				for _, action := range actions {
+					if action.Matches("update", "configmaps") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						actual := updateAction.GetObject().(*corev1.ConfigMap)
+						ts.Errorf("unexpected configmap update: %#v", actual)
+					}
+				}
+			},
+		},
+		{
+			// The configmap should remain intact because although nodes appear
+			// to have converged on a revision, bootstrap reports incomplete.
+			name: "NewClusterBootstrapProgressing",
+			objects: []runtime.Object{
+				node("master-0", withMasterLabel(), withNodeInternalIP("10.0.0.1")),
+				node("master-1", withMasterLabel(), withNodeInternalIP("10.0.0.2")),
+				node("master-2", withMasterLabel(), withNodeInternalIP("10.0.0.3")),
+				bootstrapConfigMap(withBootstrapStatus("progressing")),
+				endpointsConfigMap(
+					withBootstrapIP("192.0.2.1"),
+					withAddress("10.0.0.1"),
+					withAddress("10.0.0.2"),
+					withAddress("10.0.0.3"),
+				),
+			},
+			staticPodStatus: staticPodOperatorStatus(
+				withLatestRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+			),
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
+				for _, action := range actions {
+					if action.Matches("update", "configmaps") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						actual := updateAction.GetObject().(*corev1.ConfigMap)
+						ts.Errorf("unexpected configmap update: %#v", actual)
+					}
+				}
+			},
+		},
+		{
+			// The configmap should remain intact because there are no changes.
+			name: "NewClusterSteadyState",
+			objects: []runtime.Object{
+				node("master-0", withMasterLabel(), withNodeInternalIP("10.0.0.1")),
+				node("master-1", withMasterLabel(), withNodeInternalIP("10.0.0.2")),
+				node("master-2", withMasterLabel(), withNodeInternalIP("10.0.0.3")),
+				bootstrapConfigMap(withBootstrapStatus("complete")),
+				endpointsConfigMap(
+					withAddress("10.0.0.1"),
+					withAddress("10.0.0.2"),
+					withAddress("10.0.0.3"),
+				),
+			},
+			staticPodStatus: staticPodOperatorStatus(
+				withLatestRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+			),
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
+				for _, action := range actions {
+					if action.Matches("update", "configmaps") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						actual := updateAction.GetObject().(*corev1.ConfigMap)
+						ts.Errorf("unexpected configmap update: %#v", actual)
+					}
+				}
+			},
+		},
+		{
+			// The configmap should be created without a bootstrap IP because the
+			// only time the configmap won't already exist is when we've upgraded
+			// from a pre-configmap cluster (in which case bootstrapping already
+			// happened) or someone has deleted the configmap (which also implies
+			// bootstrap already happened). An edge case not specifically accounted
+			// for is the configmap being deleted before bootstrapping is complete.
+			name: "UpgradedClusterCreateConfigmap",
+			objects: []runtime.Object{
+				node("master-0", withMasterLabel(), withNodeInternalIP("10.0.0.1")),
+				node("master-1", withMasterLabel(), withNodeInternalIP("10.0.0.2")),
+				node("master-2", withMasterLabel(), withNodeInternalIP("10.0.0.3")),
+				bootstrapConfigMap(withBootstrapStatus("complete")),
+			},
+			staticPodStatus: staticPodOperatorStatus(
+				withLatestRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+				withNodeStatusAtCurrentRevision(3),
+			),
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
+				wasValidated := false
+				for _, action := range actions {
+					if action.Matches("create", "configmaps") {
+						createAction := action.(clientgotesting.CreateAction)
+						actual := createAction.GetObject().(*corev1.ConfigMap)
+						expected := endpointsConfigMap(
+							withAddress("10.0.0.1"),
+							withAddress("10.0.0.2"),
+							withAddress("10.0.0.3"),
+						)
+						if !equality.Semantic.DeepEqual(actual, expected) {
+							ts.Errorf(diff.ObjectDiff(expected, actual))
+						}
+						wasValidated = true
+						break
+					}
+				}
+				if !wasValidated {
+					ts.Errorf("the endpoints configmap wasn't validated")
+				}
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				&operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+				},
+				scenario.staticPodStatus,
+				nil,
+				nil,
+			)
+
+			fakeKubeClient := fake.NewSimpleClientset(scenario.objects...)
+			eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events(operatorclient.TargetNamespace), "test-etcdendpointscontroller", &corev1.ObjectReference{})
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, obj := range scenario.objects {
+				if err := indexer.Add(obj); err != nil {
+					t.Fatal(err)
+				}
+			}
+			controller := &EtcdEndpointsController{
+				operatorClient:  fakeOperatorClient,
+				nodeLister:      corev1listers.NewNodeLister(indexer),
+				configmapLister: corev1listers.NewConfigMapLister(indexer),
+				configmapClient: fakeKubeClient.CoreV1(),
+			}
+
+			err := controller.sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scenario.validateFunc != nil {
+				scenario.validateFunc(t, fakeKubeClient.Actions())
+			}
+		})
+	}
+}
+
+func bootstrapConfigMap(configs ...func(bootstrap *corev1.ConfigMap)) *corev1.ConfigMap {
+	bootstrap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bootstrap",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{},
+	}
+	for _, config := range configs {
+		config(bootstrap)
+	}
+	return bootstrap
+}
+
+func withBootstrapStatus(status string) func(*corev1.ConfigMap) {
+	return func(bootstrap *corev1.ConfigMap) {
+		bootstrap.Data["status"] = status
+	}
+}
+
+func staticPodOperatorStatus(configs ...func(status *operatorv1.StaticPodOperatorStatus)) *operatorv1.StaticPodOperatorStatus {
+	status := &operatorv1.StaticPodOperatorStatus{
+		OperatorStatus: operatorv1.OperatorStatus{
+			Conditions: []operatorv1.OperatorCondition{},
+		},
+		NodeStatuses: []operatorv1.NodeStatus{},
+	}
+	for _, config := range configs {
+		config(status)
+	}
+	return status
+}
+
+func withLatestRevision(latest int32) func(status *operatorv1.StaticPodOperatorStatus) {
+	return func(status *operatorv1.StaticPodOperatorStatus) {
+		status.LatestAvailableRevision = latest
+	}
+}
+
+func withNodeStatusAtCurrentRevision(current int32) func(*operatorv1.StaticPodOperatorStatus) {
+	return func(status *operatorv1.StaticPodOperatorStatus) {
+		status.NodeStatuses = append(status.NodeStatuses, operatorv1.NodeStatus{
+			CurrentRevision: current,
+		})
+	}
+}
+
+func endpointsConfigMap(configs ...func(endpoints *corev1.ConfigMap)) *corev1.ConfigMap {
+	endpoints := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd-endpoints",
+			Namespace: operatorclient.TargetNamespace,
+		},
+		Data: map[string]string{},
+	}
+	for _, config := range configs {
+		config(endpoints)
+	}
+	return endpoints
+}
+
+func withBootstrapIP(ip string) func(*corev1.ConfigMap) {
+	return func(endpoints *corev1.ConfigMap) {
+		if endpoints.Annotations == nil {
+			endpoints.Annotations = map[string]string{}
+		}
+		endpoints.Annotations[etcdcli.BootstrapIPAnnotationKey] = ip
+	}
+}
+
+func withAddress(ip string) func(*corev1.ConfigMap) {
+	return func(endpoints *corev1.ConfigMap) {
+		endpoints.Data[base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(ip))] = ip
+	}
+}
+
+func node(name string, configs ...func(node *corev1.Node)) *corev1.Node {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	for _, config := range configs {
+		config(node)
+	}
+	return node
+}
+
+func withMasterLabel() func(*corev1.Node) {
+	return func(node *corev1.Node) {
+		if node.Labels == nil {
+			node.Labels = map[string]string{}
+		}
+		node.Labels["node-role.kubernetes.io/master"] = ""
+	}
+}
+
+func withNodeInternalIP(ip string) func(*corev1.Node) {
+	return func(node *corev1.Node) {
+		if node.Status.Addresses == nil {
+			node.Status.Addresses = []corev1.NodeAddress{}
+		}
+		node.Status.Addresses = append(node.Status.Addresses, corev1.NodeAddress{
+			Type:    corev1.NodeInternalIP,
+			Address: ip,
+		})
+	}
+}

--- a/vendor/k8s.io/utils/diff/diff.go
+++ b/vendor/k8s.io/utils/diff/diff.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"k8s.io/utils/field"
+)
+
+// StringDiff diffs a and b and returns a human readable diff.
+func StringDiff(a, b string) string {
+	ba := []byte(a)
+	bb := []byte(b)
+	out := []byte{}
+	i := 0
+	for ; i < len(ba) && i < len(bb); i++ {
+		if ba[i] != bb[i] {
+			break
+		}
+		out = append(out, ba[i])
+	}
+	out = append(out, []byte("\n\nA: ")...)
+	out = append(out, ba[i:]...)
+	out = append(out, []byte("\n\nB: ")...)
+	out = append(out, bb[i:]...)
+	out = append(out, []byte("\n\n")...)
+	return string(out)
+}
+
+// ObjectDiff writes the two objects out as JSON and prints out the identical part of
+// the objects followed by the remaining part of 'a' and finally the remaining part of 'b'.
+// For debugging tests.
+func ObjectDiff(a, b interface{}) string {
+	ab, err := json.Marshal(a)
+	if err != nil {
+		panic(fmt.Sprintf("a: %v", err))
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		panic(fmt.Sprintf("b: %v", err))
+	}
+	return StringDiff(string(ab), string(bb))
+}
+
+// ObjectGoPrintDiff is like ObjectDiff, but uses go-spew to print the objects,
+// which shows absolutely everything by recursing into every single pointer
+// (go's %#v formatters OTOH stop at a certain point). This is needed when you
+// can't figure out why reflect.DeepEqual is returning false and nothing is
+// showing you differences. This will.
+func ObjectGoPrintDiff(a, b interface{}) string {
+	s := spew.ConfigState{DisableMethods: true}
+	return StringDiff(
+		s.Sprintf("%#v", a),
+		s.Sprintf("%#v", b),
+	)
+}
+
+// ObjectReflectDiff returns a diff computed through reflection, without serializing to JSON.
+func ObjectReflectDiff(a, b interface{}) string {
+	vA, vB := reflect.ValueOf(a), reflect.ValueOf(b)
+	if vA.Type() != vB.Type() {
+		return fmt.Sprintf("type A %T and type B %T do not match", a, b)
+	}
+	diffs := objectReflectDiff(field.NewPath("object"), vA, vB)
+	if len(diffs) == 0 {
+		return "<no diffs>"
+	}
+	out := []string{""}
+	for _, d := range diffs {
+		elidedA, elidedB := limit(d.a, d.b, 80)
+		out = append(out,
+			fmt.Sprintf("%s:", d.path),
+			fmt.Sprintf("  a: %s", elidedA),
+			fmt.Sprintf("  b: %s", elidedB),
+		)
+	}
+	return strings.Join(out, "\n")
+}
+
+// limit:
+// 1. stringifies aObj and bObj
+// 2. elides identical prefixes if either is too long
+// 3. elides remaining content from the end if either is too long
+func limit(aObj, bObj interface{}, max int) (string, string) {
+	elidedPrefix := ""
+	elidedASuffix := ""
+	elidedBSuffix := ""
+	a, b := fmt.Sprintf("%#v", aObj), fmt.Sprintf("%#v", bObj)
+
+	if aObj != nil && bObj != nil {
+		if aType, bType := fmt.Sprintf("%T", aObj), fmt.Sprintf("%T", bObj); aType != bType {
+			a = fmt.Sprintf("%s (%s)", a, aType)
+			b = fmt.Sprintf("%s (%s)", b, bType)
+		}
+	}
+
+	for {
+		switch {
+		case len(a) > max && len(a) > 4 && len(b) > 4 && a[:4] == b[:4]:
+			// a is too long, b has data, and the first several characters are the same
+			elidedPrefix = "..."
+			a = a[2:]
+			b = b[2:]
+
+		case len(b) > max && len(b) > 4 && len(a) > 4 && a[:4] == b[:4]:
+			// b is too long, a has data, and the first several characters are the same
+			elidedPrefix = "..."
+			a = a[2:]
+			b = b[2:]
+
+		case len(a) > max:
+			a = a[:max]
+			elidedASuffix = "..."
+
+		case len(b) > max:
+			b = b[:max]
+			elidedBSuffix = "..."
+
+		default:
+			// both are short enough
+			return elidedPrefix + a + elidedASuffix, elidedPrefix + b + elidedBSuffix
+		}
+	}
+}
+
+func public(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	return s[:1] == strings.ToUpper(s[:1])
+}
+
+type diff struct {
+	path *field.Path
+	a, b interface{}
+}
+
+type orderedDiffs []diff
+
+func (d orderedDiffs) Len() int      { return len(d) }
+func (d orderedDiffs) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d orderedDiffs) Less(i, j int) bool {
+	a, b := d[i].path.String(), d[j].path.String()
+	if a < b {
+		return true
+	}
+	return false
+}
+
+func objectReflectDiff(path *field.Path, a, b reflect.Value) []diff {
+	switch a.Type().Kind() {
+	case reflect.Struct:
+		var changes []diff
+		for i := 0; i < a.Type().NumField(); i++ {
+			if !public(a.Type().Field(i).Name) {
+				if reflect.DeepEqual(a.Interface(), b.Interface()) {
+					continue
+				}
+				return []diff{{path: path, a: fmt.Sprintf("%#v", a), b: fmt.Sprintf("%#v", b)}}
+			}
+			if sub := objectReflectDiff(path.Child(a.Type().Field(i).Name), a.Field(i), b.Field(i)); len(sub) > 0 {
+				changes = append(changes, sub...)
+			}
+		}
+		return changes
+	case reflect.Ptr, reflect.Interface:
+		if a.IsNil() || b.IsNil() {
+			switch {
+			case a.IsNil() && b.IsNil():
+				return nil
+			case a.IsNil():
+				return []diff{{path: path, a: nil, b: b.Interface()}}
+			default:
+				return []diff{{path: path, a: a.Interface(), b: nil}}
+			}
+		}
+		return objectReflectDiff(path, a.Elem(), b.Elem())
+	case reflect.Chan:
+		if !reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+		}
+		return nil
+	case reflect.Slice:
+		lA, lB := a.Len(), b.Len()
+		l := lA
+		if lB < lA {
+			l = lB
+		}
+		if lA == lB && lA == 0 {
+			if a.IsNil() != b.IsNil() {
+				return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+			}
+			return nil
+		}
+		var diffs []diff
+		for i := 0; i < l; i++ {
+			if !reflect.DeepEqual(a.Index(i), b.Index(i)) {
+				diffs = append(diffs, objectReflectDiff(path.Index(i), a.Index(i), b.Index(i))...)
+			}
+		}
+		for i := l; i < lA; i++ {
+			diffs = append(diffs, diff{path: path.Index(i), a: a.Index(i), b: nil})
+		}
+		for i := l; i < lB; i++ {
+			diffs = append(diffs, diff{path: path.Index(i), a: nil, b: b.Index(i)})
+		}
+		return diffs
+	case reflect.Map:
+		if reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return nil
+		}
+		aKeys := make(map[interface{}]interface{})
+		for _, key := range a.MapKeys() {
+			aKeys[key.Interface()] = a.MapIndex(key).Interface()
+		}
+		var missing []diff
+		for _, key := range b.MapKeys() {
+			if _, ok := aKeys[key.Interface()]; ok {
+				delete(aKeys, key.Interface())
+				if reflect.DeepEqual(a.MapIndex(key).Interface(), b.MapIndex(key).Interface()) {
+					continue
+				}
+				missing = append(missing, objectReflectDiff(path.Key(fmt.Sprintf("%s", key.Interface())), a.MapIndex(key), b.MapIndex(key))...)
+				continue
+			}
+			missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key.Interface())), a: nil, b: b.MapIndex(key).Interface()})
+		}
+		for key, value := range aKeys {
+			missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key)), a: value, b: nil})
+		}
+		if len(missing) == 0 {
+			missing = append(missing, diff{path: path, a: a.Interface(), b: b.Interface()})
+		}
+		sort.Sort(orderedDiffs(missing))
+		return missing
+	default:
+		if reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return nil
+		}
+		if !a.CanInterface() {
+			return []diff{{path: path, a: fmt.Sprintf("%#v", a), b: fmt.Sprintf("%#v", b)}}
+		}
+		return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+	}
+}
+
+// ObjectGoPrintSideBySide prints a and b as textual dumps side by side,
+// enabling easy visual scanning for mismatches.
+func ObjectGoPrintSideBySide(a, b interface{}) string {
+	s := spew.ConfigState{
+		Indent: " ",
+		// Extra deep spew.
+		DisableMethods: true,
+	}
+	sA := s.Sdump(a)
+	sB := s.Sdump(b)
+
+	linesA := strings.Split(sA, "\n")
+	linesB := strings.Split(sB, "\n")
+	width := 0
+	for _, s := range linesA {
+		l := len(s)
+		if l > width {
+			width = l
+		}
+	}
+	for _, s := range linesB {
+		l := len(s)
+		if l > width {
+			width = l
+		}
+	}
+	buf := &bytes.Buffer{}
+	w := tabwriter.NewWriter(buf, width, 0, 1, ' ', 0)
+	max := len(linesA)
+	if len(linesB) > max {
+		max = len(linesB)
+	}
+	for i := 0; i < max; i++ {
+		var a, b string
+		if i < len(linesA) {
+			a = linesA[i]
+		}
+		if i < len(linesB) {
+			b = linesB[i]
+		}
+		fmt.Fprintf(w, "%s\t%s\n", a, b)
+	}
+	w.Flush()
+	return buf.String()
+}

--- a/vendor/k8s.io/utils/field/path.go
+++ b/vendor/k8s.io/utils/field/path.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package field
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+// Path represents the path from some root to a particular field.
+type Path struct {
+	name   string // the name of this field or "" if this is an index
+	index  string // if name == "", this is a subscript (index or map key) of the previous element
+	parent *Path  // nil if this is the root element
+}
+
+// NewPath creates a root Path object.
+func NewPath(name string, moreNames ...string) *Path {
+	r := &Path{name: name, parent: nil}
+	for _, anotherName := range moreNames {
+		r = &Path{name: anotherName, parent: r}
+	}
+	return r
+}
+
+// Root returns the root element of this Path.
+func (p *Path) Root() *Path {
+	for ; p.parent != nil; p = p.parent {
+		// Do nothing.
+	}
+	return p
+}
+
+// Child creates a new Path that is a child of the method receiver.
+func (p *Path) Child(name string, moreNames ...string) *Path {
+	r := NewPath(name, moreNames...)
+	r.Root().parent = p
+	return r
+}
+
+// Index indicates that the previous Path is to be subscripted by an int.
+// This sets the same underlying value as Key.
+func (p *Path) Index(index int) *Path {
+	return &Path{index: strconv.Itoa(index), parent: p}
+}
+
+// Key indicates that the previous Path is to be subscripted by a string.
+// This sets the same underlying value as Index.
+func (p *Path) Key(key string) *Path {
+	return &Path{index: key, parent: p}
+}
+
+// String produces a string representation of the Path.
+func (p *Path) String() string {
+	// make a slice to iterate
+	elems := []*Path{}
+	for ; p != nil; p = p.parent {
+		elems = append(elems, p)
+	}
+
+	// iterate, but it has to be backwards
+	buf := bytes.NewBuffer(nil)
+	for i := range elems {
+		p := elems[len(elems)-1-i]
+		if p.parent != nil && len(p.name) > 0 {
+			// This is either the root or it is a subscript.
+			buf.WriteString(".")
+		}
+		if len(p.name) > 0 {
+			buf.WriteString(p.name)
+		} else {
+			fmt.Fprintf(buf, "[%s]", p.index)
+		}
+	}
+	return buf.String()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -870,6 +870,8 @@ k8s.io/kube-openapi/pkg/util
 k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 k8s.io/utils/buffer
+k8s.io/utils/diff
+k8s.io/utils/field
 k8s.io/utils/integer
 k8s.io/utils/net
 k8s.io/utils/path


### PR DESCRIPTION
After bootstrap completes, forget the bootstrap etcd member IP by clearing
the annotation from the endpoint configmap. Otherwise the etcd client will
continue failing to connect to the dead bootstrap node forever.