### PR TITLE
Bug 1842431: cluster-backup.sh: error if script dependencies are not met

### DIFF
--- a/bindata/etcd/cluster-backup.sh
+++ b/bindata/etcd/cluster-backup.sh
@@ -25,7 +25,7 @@ if [ -z "$1" ] || [ -f "$1" ]; then
 fi
 
 if [ ! -d "$1" ]; then
-  mkdir -p $1
+  mkdir -p "$1"
 fi
 
 # backup latest static pod resources
@@ -34,7 +34,8 @@ function backup_latest_kube_static_resources {
 
   LATEST_RESOURCE_DIRS=()
   for RESOURCE in "${RESOURCES[@]}"; do
-    LATEST_RESOURCE=$(ls -trd "${CONFIG_FILE_DIR}"/static-pod-resources/${RESOURCE}-[0-9]* | tail -1) || true
+    # shellcheck disable=SC2012
+    LATEST_RESOURCE=$(ls -trd "${CONFIG_FILE_DIR}"/static-pod-resources/"${RESOURCE}"-[0-9]* | tail -1) || true
     if [ -z "$LATEST_RESOURCE" ]; then
       echo "error finding static-pod-resource ${RESOURCE}"
       exit 1
@@ -45,7 +46,18 @@ function backup_latest_kube_static_resources {
   done
 
   # tar latest resources with the path relative to CONFIG_FILE_DIR
-  tar -cpzf $BACKUP_TAR_FILE -C ${CONFIG_FILE_DIR} "${LATEST_RESOURCE_DIRS[@]}"
+  tar -cpzf "$BACKUP_TAR_FILE" -C "${CONFIG_FILE_DIR}" "${LATEST_RESOURCE_DIRS[@]}"
+  chmod 600 "$BACKUP_TAR_FILE"
+}
+
+function source_required_dependency {
+  local path="$1"
+  if [ ! -f "${path}" ]; then
+    echo "required dependencies not found, please ensure this script is run on a node with a functional etcd static pod"
+    exit 1
+  fi
+  # shellcheck disable=SC1090
+  source "${path}"
 }
 
 BACKUP_DIR="$1"
@@ -54,17 +66,17 @@ BACKUP_TAR_FILE=${BACKUP_DIR}/static_kuberesources_${DATESTRING}.tar.gz
 SNAPSHOT_FILE="${BACKUP_DIR}/snapshot_${DATESTRING}.db"
 BACKUP_RESOURCE_LIST=("kube-apiserver-pod" "kube-controller-manager-pod" "kube-scheduler-pod" "etcd-pod")
 
-trap "rm -f ${BACKUP_TAR_FILE} ${SNAPSHOT_FILE}" ERR
+trap 'rm -f ${BACKUP_TAR_FILE} ${SNAPSHOT_FILE}' ERR
 
-source /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
-source /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
+source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
+source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
 
 # TODO handle properly
 if [ ! -f "$ETCDCTL_CACERT" ] && [ ! -d "${CONFIG_FILE_DIR}/static-pod-certs" ]; then
-  ln -s ${CONFIG_FILE_DIR}/static-pod-resources/etcd-certs ${CONFIG_FILE_DIR}/static-pod-certs
+  ln -s "${CONFIG_FILE_DIR}"/static-pod-resources/etcd-certs "${CONFIG_FILE_DIR}"/static-pod-certs
 fi
 
 dl_etcdctl
 backup_latest_kube_static_resources "${BACKUP_RESOURCE_LIST[@]}"
-ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot save ${SNAPSHOT_FILE}
+ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot save "${SNAPSHOT_FILE}"
 echo "snapshot db and kube resources are successfully saved to ${BACKUP_DIR}"

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -93,7 +93,7 @@ if [ -z "$1" ] || [ -f "$1" ]; then
 fi
 
 if [ ! -d "$1" ]; then
-  mkdir -p $1
+  mkdir -p "$1"
 fi
 
 # backup latest static pod resources
@@ -102,7 +102,8 @@ function backup_latest_kube_static_resources {
 
   LATEST_RESOURCE_DIRS=()
   for RESOURCE in "${RESOURCES[@]}"; do
-    LATEST_RESOURCE=$(ls -trd "${CONFIG_FILE_DIR}"/static-pod-resources/${RESOURCE}-[0-9]* | tail -1) || true
+    # shellcheck disable=SC2012
+    LATEST_RESOURCE=$(ls -trd "${CONFIG_FILE_DIR}"/static-pod-resources/"${RESOURCE}"-[0-9]* | tail -1) || true
     if [ -z "$LATEST_RESOURCE" ]; then
       echo "error finding static-pod-resource ${RESOURCE}"
       exit 1
@@ -113,7 +114,18 @@ function backup_latest_kube_static_resources {
   done
 
   # tar latest resources with the path relative to CONFIG_FILE_DIR
-  tar -cpzf $BACKUP_TAR_FILE -C ${CONFIG_FILE_DIR} "${LATEST_RESOURCE_DIRS[@]}"
+  tar -cpzf "$BACKUP_TAR_FILE" -C "${CONFIG_FILE_DIR}" "${LATEST_RESOURCE_DIRS[@]}"
+  chmod 600 "$BACKUP_TAR_FILE"
+}
+
+function source_required_dependency {
+  local path="$1"
+  if [ ! -f "${path}" ]; then
+    echo "required dependencies not found, please ensure this script is run on a node with a functional etcd static pod"
+    exit 1
+  fi
+  # shellcheck disable=SC1090
+  source "${path}"
 }
 
 BACKUP_DIR="$1"
@@ -122,19 +134,19 @@ BACKUP_TAR_FILE=${BACKUP_DIR}/static_kuberesources_${DATESTRING}.tar.gz
 SNAPSHOT_FILE="${BACKUP_DIR}/snapshot_${DATESTRING}.db"
 BACKUP_RESOURCE_LIST=("kube-apiserver-pod" "kube-controller-manager-pod" "kube-scheduler-pod" "etcd-pod")
 
-trap "rm -f ${BACKUP_TAR_FILE} ${SNAPSHOT_FILE}" ERR
+trap 'rm -f ${BACKUP_TAR_FILE} ${SNAPSHOT_FILE}' ERR
 
-source /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
-source /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
+source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
+source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
 
 # TODO handle properly
 if [ ! -f "$ETCDCTL_CACERT" ] && [ ! -d "${CONFIG_FILE_DIR}/static-pod-certs" ]; then
-  ln -s ${CONFIG_FILE_DIR}/static-pod-resources/etcd-certs ${CONFIG_FILE_DIR}/static-pod-certs
+  ln -s "${CONFIG_FILE_DIR}"/static-pod-resources/etcd-certs "${CONFIG_FILE_DIR}"/static-pod-certs
 fi
 
 dl_etcdctl
 backup_latest_kube_static_resources "${BACKUP_RESOURCE_LIST[@]}"
-ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot save ${SNAPSHOT_FILE}
+ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot save "${SNAPSHOT_FILE}"
 echo "snapshot db and kube resources are successfully saved to ${BACKUP_DIR}"
 `)
 


### PR DESCRIPTION
This PR adds error handling to assist user in understanding that the backup script is not located on a node that is able to perform backup. Also updated the script to be valid against shellcheck.