### PR TITLE
Bug 1840531: Adding rollbackcopy subcommand

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -233,6 +233,34 @@ ${COMPUTED_ENV_VARS}
         name: cert-dir
       - mountPath: /var/lib/etcd/
         name: data-dir
+  - name: rollbackcopier
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command:
+      - /bin/sh
+      - -c
+      - |
+        #!/bin/sh
+        set -euo pipefail
+
+        export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
+        exec cluster-etcd-operator rollbackcopy
+    resources:
+      requests:
+        memory: 60Mi
+        cpu: 30m
+    securityContext:
+      privileged: true
+    volumeMounts:
+      - mountPath: /etc/kubernetes/rollbackcopy
+        name: rollbackcopy
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: full-resource-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
+    env:
+${COMPUTED_ENV_VARS}
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -247,6 +275,12 @@ ${COMPUTED_ENV_VARS}
     - hostPath:
         path: /etc/kubernetes/static-pod-resources/etcd-pod-REVISION
       name: resource-dir
+    - hostPath:
+        path: /etc/kubernetes/static-pod-resources
+      name: full-resource-dir
+    - hostPath:
+        path: /etc/kubernetes/rollbackcopy
+      name: rollbackcopy
     - hostPath:
         path: /etc/kubernetes/static-pod-resources/etcd-certs
       name: cert-dir

--- a/cmd/cluster-etcd-operator/main.go
+++ b/cmd/cluster-etcd-operator/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/mount"
 	operatorcmd "github.com/openshift/cluster-etcd-operator/pkg/cmd/operator"
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/render"
+	"github.com/openshift/cluster-etcd-operator/pkg/cmd/rollbackcopy"
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/staticpodcontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/staticsynccontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/waitforceo"
@@ -58,6 +59,7 @@ func NewSSCSCommand() *cobra.Command {
 	cmd.AddCommand(staticsynccontroller.NewStaticSyncCommand(os.Stderr))
 	cmd.AddCommand(staticpodcontroller.NewStaticPodCommand(os.Stderr))
 	cmd.AddCommand(mount.NewMountCommand(os.Stderr))
+	cmd.AddCommand(rollbackcopy.NewRollbackCopy(os.Stderr))
 	cmd.AddCommand(waitforceo.NewWaitForCeoCommand(os.Stderr))
 	cmd.AddCommand(waitforkube.NewWaitForKubeCommand(os.Stderr))
 

--- a/pkg/cmd/rollbackcopy/backuputils.go
+++ b/pkg/cmd/rollbackcopy/backuputils.go
@@ -1,0 +1,118 @@
+package rollbackcopy
+
+import (
+	"fmt"
+	"k8s.io/klog"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+//This backup mimics the functionality of cluster-backup.sh
+
+var backupResourcePodList = []string{
+	"kube-apiserver-pod",
+	"kube-controller-manager-pod",
+	"kube-scheduler-pod",
+	"etcd-pod",
+}
+
+func archiveLatestResources(configDir, backupFile string) error {
+	klog.Info("Static Pod Resources are being stored in: ", backupFile)
+
+	paths := []string{}
+	for _, podName := range backupResourcePodList {
+		latestPod, err := findTheLatestRevision(filepath.Join(configDir, "static-pod-resources"), podName)
+		if err != nil {
+			return fmt.Errorf("findTheLatestRevision failed: %w", err)
+		}
+		paths = append(paths, latestPod)
+		klog.Info("\tAdding the latest revision for podName ", podName, ": ", latestPod)
+	}
+
+	err := createTarball(backupFile, paths, configDir)
+	if err != nil {
+		return fmt.Errorf("Got error creating the tar archive: %w", err)
+	}
+	return nil
+}
+
+func backup(configDir string) error {
+	cli, err := getEtcdClient([]string{"localhost:2379"})
+	if err != nil {
+		return fmt.Errorf("backup: failed to get etcd client: %w", err)
+	}
+	defer cli.Close()
+
+	currentClusterVersion, upgradeInProgress, err := getClusterVersionAndUpgradeInfo(cli)
+	if err != nil {
+		return fmt.Errorf("getClusterVersionAndUpgradeInfo failed: %w", err)
+	}
+
+	if upgradeInProgress {
+		return fmt.Errorf("The cluster is being upgraded. Skipping backup!")
+	}
+
+	tmpBackupDir := filepath.Join(configDir, "rollbackcopy", "tmp")
+	defer os.RemoveAll(tmpBackupDir)
+
+	if err := checkAndCreateDir(tmpBackupDir); err != nil {
+		return fmt.Errorf("backup: checkAndCreateDir failed: %w", err)
+	}
+
+	// Trying to match the output file formats with the formats of the current cluster-backup.sh script
+	dateString := time.Now().Format("2006-01-02_150405")
+	outputArchive := "static_kuberesources_" + dateString + ".tar.gz"
+	snapshotOutFile := "snapshot_" + dateString + ".db"
+
+	// Save snapshot
+	if err := saveSnapshot(cli, filepath.Join(tmpBackupDir, snapshotOutFile)); err != nil {
+		return fmt.Errorf("saveSnapshot failed: %w", err)
+	}
+
+	// Save the corresponding static pod resources
+	if err := archiveLatestResources(configDir, filepath.Join(tmpBackupDir, outputArchive)); err != nil {
+		return fmt.Errorf("archiveLatestResources failed: %w", err)
+	}
+
+	// Write the version
+	version := backupVersion{currentClusterVersion, dateString}
+	if err := putVersion(&version, tmpBackupDir); err != nil {
+		return fmt.Errorf("putVersion failed: %w", err)
+	}
+
+	if err := checkVersionsAndMoveDirs(configDir, tmpBackupDir, upgradeInProgress); err != nil {
+		return fmt.Errorf("checkVersionsAndMoveDirs failed: %w", err)
+	}
+
+	dumpDirs(filepath.Join(configDir, "rollbackcopy"))
+
+	return nil
+}
+
+func checkVersionsAndMoveDirs(configDir, newBackupDir string, beingUpgraded bool) error {
+	if beingUpgraded {
+		return nil
+	}
+	currentVersionlatestDir := filepath.Join(configDir, "rollbackcopy", "currentVersion.latest")
+	currentVersionPrevDir := filepath.Join(configDir, "rollbackcopy", "currentVersion.prev")
+	if versionChanged(currentVersionlatestDir, newBackupDir) {
+		olderVersionlatestDir := filepath.Join(configDir, "rollbackcopy", "olderVersion.latest")
+		olderVersionPrevDir := filepath.Join(configDir, "rollbackcopy", "olderVersion.prev")
+		if err := safeDirRename(currentVersionPrevDir, olderVersionPrevDir, true); err != nil {
+			return err
+		}
+		if err := safeDirRename(currentVersionlatestDir, olderVersionlatestDir, true); err != nil {
+			return err
+		}
+	} else {
+		if err := safeDirRename(currentVersionlatestDir, currentVersionPrevDir, true); err != nil {
+			return err
+		}
+	}
+	if err := safeDirRename(newBackupDir, currentVersionlatestDir, false); err != nil {
+		return err
+	}
+	klog.Info("Backed up resources and snapshot to ", currentVersionlatestDir)
+	return nil
+}

--- a/pkg/cmd/rollbackcopy/backuputils_test.go
+++ b/pkg/cmd/rollbackcopy/backuputils_test.go
@@ -1,0 +1,187 @@
+package rollbackcopy
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type dirEntry struct {
+	name      string
+	version   string
+	timestamp string
+}
+
+func createBackupDir(basedirpath string, dir *dirEntry) error {
+	fullpath := filepath.Join(basedirpath, dir.name)
+	if err := checkAndCreateDir(fullpath); err != nil {
+		return fmt.Errorf("createBackupDir failed: %w", err)
+	}
+	backupVersion := &backupVersion{ClusterVersion: dir.version, TimeStamp: dir.timestamp}
+	if err := putVersion(backupVersion, fullpath); err != nil {
+		return fmt.Errorf("createBackupDir: putVersion failed: %w", err)
+	}
+	return nil
+}
+
+func checkBackupDir(basedirpath string, dir *dirEntry) error {
+	fullpath := filepath.Join(basedirpath, dir.name)
+	isDir, err := dirExists(fullpath)
+	if err != nil {
+		return fmt.Errorf("checkBackupDir: dirExists on %s failed: %w", fullpath, err)
+	}
+
+	if !isDir {
+		return fmt.Errorf("checkBackupDir: %s is not a directory", fullpath)
+	}
+
+	backupVersion, err := getVersion(fullpath)
+	if err != nil {
+		return fmt.Errorf("checkBackupDir: getVersion failed: %w", err)
+	}
+	if backupVersion.ClusterVersion != dir.version || backupVersion.TimeStamp != dir.timestamp {
+		return fmt.Errorf("Directory mismatch: expected %v, but got %v", dir, backupVersion)
+	}
+	return nil
+}
+
+func Test_checkVersionsAndMoveDirs(t *testing.T) {
+	type args struct {
+		newBackupDir     dirEntry
+		updateInProgress bool
+	}
+	configDir, err := ioutil.TempDir(os.TempDir(), "kubernetes-")
+	if err != nil {
+		t.Fatalf("Fatal: %v", err)
+	}
+	t.Logf("ConfigDir: %s", configDir)
+	defer os.RemoveAll(configDir) // clean up
+
+	tests := []struct {
+		name         string
+		args         args
+		existingDirs []dirEntry
+		want         []dirEntry
+		wantErr      bool
+	}{
+		{
+			name: "Successful initial backup",
+			args: args{
+				newBackupDir:     dirEntry{"tmp", "4.4.10-0", "2020-06-12_220858"},
+				updateInProgress: false,
+			},
+			existingDirs: []dirEntry{},
+			want: []dirEntry{
+				{"currentVersion.latest", "4.4.10-0", "2020-06-12_220858"},
+			},
+		},
+		{
+			name: "Successful periodic backup after the initial backup",
+			args: args{
+				newBackupDir:     dirEntry{"tmp", "4.4.10-0", "2020-06-12_230858"},
+				updateInProgress: false,
+			},
+			existingDirs: []dirEntry{
+				{"currentVersion.latest", "4.4.10-0", "2020-06-12_220858"},
+			},
+			want: []dirEntry{
+				{"currentVersion.latest", "4.4.10-0", "2020-06-12_230858"},
+				{"currentVersion.prev", "4.4.10-0", "2020-06-12_220858"},
+			},
+		},
+		{
+			name: "Don't try to move directories during upgrade",
+			args: args{
+				newBackupDir:     dirEntry{"tmp", "4.4.11-0", "2020-06-12_230858"},
+				updateInProgress: true,
+			},
+			existingDirs: []dirEntry{
+				{"currentVersion.latest", "4.4.10-0", "2020-06-12_220858"},
+				{"olderVersion.latest", "4.4.9-0", "2020-06-10_010858"},
+			},
+			want: []dirEntry{
+				{"currentVersion.latest", "4.4.10-0", "2020-06-12_220858"},
+				{"olderVersion.latest", "4.4.9-0", "2020-06-10_010858"},
+			},
+		},
+		{
+			name: "backup after rollout of new Y at time T",
+			args: args{
+				newBackupDir:     dirEntry{"tmp", "4.4.11-0", "2020-06-12_230858"},
+				updateInProgress: false,
+			},
+			existingDirs: []dirEntry{
+				{"currentVersion.latest", "4.4.10-0", "2020-06-12_220858"},
+				{"currentVersion.prev", "4.4.10-0", "2020-06-12_210858"},
+			},
+			want: []dirEntry{
+				{"currentVersion.latest", "4.4.11-0", "2020-06-12_230858"},
+				{"olderVersion.latest", "4.4.10-0", "2020-06-12_220858"},
+				{"olderVersion.prev", "4.4.10-0", "2020-06-12_210858"},
+			},
+		},
+		{
+			name: "successful periodic backup at time T preserves all prior backups",
+			args: args{
+				newBackupDir:     dirEntry{"tmp", "4.4.10-0", "2020-06-12_230858"},
+				updateInProgress: false,
+			},
+			existingDirs: []dirEntry{
+				{"currentVersion.latest", "4.4.10-0", "2020-06-12_220858"},
+				{"currentVersion.prev", "4.4.10-0", "2020-06-12_210858"},
+				{"olderVersion.latest", "4.4.9-0", "2020-06-12_200858"},
+				{"olderVersion.prev", "4.4.9-0", "2020-06-12_190858"},
+			},
+			want: []dirEntry{
+				{"currentVersion.latest", "4.4.10-0", "2020-06-12_230858"},
+				{"currentVersion.prev", "4.4.10-0", "2020-06-12_220858"},
+				{"olderVersion.latest", "4.4.9-0", "2020-06-12_200858"},
+				{"olderVersion.prev", "4.4.9-0", "2020-06-12_190858"},
+			},
+		},
+		{
+			name: "Upgrade after time T",
+			args: args{
+				newBackupDir:     dirEntry{"tmp", "4.4.11-0", "2020-06-12_230858"},
+				updateInProgress: false,
+			},
+			existingDirs: []dirEntry{
+				{"currentVersion.latest", "4.4.10-0", "2020-06-12_220858"},
+				{"currentVersion.prev", "4.4.10-0", "2020-06-12_210858"},
+				{"olderVersion.latest", "4.4.9-0", "2020-06-12_200858"},
+				{"olderVersion.prev", "4.4.9-0", "2020-06-12_190858"},
+			},
+			want: []dirEntry{
+				{"currentVersion.latest", "4.4.11-0", "2020-06-12_230858"},
+				{"olderVersion.latest", "4.4.10-0", "2020-06-12_220858"},
+				{"olderVersion.prev", "4.4.10-0", "2020-06-12_210858"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseDirPath := filepath.Join(configDir, "rollbackcopy")
+			os.RemoveAll(baseDirPath)
+			if err := createBackupDir(baseDirPath, &tt.args.newBackupDir); err != nil {
+				t.Fatalf("createDirWithVersion() baseDir=%s, %v, error= %v", baseDirPath, tt.args.newBackupDir, err)
+			}
+			for _, existingDir := range tt.existingDirs {
+				if err := createBackupDir(baseDirPath, &existingDir); err != nil {
+					t.Errorf("createDirWithVersion() error= %v", err)
+				}
+			}
+
+			if err := checkVersionsAndMoveDirs(configDir, filepath.Join(baseDirPath, tt.args.newBackupDir.name), tt.args.updateInProgress); (err != nil) != tt.wantErr {
+				t.Errorf("checkVersionsAndMoveDirs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			for _, wantDir := range tt.want {
+				if err := checkBackupDir(baseDirPath, &wantDir); err != nil {
+					t.Errorf("checkBackupDir() error= %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cmd/rollbackcopy/etcdclientutils.go
+++ b/pkg/cmd/rollbackcopy/etcdclientutils.go
@@ -1,0 +1,138 @@
+package rollbackcopy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"google.golang.org/grpc"
+	"io"
+	"k8s.io/klog"
+	"os"
+	"time"
+
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/pkg/transport"
+)
+
+func getEtcdClient(endpoints []string) (*clientv3.Client, error) {
+	dialOptions := []grpc.DialOption{
+		grpc.WithBlock(), // block until the underlying connection is up
+	}
+
+	tlsInfo := transport.TLSInfo{
+		CertFile:      os.Getenv("ETCDCTL_CERT"),
+		KeyFile:       os.Getenv("ETCDCTL_KEY"),
+		TrustedCAFile: os.Getenv("ETCDCTL_CACERT"),
+	}
+	tlsConfig, err := tlsInfo.ClientConfig()
+
+	cfg := &clientv3.Config{
+		DialOptions: dialOptions,
+		Endpoints:   endpoints,
+		DialTimeout: 2 * time.Second,
+		TLS:         tlsConfig,
+	}
+
+	cli, err := clientv3.New(*cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make etcd client for endpoints %v: %w", endpoints, err)
+	}
+	return cli, nil
+}
+
+func getClusterVersionAndUpgradeInfo(cli *clientv3.Client) (string, bool, error) {
+	upgradeInProgress := false
+	clusterversionKey := "/kubernetes.io/config.openshift.io/clusterversions/version"
+	resp, err := cli.Get(context.Background(), clusterversionKey)
+	if err != nil {
+		return "", false, err
+	}
+	if len(resp.Kvs) != 1 {
+		return "", false, fmt.Errorf("Expected to get a single key from etcd, got %d", len(resp.Kvs))
+	}
+
+	var cv map[string]interface{}
+	if err := json.Unmarshal(resp.Kvs[0].Value, &cv); err != nil {
+		return "", false, err
+	}
+
+	status := cv["status"].(map[string]interface{})
+	desired := status["desired"].(map[string]interface{})
+
+	history := status["history"].([]interface{})
+	if len(history) <= 0 {
+		return "", false, fmt.Errorf("getClusterVersionAndUpgradeInfo: status has no history")
+	}
+	latestHistory := history[0].(map[string]interface{})
+	latestVersion := latestHistory["version"].(string)
+	if latestVersion == "" {
+		upgradeInProgress = true
+	} else if latestHistory["state"].(string) != "Completed" {
+		upgradeInProgress = true
+	} else if desired["version"].(string) != latestVersion {
+		upgradeInProgress = true
+	}
+	return latestVersion, upgradeInProgress, nil
+}
+
+func checkLeadership(name string) (bool, error) {
+	cli, err := getEtcdClient([]string{"localhost:2379"})
+	if err != nil {
+		return false, fmt.Errorf("checkLeadership: failed to get etcd client: %w", err)
+	}
+	defer cli.Close()
+
+	membersResp, err := cli.MemberList(context.Background())
+	if err != nil {
+		return false, err
+	}
+	for _, member := range membersResp.Members {
+		if member.Name != name {
+			continue
+		}
+		if len(member.ClientURLs) == 0 && member.Name == "" {
+			return false, fmt.Errorf("EtcdMemberNotStarted")
+		}
+
+		resp, err := cli.Status(context.Background(), member.ClientURLs[0])
+		if err != nil {
+			return false, fmt.Errorf("isLeader: error getting the status of the member %s. err=%w", member.Name, err)
+		}
+		return resp.Header.MemberId == resp.Leader, nil
+	}
+	return false, fmt.Errorf("EtcdMemberStatusUnknown")
+}
+
+func saveSnapshot(cli *clientv3.Client, dbPath string) error {
+	partpath := dbPath + ".part"
+	defer os.RemoveAll(partpath)
+
+	f, err := os.OpenFile(partpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("could not open %s (%w)", partpath, err)
+	}
+
+	opBegin := time.Now()
+	var rd io.ReadCloser
+	rd, err = cli.Snapshot(context.Background())
+	if err != nil {
+		return fmt.Errorf("saveSnapshot failed: %w", err)
+	}
+
+	if _, err := io.Copy(f, rd); err != nil {
+		return fmt.Errorf("saveSnapshot failed: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("saveSnapshot failed: %w", err)
+	}
+	klog.Info(
+		"fetched snapshot. ",
+		"Time taken: ", time.Since(opBegin),
+	)
+
+	if err := os.Rename(partpath, dbPath); err != nil {
+		return fmt.Errorf("could not rename %s to %s (%v)", partpath, dbPath, err)
+	}
+	klog.Info("saved snapshot to path", dbPath)
+	return nil
+}

--- a/pkg/cmd/rollbackcopy/fileioutils.go
+++ b/pkg/cmd/rollbackcopy/fileioutils.go
@@ -1,0 +1,183 @@
+package rollbackcopy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"k8s.io/klog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func dirExists(dirname string) (bool, error) {
+	info, err := os.Stat(dirname)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("dirExists: %s. Error=%w", dirname, err)
+	}
+	return info.IsDir(), nil
+}
+
+func safeDirRename(src, dest string, srcMayNotExist bool) error {
+	srcPresent, err := dirExists(src)
+
+	if err != nil {
+		return fmt.Errorf("safeDirRename: Unexpected error checking dir: %s. Error: %w", src, err)
+	}
+
+	if !srcPresent {
+		if !srcMayNotExist {
+			return fmt.Errorf("SafeDirRename: src dir %s does not exist", src)
+		} else {
+			return nil
+		}
+	}
+
+	destExists, err := dirExists(dest)
+	if err != nil {
+		return fmt.Errorf("safeDirRename: Unexpected error checking dir: %s. Error: %w", dest, err)
+	}
+
+	destToBeRemoved := dest + ".to_be_removed"
+	if destExists {
+		if exists, _ := dirExists(destToBeRemoved); exists {
+			if err := os.RemoveAll(destToBeRemoved); err != nil {
+				return fmt.Errorf("safeDirRename: failed to remove dir %s. Error: %w", destToBeRemoved, err)
+			}
+		}
+		if err := os.Rename(dest, destToBeRemoved); err != nil {
+			return fmt.Errorf("safeDirRename: got error renaming %s %s. Err: %w", dest, destToBeRemoved, err)
+		}
+	}
+
+	if err := os.Rename(src, dest); err != nil {
+		if destExists {
+			if err := os.Rename(destToBeRemoved, dest); err != nil {
+				klog.Errorf("safeDirRename: got error renaming %s to %s. Error: %v", destToBeRemoved, dest, err)
+			}
+		}
+		return fmt.Errorf("safeDirRename: got error renaming %s to %s. Err: %w", src, dest, err)
+	}
+
+	klog.Info("Successfully moved ", src, " to ", dest)
+
+	if err := os.RemoveAll(destToBeRemoved); err != nil {
+		klog.Errorf("safeDirRename: got error removing %s. Error: %v", destToBeRemoved, err)
+	}
+	return nil
+}
+
+func dumpDirs(dir string) error {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("DumpDirs: could not read dir %s: %w", dir, err)
+	}
+
+	klog.Infof("dumpDirs: Dumping currently saved directories in %s:", dir)
+	for _, f := range files {
+		if f.IsDir() {
+			dirname := filepath.Join(dir, f.Name())
+			if dirVersion, err := getVersion(dirname); err != nil {
+				klog.Errorf("dumpDirs: Could not dump dir %s. Error: %w", dirname, err)
+			} else {
+				klog.Infof("\t%s ClusterVersion: %s TimeStamp: %s", dirname, dirVersion.ClusterVersion, dirVersion.TimeStamp)
+			}
+		}
+	}
+	return nil
+}
+
+func findTheLatestRevision(dir, podname string) (string, error) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+
+	var modTime time.Time
+	var latest string
+	found := false
+	for _, f := range files {
+		if f.IsDir() && strings.HasPrefix(f.Name(), podname) {
+			if f.ModTime().After(modTime) {
+				modTime = f.ModTime()
+				latest = f.Name()
+				found = true
+			}
+		}
+	}
+	if !found {
+		return "", fmt.Errorf("Not found any resources for pod %s", podname)
+	}
+	return filepath.Join(dir, latest), nil
+}
+
+type backupVersion struct {
+	ClusterVersion string `json:"ClusterVersion"`
+	TimeStamp      string `json:"TimeStamp"`
+}
+
+func versionChanged(dir1, dir2 string) bool {
+	dir1Version, err := getVersion(dir1)
+	if err != nil {
+		klog.Errorf("getVersion failed on %s", dir1)
+		return false
+	}
+	dir2Version, err := getVersion(dir2)
+	if err != nil {
+		klog.Errorf("getVersion failed on %s", dir2)
+		return false
+	}
+	klog.Infof("versionCheck: Dir: %s Version: %s", dir1, dir1Version.ClusterVersion)
+	klog.Infof("versionCheck: Dir: %s Version: %s", dir2, dir2Version.ClusterVersion)
+	if dir1Version.ClusterVersion != dir2Version.ClusterVersion {
+		klog.Infof("Version changed from %s to %s", dir1Version.ClusterVersion, dir2Version.ClusterVersion)
+	}
+	return (dir1Version.ClusterVersion != dir2Version.ClusterVersion)
+}
+
+func getVersion(dir string) (*backupVersion, error) {
+	version := backupVersion{}
+	jsonFile, err := ioutil.ReadFile(filepath.Join(dir, "backupenv.json"))
+	if err != nil {
+		return nil, fmt.Errorf("getVersion failed: %w", err)
+	}
+	if err := json.Unmarshal(jsonFile, &version); err != nil {
+		return nil, fmt.Errorf("getVersion: json unmarshal error: %w", err)
+	}
+
+	return &version, nil
+}
+
+func putVersion(c *backupVersion, dir string) error {
+	confBytes, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("putVersion json marshal error: %w", err)
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "backupenv.json"), confBytes, 0644); err != nil {
+		return fmt.Errorf("putVersion: writeFile failed: %w", err)
+	}
+
+	return nil
+}
+
+func checkAndCreateDir(dirName string) error {
+	_, err := os.Stat(dirName)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("checkAndCreateDir failed: %w", err)
+	}
+	// If dirName already exists, remove it
+	if err == nil {
+		if err := os.RemoveAll(dirName); err != nil {
+			return fmt.Errorf("checkAndCreateDir failed to remove %s: %w", dirName, err)
+		}
+	}
+	if err := os.MkdirAll(dirName, os.ModePerm); err != nil {
+		return fmt.Errorf("checkAndCreateDir failed: %w", err)
+	}
+	return nil
+}

--- a/pkg/cmd/rollbackcopy/rollbackcopy.go
+++ b/pkg/cmd/rollbackcopy/rollbackcopy.go
@@ -1,0 +1,133 @@
+package rollbackcopy
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"io"
+	"k8s.io/klog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+type rollbackCopyOpts struct {
+	checkLeadershipInterval time.Duration
+	rollbackCopyInterval    time.Duration
+	configDir               string
+	errOut                  io.Writer
+}
+
+const (
+	leaderShipCheckInterval time.Duration = 5 * time.Minute
+	rollbackSaveInterval    time.Duration = 60 * time.Minute
+)
+
+func NewRollbackCopy(errOut io.Writer) *cobra.Command {
+	rollbackCopyOpts := &rollbackCopyOpts{
+		checkLeadershipInterval: leaderShipCheckInterval,
+		rollbackCopyInterval:    rollbackSaveInterval,
+		errOut:                  errOut,
+	}
+	cmd := &cobra.Command{
+		Use:   "rollbackcopy",
+		Short: "Periodically save snapshot and resources every hour, useful for a rollback",
+		Run: func(cmd *cobra.Command, args []string) {
+			must := func(fn func() error) {
+				if err := fn(); err != nil {
+					if cmd.HasParent() {
+						klog.Fatal(err)
+					}
+					fmt.Fprint(rollbackCopyOpts.errOut, err.Error())
+				}
+			}
+
+			must(rollbackCopyOpts.Run)
+		},
+	}
+	rollbackCopyOpts.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (r *rollbackCopyOpts) AddFlags(fs *pflag.FlagSet) {
+	fs.Set("logtostderr", "true")
+	fs.StringVar(&r.configDir, "config-dir", "/etc/kubernetes", "Dir containing kubernetes resources")
+}
+
+func (r *rollbackCopyOpts) Run() error {
+	localEtcdName := os.Getenv("ETCD_NAME")
+	ossignal := make(chan os.Signal, 1)
+	signal.Notify(ossignal, os.Interrupt, syscall.SIGTERM)
+
+	initial := make(chan struct{}, 1)
+	initial <- struct{}{}
+
+outerLoop:
+	for {
+		// Block until we're the leader, checking every 5 mins
+		leaderCheckTicker := time.NewTicker(r.checkLeadershipInterval)
+	leaderWait:
+		for {
+			select {
+			case <-ossignal:
+				leaderCheckTicker.Stop()
+				break outerLoop
+			case <-initial:
+				if leader, err := checkLeadership(localEtcdName); err != nil {
+					klog.Errorf("run: leadershipCheck failed %w", err)
+					continue leaderWait
+				} else if !leader {
+					klog.Info("run: member is NOT the leader.")
+					continue leaderWait
+				}
+				break leaderWait
+			case <-leaderCheckTicker.C:
+				if leader, err := checkLeadership(localEtcdName); err != nil {
+					klog.Errorf("run: leadershipCheck failed %w", err)
+					continue leaderWait
+				} else if !leader {
+					klog.Info("run: member is NOT the leader.")
+					continue leaderWait
+				}
+				break leaderWait
+			}
+		}
+
+		leaderCheckTicker.Stop()
+
+		// We are leader. Take a back up.
+		klog.Info("run: member IS the leader")
+		if err := backup(r.configDir); err != nil {
+			klog.Errorf("backup: %v", err)
+			continue outerLoop
+		}
+
+		// Try to back up every hour while we're the leader
+		backupTicker := time.NewTicker(r.rollbackCopyInterval)
+	backupLoop:
+		for {
+			select {
+			case <-ossignal:
+				backupTicker.Stop()
+				break outerLoop
+			case <-backupTicker.C:
+				if leader, err := checkLeadership(localEtcdName); err != nil {
+					klog.Errorf("run: leadershipCheck failed: %w", err)
+					break backupLoop
+				} else if !leader {
+					klog.Info("run: member is NOT the leader anymore.")
+					break backupLoop
+				}
+				klog.Info("run: member IS still the leader")
+				if err := backup(r.configDir); err != nil {
+					klog.Errorf("run: backup failed: %v", err)
+					break backupLoop
+				}
+			}
+		}
+		backupTicker.Stop()
+	}
+
+	return nil
+}

--- a/pkg/cmd/rollbackcopy/tarutils.go
+++ b/pkg/cmd/rollbackcopy/tarutils.go
@@ -1,0 +1,90 @@
+package rollbackcopy
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func createTarball(tarballFilePath string, filePaths []string, prefixTrim string) error {
+	file, err := os.OpenFile(tarballFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Could not create tarball file '%s', got error '%s'", tarballFilePath, err.Error()))
+	}
+	defer file.Close()
+
+	gzipWriter := gzip.NewWriter(file)
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	if prefixTrim != "" && !strings.HasSuffix(prefixTrim, "/") {
+		prefixTrim += "/"
+	}
+
+	for _, filePath := range filePaths {
+		err := addFileToTarWriter(filePath, tarWriter, prefixTrim)
+		if err != nil {
+			return errors.New(fmt.Sprintf("Could not add file '%s', to tarball, got error '%s'", filePath, err.Error()))
+		}
+	}
+
+	return nil
+}
+
+// Private methods
+
+func addFileToTarWriter(src string, tarWriter *tar.Writer, prefixTrim string) error {
+
+	return filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
+
+		// return on any error
+		if err != nil {
+			return fmt.Errorf("addFileToTarWriter failed: %w", err)
+		}
+
+		// return on non-regular files
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
+
+		header := &tar.Header{
+			Name:    file,
+			Size:    fi.Size(),
+			Mode:    int64(fi.Mode()),
+			ModTime: fi.ModTime(),
+		}
+
+		// update the name to correctly reflect the desired destination when untaring
+		header.Name = strings.TrimPrefix(file, prefixTrim)
+
+		// write the header
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return fmt.Errorf("addFileToTarWriter: WriteHeader failed: %w", err)
+		}
+
+		// open files for taring
+		f, err := os.Open(file)
+		if err != nil {
+			return fmt.Errorf("addFileToTarWriter: file open failed: %w", err)
+		}
+
+		// copy file data into tar writer
+		if _, err := io.Copy(tarWriter, f); err != nil {
+			return fmt.Errorf("addFileToTarWriter: file write failed: %w", err)
+		}
+
+		// manually close here after each file operation; defering would cause each file close
+		// to wait until all operations have completed.
+		f.Close()
+
+		return nil
+	})
+
+}

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -660,6 +660,34 @@ ${COMPUTED_ENV_VARS}
         name: cert-dir
       - mountPath: /var/lib/etcd/
         name: data-dir
+  - name: rollbackcopier
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command:
+      - /bin/sh
+      - -c
+      - |
+        #!/bin/sh
+        set -euo pipefail
+
+        export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
+        exec cluster-etcd-operator rollbackcopy
+    resources:
+      requests:
+        memory: 60Mi
+        cpu: 30m
+    securityContext:
+      privileged: true
+    volumeMounts:
+      - mountPath: /etc/kubernetes/rollbackcopy
+        name: rollbackcopy
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: full-resource-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
+    env:
+${COMPUTED_ENV_VARS}
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -674,6 +702,12 @@ ${COMPUTED_ENV_VARS}
     - hostPath:
         path: /etc/kubernetes/static-pod-resources/etcd-pod-REVISION
       name: resource-dir
+    - hostPath:
+        path: /etc/kubernetes/static-pod-resources
+      name: full-resource-dir
+    - hostPath:
+        path: /etc/kubernetes/rollbackcopy
+      name: rollbackcopy
     - hostPath:
         path: /etc/kubernetes/static-pod-resources/etcd-certs
       name: cert-dir


### PR DESCRIPTION
This work provides a container within the etcd pod to take periodic backups.

The immediate need for automated backups is to provide a path to upgrade from 4.4 to 4.5, with the knowledge that if the upgrade fails for some reason, there is no easy path to rollback, as the etcd version 3.4.x (used in OCP 4.5) is incompatible with the etcd version of 3.3.x (used in 4.4.x). Since restoring a backup is the safest way to rollback, it is important to have automated periodical backups to protect the users from unexpected data loss in such scenarios.


