### PR TITLE
Bug 1812570: Restart operator when metrics serving cert is modified

### DIFF
--- a/manifests/0000_12_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_06_deployment.yaml
@@ -33,6 +33,8 @@ spec:
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
         - "-v=4"
+        - "--terminate-on-files=/var/run/secrets/serving-cert/tls.crt"
+        - "--terminate-on-files=/var/run/secrets/serving-cert/tls.key"
         resources:
           requests:
             memory: 50Mi


### PR DESCRIPTION
Update the operator command so that when the metrics serving certificate or key
is modified, the operator restarts to pick up the new contents.