### PR TITLE
Defrag etcd on startup

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -10,6 +10,35 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
+    - name: defrag
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      terminationMessagePolicy: FallbackToLogsOnError
+      resources:
+        requests:
+          memory: 60Mi
+          cpu: 30m
+      volumeMounts:
+      - mountPath: /var/lib/etcd/
+        name: data-dir
+      env:
+${COMPUTED_ENV_VARS}
+      command:
+        - /bin/sh
+        - -c
+        - |
+          #!/bin/sh
+          set -euo pipefail
+
+          # Try and ensure etcd is really shut down.
+          echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
+          while [ -n "$(lsof -ni :2379)$(lsof -ni :2380)$(lsof -ni :9978)" ]; do
+            echo -n "."
+            sleep 1
+          done
+
+          echo "Defragging etcd"
+          time etcdctl defrag --data-dir /var/lib/etcd
     - name: etcd-ensure-env-vars
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
@@ -139,8 +168,7 @@ ${COMPUTED_ENV_VARS}
         # move it somewhere safe so we can retrieve it again later if something goes badly.
         mv /etc/kubernetes/manifests/etcd-member.yaml /etc/kubernetes/etcd-backup-dir || true
 
-        # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
-        # so we do the detection in etcd container itsefl.
+        # Try and ensure etcd is really shut down.
         echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
         while [ -n "$(lsof -ni :2379)$(lsof -ni :2380)$(lsof -ni :9978)" ]; do
           echo -n "."

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -449,6 +449,35 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
+    - name: defrag
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      terminationMessagePolicy: FallbackToLogsOnError
+      resources:
+        requests:
+          memory: 60Mi
+          cpu: 30m
+      volumeMounts:
+      - mountPath: /var/lib/etcd/
+        name: data-dir
+      env:
+${COMPUTED_ENV_VARS}
+      command:
+        - /bin/sh
+        - -c
+        - |
+          #!/bin/sh
+          set -euo pipefail
+
+          # Try and ensure etcd is really shut down.
+          echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
+          while [ -n "$(lsof -ni :2379)$(lsof -ni :2380)$(lsof -ni :9978)" ]; do
+            echo -n "."
+            sleep 1
+          done
+
+          echo "Defragging etcd"
+          time etcdctl defrag --data-dir /var/lib/etcd
     - name: etcd-ensure-env-vars
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
@@ -578,8 +607,7 @@ ${COMPUTED_ENV_VARS}
         # move it somewhere safe so we can retrieve it again later if something goes badly.
         mv /etc/kubernetes/manifests/etcd-member.yaml /etc/kubernetes/etcd-backup-dir || true
 
-        # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
-        # so we do the detection in etcd container itsefl.
+        # Try and ensure etcd is really shut down.
         echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
         while [ -n "$(lsof -ni :2379)$(lsof -ni :2380)$(lsof -ni :9978)" ]; do
           echo -n "."


### PR DESCRIPTION
This change introduces an etcd defrag on startup during pod init.

Performing the defrag on startup is a low risk way to establish a minimal
guarantee that defrag will occur automatically under at least one condition
(during an upgrade). This changes is not intended to replace the need for live
defrags during steady state operations.