### PR TITLE
Remove etcdDiscoveryDomain

### DIFF
--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -117,9 +117,6 @@ func (r *renderOpts) Validate() error {
 	if len(r.clusterEtcdOperatorImage) == 0 {
 		return errors.New("missing required flag: --manifest-cluster-etcd-operator-image")
 	}
-	if len(r.etcdDiscoveryDomain) == 0 {
-		return errors.New("missing required flag: --etcd-discovery-domain")
-	}
 	if len(r.clusterConfigFile) == 0 {
 		return errors.New("missing required flag: --cluster-config-file")
 	}

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -225,23 +225,17 @@ func (c *EtcdCertSignerController) createSecretForNode(node *corev1.Node, record
 		return err
 	}
 
-	// get what we're going to sign for
-	etcdDiscoveryDomain, err := c.getEtcdDiscoveryDomain()
-	if err != nil {
-		return err
-	}
 	nodeInternalIPs, err := dnshelpers.GetInternalIPAddressesForNodeName(node)
 	if err != nil {
 		return err
 	}
-	peerHostNames := append([]string{"localhost", etcdDiscoveryDomain}, nodeInternalIPs...)
+	peerHostNames := append([]string{"localhost"}, nodeInternalIPs...)
 	serverHostNames := append([]string{
 		"localhost",
 		"etcd.kube-system.svc",
 		"etcd.kube-system.svc.cluster.local",
 		"etcd.openshift-etcd.svc",
 		"etcd.openshift-etcd.svc.cluster.local",
-		"*." + etcdDiscoveryDomain,
 		"127.0.0.1",
 		"::1",
 		"0:0:0:0:0:0:0:1",
@@ -335,19 +329,6 @@ func getCommonNameFromOrg(org string) (string, error) {
 		return "etcd-metric-signer", nil
 	}
 	return "", errors.New("unable to recognise secret name")
-}
-
-func (c *EtcdCertSignerController) getEtcdDiscoveryDomain() (string, error) {
-	infrastructure, err := c.infrastructureLister.Get("cluster")
-	if err != nil {
-		return "", err
-	}
-
-	etcdDiscoveryDomain := infrastructure.Status.EtcdDiscoveryDomain
-	if len(etcdDiscoveryDomain) == 0 {
-		return "", fmt.Errorf("infrastructures.config.openshit.io/cluster missing .status.etcdDiscoveryDomain")
-	}
-	return etcdDiscoveryDomain, nil
 }
 
 func (c *EtcdCertSignerController) createSecret(secretName string, cert *bytes.Buffer, key *bytes.Buffer, recorder events.Recorder) error {


### PR DESCRIPTION
After 4.4 we no longer require DNS entries for etcd in SAN so lets clean that up.

requires https://github.com/openshift/cluster-etcd-operator/pull/381
required for https://github.com/openshift/installer/pull/3626/files
