### PR TITLE
hack: add shellcheck

### DIFF
--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eux
+
+#TODO add make support in https://github.com/openshift/build-machinery-go
+
+if [ "${IS_CONTAINER:-}" != "" ]; then
+  TOP_DIR="${1:-.}"
+  find "${TOP_DIR}" \
+    -path "${TOP_DIR}/vendor" -prune \
+    -o -type f -name '*.sh' -exec shellcheck --format=gcc {} \+
+else
+  docker run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/workdir:ro,z" \
+    --entrypoint sh \
+    --workdir /workdir \
+    koalaman/shellcheck-alpine:stable \
+    /workdir/hack/shellcheck.sh "${@}"
+fi;


### PR DESCRIPTION
I borrowed the implementation from the cluster monitor operator. With this we can add a test to CI.