### PR TITLE
Bug 1846093: Make bootstrap IP discovery backwards compatible with previous assumptions

### DIFF
--- a/pkg/cmd/render/bootstrap_ip_test.go
+++ b/pkg/cmd/render/bootstrap_ip_test.go
@@ -53,6 +53,21 @@ func TestBootstrapIPLocator(t *testing.T) {
 			exclude:  []string{"192.168.125.5"},
 			expect:   net.ParseIP("192.168.125.112"),
 		},
+		{
+			name:        "fallback to first IP",
+			machineCIDR: "192.168.125.0/24",
+			ips: newIPs(
+				"10.88.0.1",
+				"172.17.0.1",
+			),
+			addrMap: newAddrMap(
+				withDevice(0, "10.88.0.1"),
+				withDevice(1, "172.17.0.1"),
+			),
+			routeMap: map[int][]netlink.Route{},
+			exclude:  []string{},
+			expect:   net.ParseIP("10.88.0.1"),
+		},
 	}
 
 	for _, scenario := range scenarios {

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -325,6 +325,7 @@ func (t *TemplateData) setBootstrapIP(machineCIDR string, ipv6 bool, excludedIPs
 	if err != nil {
 		return err
 	}
+	klog.Infof("using bootstrap IP %s", ip.String())
 	t.BootstrapIP = ip.String()
 	return nil
 }


### PR DESCRIPTION
Before this patch, the new bootstrap IP discovery mechanism would fail bootstrapping
if no IP could be intelligently discovered. A side-effect of that is effectively
validating the machine network CIDR by asserting the bootstrap IPs ability to be
discovered within it. Because there may still be edge cases where we fail to detect
but where the old assumption to choose the "first IP" would still work, we could
introduce an undue burden to fix all existing uses of machine network CIDR even
when our fallback could continue to work in those cases.

This patch adds a fallback behavior so that when intelligent discovery fails, the
first listed IP is selected with a warning, preserving the original discovery
behavior.

This does effectively mean that clusters can still fail to bootstrap if even the
first IP assumption is wrong, but we can presumably use those failures to further
improve detection.

A worthwhile future improvement would be to find a way to more loudly and clearly
surface to the user when we're blindly guessing about the IP, as the resulting
downstream failure may obfuscate the source of failure if bootkube logs are lost.