### PR TITLE
Bug 1847878: Reduce superfluous leader change logging

### DIFF
--- a/pkg/operator/metriccontroller/fsync_controller.go
+++ b/pkg/operator/metriccontroller/fsync_controller.go
@@ -48,7 +48,7 @@ func (c *FSyncController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		return err
 	}
 	leaderChanges := etcdLeaderChangesResult.(model.Vector)[0].Value
-	klog.Infof("Etcd leader changes increase in last 5m: %s", leaderChanges)
+	klog.V(4).Infof("Etcd leader changes increase in last 5m: %s", leaderChanges)
 
 	// Do nothing if there are no leader changes
 	if leaderChanges == 0.0 {


### PR DESCRIPTION
Before this patch, leader change stats were logged at V(0) even when
the value is zero, which isn't useful. We already record an event when
the value is greater than zero.

This patch changes the leader change log to V(4) to reduce useless
log messages in the steady state while preserving the ability to enable
the log through operator configuration.