### PR TITLE
Bug 1846574: bindata/bootkube/bootstrap-manifests: add proper env to metrics container on bootstrap.

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -138,7 +138,10 @@ spec:
       mountPath: /run/etcd/
     - name: certs
       mountPath: /etc/ssl/etcd/
-    ports:
+
+    env:
+{{.ComputedEnvVars }}
+      ports:
     - name: metric
       containerPort: 9979
       protocol: TCP


### PR DESCRIPTION


Signed-off-by: Sam Batschelet <sbatsche@redhat.com>