### PR TITLE
Migrate etcd-quorum-guard from MCO.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,14 @@ $(call add-bindata,etcd,./bindata/etcd/...,bindata,etcd_assets,pkg/operator/etcd
 # See vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh for usage and configuration details
 export TP_DEPLOYMENT_YAML ?=./manifests/0000_12_etcd-operator_06_deployment.yaml
 export TP_CMD_PATH ?=./cmd/cluster-etcd-operator
+
+# This was copied from https://github.com/openshift/cluster-kube-apiserver-operator
+# Exclude e2e tests from unit testing
+GO_TEST_PACKAGES :=./pkg/... ./cmd/...
+
+test-e2e: GO_TEST_PACKAGES :=./test/e2e/...
+test-e2e: GO_TEST_FLAGS += -v
+test-e2e: GO_TEST_FLAGS += -timeout 2h
+test-e2e: GO_TEST_FLAGS += -p 1
+test-e2e: test-unit
+.PHONY: test-e2e

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131
 	github.com/openshift/client-go v0.0.0-20200521150516-05eb9880269c
 	github.com/openshift/library-go v0.0.0-20200526124911-cd27f9384ffc
+	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/common v0.6.0
 	github.com/spf13/cobra v0.0.5
@@ -19,6 +20,7 @@ require (
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
 	google.golang.org/grpc v1.26.0
 	k8s.io/api v0.18.3
+	k8s.io/apiextensions-apiserver v0.18.3
 	k8s.io/apimachinery v0.18.3
 	k8s.io/client-go v0.18.3
 	k8s.io/component-base v0.18.3

--- a/manifests/0000_12_etcd-operator_08_etcdquorumguard_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_08_etcdquorumguard_deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-quorum-guard
+  namespace: openshift-etcd
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      k8s-app: etcd-quorum-guard
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: etcd-quorum-guard
+        k8s-app: etcd-quorum-guard
+    spec:
+      hostNetwork: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values:
+                      - "etcd-quorum-guard"
+              topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      terminationGracePeriodSeconds: 3
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+          operator: Exists
+        - key: node.kubernetes.io/not-ready
+          effect: NoExecute
+          operator: Exists
+          tolerationSeconds: 120
+        - key: node.kubernetes.io/unreachable
+          effect: NoExecute
+          operator: Exists
+          tolerationSeconds: 120
+        - key: node-role.kubernetes.io/etcd
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: guard
+          image: quay.io/openshift/origin-cli:latest
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /var/run/secrets/etcd-client
+              name: etcd-client
+            - mountPath: /var/run/configmaps/etcd-ca
+              name: etcd-ca
+          command:
+            - /bin/bash
+          args:
+            - -c
+            - |
+              # properly handle TERM and exit as soon as it is signaled
+              set -euo pipefail
+              trap 'jobs -p | xargs -r kill; exit 0' TERM
+              sleep infinity & wait
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  declare -r health_endpoint="https://localhost:2379/health"
+                  declare -r cert="/var/run/secrets/etcd-client/tls.crt"
+                  declare -r key="/var/run/secrets/etcd-client/tls.key"
+                  declare -r cacert="/var/run/configmaps/etcd-ca/ca-bundle.crt"
+                  export NSS_SDB_USE_CACHE=no
+                  [[ -z $cert || -z $key ]] && exit 1
+                  curl --max-time 2 --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 5Mi
+          securityContext:
+            privileged: true
+      volumes:
+        - name: etcd-client
+          secret:
+            secretName: etcd-client
+        - name: etcd-ca
+          configMap:
+            name: etcd-ca-bundle

--- a/manifests/0000_12_etcd-operator_09_etcdquorumguard_pdb.yaml
+++ b/manifests/0000_12_etcd-operator_09_etcdquorumguard_pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  namespace: openshift-etcd
+  name: etcd-quorum-guard
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: etcd-quorum-guard

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,3 +10,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-etcd
+  - name: cli
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-cli:latest

--- a/test/e2e/etcquorumguard_test.go
+++ b/test/e2e/etcquorumguard_test.go
@@ -1,0 +1,272 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/cluster-etcd-operator/test/e2e/framework"
+	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type podstatus struct {
+	node   string
+	status corev1.PodPhase
+}
+
+var nodes = make(map[string]bool)
+var pods = make(map[string]podstatus)
+
+// TestEtcdQuorumGuard tests the etcd Quorum Guard.  It assumes there
+// are exactly three master pods (as does the etcd Quorum Guard at
+// present).  The test first makes one node unschedulable and evicts
+// the EQG pod from it, ensuring that eviction succeeds.  The test
+// next makes a second node unschedulable and then attempts to evict
+// the EQG pod from it.  It checks that the pod is *not* evicted.  It
+// then makes all nodes schedulable and checks that the EQG pod is
+// present/restarted on all masters.  It then makes one node
+// unschedulable again and checks that the EQG pod is evicted.
+func TestEtcdQuorumGuard(t *testing.T) {
+	cs := framework.NewClientSet("")
+	if err := waitForEtcdQuorumGuardDeployment(cs); err != nil {
+		t.Fatalf("etcdQuorumGuard deployment not present: %s", err.Error())
+	}
+	fmt.Print("Make all schedulable\n")
+	if err := makeAllNodesSchedulable(cs); err != nil {
+		t.Errorf("Unable to make all nodes schedulable: %s", err.Error())
+	}
+	fmt.Print("Check for all running\n")
+	if err := waitForPods(cs, 3, 3, 3); err != nil {
+		t.Errorf("Unable to get all etcd-quorum-guard pods running: %s", err.Error())
+	}
+	fmt.Print("Make one unschedulable\n")
+	if err := makeOneNodeUnschedulableAndEvict(cs); err != nil {
+		t.Errorf("Unable to make one node unschedulable: %s", err.Error())
+	}
+	fmt.Print("Wait for 2 running\n")
+	if err := waitForPods(cs, 3, 2, 2); err != nil {
+		t.Errorf("Unable to get one etcd-quorum-guard pod stopped: %s", err.Error())
+	}
+	fmt.Print("Make second unschedulable\n")
+	if err := makeOneNodeUnschedulableAndEvict(cs); err == nil || !strings.Contains(err.Error(), "it would violate the pod's disruption budget") {
+		fmt.Print("  Pod should not have been evicted\n")
+		t.Errorf("Pod should not have been evicted because it violated disruption budget: %v", err)
+	} else {
+		fmt.Print("  Eviction correctly failed because it would violate the pod's disruption budget.\n")
+	}
+	fmt.Print("Make all schedulable\n")
+	if err := makeAllNodesSchedulable(cs); err != nil {
+		t.Errorf("Unable to make all nodes schedulable: %s", err.Error())
+	}
+	fmt.Print("Wait for all running\n")
+	if err := waitForPods(cs, 3, 3, 3); err != nil {
+		t.Errorf("Unable to get all etcd-quorum-guard pods running: %s", err.Error())
+	}
+	fmt.Print("Make one unschedulable\n")
+	if err := makeOneNodeUnschedulableAndEvict(cs); err != nil {
+		t.Errorf("Unable to make one node unschedulable: %s", err.Error())
+	}
+	fmt.Print("Wait for one not running\n")
+	if err := waitForPods(cs, 3, 2, 2); err != nil {
+		t.Errorf("Unable to get one etcd-quorum-guard pod stopped: %s", err.Error())
+	}
+	fmt.Print("Make all schedulable\n")
+	if err := makeAllNodesSchedulable(cs); err != nil {
+		t.Errorf("Unable to make all nodes schedulable: %s", err.Error())
+	}
+	fmt.Print("Wait for all\n")
+	if err := waitForPods(cs, 3, 3, 3); err != nil {
+		t.Errorf("Unable to get all etcd-quorum-guard pods running: %s", err.Error())
+	}
+}
+
+func makeNodeUnSchedulableOrSchedulable(cs *framework.ClientSet, node string, unschedulable bool) error {
+	prefix := ""
+	if unschedulable {
+		prefix = "un"
+	}
+	for {
+		n, err := getNode(cs, node)
+		if err != nil {
+			return err
+		}
+		if n.Spec.Unschedulable == unschedulable {
+			fmt.Printf("  Node %s is already %sschedulable\n", node, prefix)
+			return nil
+		}
+		n.Spec.Unschedulable = unschedulable
+		if _, err := cs.CoreV1Interface.Nodes().Update(context.TODO(), n, metav1.UpdateOptions{}); err != nil {
+			if strings.Contains(err.Error(), "the object has been modified") {
+				fmt.Print("    Node object was modified and not up to date; retrying\n")
+				continue
+			}
+			return errors.Wrapf(err, "failed to make node %s %sschedulable", node, prefix)
+		}
+		break
+	}
+	return wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+		if err := getMasterNodes(cs); err != nil {
+			fmt.Printf("Error getting master nodes: %s\n", err.Error())
+			return true, err
+		}
+		n, err := getNode(cs, node)
+		if err != nil {
+			fmt.Printf("Error getting node status for %s: %s\n", node, err.Error())
+			return true, err
+		}
+		if n.Spec.Unschedulable == unschedulable {
+			return true, nil
+		}
+		fmt.Printf("Node %s not yet %sschedulable\n", node, prefix)
+		return false, nil
+	})
+}
+
+func makeAllNodesSchedulable(cs *framework.ClientSet) error {
+	if err := getMasterNodes(cs); err != nil {
+		fmt.Printf("Error getting master nodes %s\n", err.Error())
+		return err
+	}
+	for node, unschedulable := range nodes {
+		if unschedulable {
+			err := makeNodeUnSchedulableOrSchedulable(cs, node, false)
+			if err != nil {
+				return err
+			}
+			nodes[node] = false
+		}
+	}
+	return getMasterNodes(cs)
+}
+
+func evictEtcdQuotaGuardPodsFromNode(cs *framework.ClientSet, node string) error {
+	pods, err := getEtcdQuotaGuardPodsOnNode(cs, node)
+	if err != nil {
+		return err
+	}
+	var podErrs []error
+	for _, pod := range pods {
+		fmt.Printf("  Evicting pod %s/%s/%s...\n", node, pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
+		err = cs.CoreV1Interface.Pods(pod.ObjectMeta.Namespace).Evict(context.TODO(), &policyv1beta1.Eviction{TypeMeta: metav1.TypeMeta{}, ObjectMeta: pod.ObjectMeta, DeleteOptions: &metav1.DeleteOptions{}})
+		if err != nil {
+			podErrs = append(podErrs, errors.Wrapf(err, "Unable to evict pod %s/%s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name))
+		}
+	}
+	return utilerrors.NewAggregate(podErrs)
+}
+
+// makeOneNodeUnschedulableAndEvict attempts to evict the etcd Quorum
+// Guard pod from a node after making it unschedulable.
+func makeOneNodeUnschedulableAndEvict(cs *framework.ClientSet) error {
+	var err error
+	for node, unschedulable := range nodes {
+		if !unschedulable {
+			err = makeNodeUnSchedulableOrSchedulable(cs, node, true)
+			if err != nil {
+				fmt.Printf("    Make %s unschedulable failed: %s\n", node, err.Error())
+				break
+			}
+			nodes[node] = true
+			err = evictEtcdQuotaGuardPodsFromNode(cs, node)
+			break
+		}
+	}
+	// Always update the list of master nodes regardless of whether there
+	// was an earlier error.  If there was an earlier error, return that;
+	// otherwise return any error that getMasterNodes() produced.
+	err1 := getMasterNodes(cs)
+	if err != nil {
+		return err
+	}
+	return err1
+
+}
+
+func getNode(cs *framework.ClientSet, node string) (*corev1.Node, error) {
+	return cs.CoreV1Interface.Nodes().Get(context.TODO(), node, metav1.GetOptions{})
+}
+
+func waitForEtcdQuorumGuardDeployment(cs *framework.ClientSet) error {
+	err := wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+		_, err := cs.AppsV1Interface.Deployments("openshift-etcd").Get(context.TODO(), "etcd-quorum-guard", metav1.GetOptions{})
+		if err == nil {
+			return true, nil
+		}
+		fmt.Printf("  error waiting for etcd-quorum-guard deployment to exist: %v\n", err)
+		return false, nil
+	})
+	return err
+}
+
+// waitForPods waits for the expected number of etcd Quorum Guard pods
+// to be present and for the number of available pods to be within the
+// specified bounds.
+func waitForPods(cs *framework.ClientSet, expectedTotal, min, max int32) error {
+	err := wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+		d, err := cs.AppsV1Interface.Deployments("openshift-etcd").Get(context.TODO(), "etcd-quorum-guard", metav1.GetOptions{})
+		if err != nil {
+			// By this point the deployment should exist.
+			fmt.Printf("  error waiting for etcd-quorum-guard deployment to exist: %v\n", err)
+			return true, err
+		}
+		if d.Status.Replicas < 1 {
+			fmt.Println("operator deployment has no replicas")
+			return false, nil
+		}
+		if d.Status.Replicas == expectedTotal &&
+			d.Status.AvailableReplicas >= min &&
+			d.Status.AvailableReplicas <= max {
+			fmt.Printf("  Deployment is ready! %d %d\n", d.Status.Replicas, d.Status.AvailableReplicas)
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	for pod, info := range pods {
+		if info.status == "Running" {
+			node := info.node
+			if node == "" {
+				return fmt.Errorf("Pod %s not associated with a node", pod)
+			}
+			if _, ok := nodes[node]; !ok {
+				return fmt.Errorf("pod %s running on %s, not a master", pod, node)
+			}
+		}
+	}
+	return nil
+}
+
+func getMasterNodes(cs *framework.ClientSet) error {
+	n, err := cs.CoreV1Interface.Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/master="})
+	if err != nil {
+		return err
+	}
+	for _, no := range n.Items {
+		nodes[no.ObjectMeta.Name] = no.Spec.Unschedulable
+	}
+	return nil
+}
+
+func getEtcdQuotaGuardPodsOnNode(cs *framework.ClientSet, node string) ([]corev1.Pod, error) {
+	_, err := getNode(cs, node)
+	var answer []corev1.Pod
+	if err != nil {
+		return answer, fmt.Errorf("No such node %s", node)
+	}
+	p, err := cs.CoreV1Interface.Pods("openshift-etcd").List(context.TODO(), metav1.ListOptions{LabelSelector: "name=etcd-quorum-guard"})
+	for _, pod := range p.Items {
+		if pod.Spec.NodeName == node {
+			answer = append(answer, pod)
+		}
+	}
+	return answer, nil
+}

--- a/test/e2e/framework/clientset.go
+++ b/test/e2e/framework/clientset.go
@@ -1,0 +1,49 @@
+package framework
+
+import (
+	"os"
+
+	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	clientapiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+)
+
+type ClientSet struct {
+	corev1client.CoreV1Interface
+	appsv1client.AppsV1Interface
+	clientconfigv1.ConfigV1Interface
+	clientapiextensionsv1beta1.ApiextensionsV1beta1Interface
+}
+
+// NewClientSet returns a *ClientBuilder with the given kubeconfig.
+func NewClientSet(kubeconfig string) *ClientSet {
+	var config *rest.Config
+	var err error
+
+	if kubeconfig == "" {
+		kubeconfig = os.Getenv("KUBECONFIG")
+	}
+
+	if kubeconfig != "" {
+		klog.V(4).Infof("Loading kube client config from path %q", kubeconfig)
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else {
+		klog.V(4).Infof("Using in-cluster kube client config")
+		config, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		panic(err)
+	}
+
+	clientSet := &ClientSet{}
+	clientSet.CoreV1Interface = corev1client.NewForConfigOrDie(config)
+	clientSet.ConfigV1Interface = clientconfigv1.NewForConfigOrDie(config)
+	clientSet.ApiextensionsV1beta1Interface = clientapiextensionsv1beta1.NewForConfigOrDie(config)
+	clientSet.AppsV1Interface = appsv1client.NewForConfigOrDie(config)
+
+	return clientSet
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,10 @@
+package e2e_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Migrating the quorum guard from machine-config-operator. 

Note that the TLS certs come from secrets and configmaps, instead of files from the host (MCO was using files on disk).