### PR TITLE
bindata/etcd: remove MCO dependency for ca.crt

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -64,6 +64,7 @@ ${COMPUTED_ENV_VARS}
 
           cp /etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt /etc/kubernetes/etcd-backup-dir/system:etcd-peer-NODE_NAME.crt
           cp /etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key /etc/kubernetes/etcd-backup-dir/system:etcd-peer-NODE_NAME.key
+          cp /etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt /etc/kubernetes/etcd-backup-dir/ca.crt
           rm -f $(grep -l '^### Created by cluster-etcd-operator' /usr/local/bin/*)
           cp -p /etc/kubernetes/static-pod-certs/configmaps/etcd-scripts/*.sh /usr/local/bin
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -503,6 +503,7 @@ ${COMPUTED_ENV_VARS}
 
           cp /etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt /etc/kubernetes/etcd-backup-dir/system:etcd-peer-NODE_NAME.crt
           cp /etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key /etc/kubernetes/etcd-backup-dir/system:etcd-peer-NODE_NAME.key
+          cp /etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt /etc/kubernetes/etcd-backup-dir/ca.crt
           rm -f $(grep -l '^### Created by cluster-etcd-operator' /usr/local/bin/*)
           cp -p /etc/kubernetes/static-pod-certs/configmaps/etcd-scripts/*.sh /usr/local/bin
 


### PR DESCRIPTION
This change is intended to replace the existing CA on disk by MCO. If this goes right we can essentially remove all of the MCO related bits that populated the CA from MCO end.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>