### PR TITLE
manifests: add operand to co

### DIFF
--- a/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
+++ b/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
@@ -9,6 +9,8 @@ status:
   versions:
   - name: operator
     version: "0.0.1-snapshot"
+  - name: etcd
+    version: "0.0.1-snapshot"
   relatedObjects:
     - group: operator.openshift.io
       name: cluster


### PR DESCRIPTION
I am curious why we would not do this.

I am wondering if it is possibly related to https://github.com/openshift/installer/pull/3626#issuecomment-664773438

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>