### PR TITLE
Render bootstrap certificates

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -6,58 +6,6 @@ metadata:
   labels:
     k8s-app: etcd
 spec:
-  initContainers:
-  - name: certs
-    image: "{{.Images.KubeClientAgent}}"
-    command:
-    - /bin/sh
-    - -c
-    - |
-      #!/bin/sh
-      set -euxo pipefail
-
-      [ -e /etc/ssl/etcd/system:etcd-server:{{ .Hostname }}.crt -a \
-        -e /etc/ssl/etcd/system:etcd-server:{{ .Hostname }}.key ] || \
-        kube-client-agent \
-          request \
-            --kubeconfig=/etc/kubernetes/kubeconfig \
-            --orgname=system:etcd-servers \
-            --assetsdir=/etc/ssl/etcd \
-            --dnsnames={{.EtcdServerCertDNSNames}} \
-            --commonname=system:etcd-server:{{ .Hostname }} \
-            --ipaddrs={{ .EtcdAddress.EscapedBootstrapIP }},{{ .EtcdAddress.LocalHost }} \
-
-      [ -e /etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.crt -a \
-        -e /etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.key ] || \
-        kube-client-agent \
-          request \
-            --kubeconfig=/etc/kubernetes/kubeconfig \
-            --orgname=system:etcd-peers \
-            --assetsdir=/etc/ssl/etcd \
-            --dnsnames={{.EtcdPeerCertDNSNames}} \
-            --commonname=system:etcd-peer:{{ .Hostname }} \
-            --ipaddrs={{ .EtcdAddress.EscapedBootstrapIP }} \
-
-      [ -e /etc/ssl/etcd/system:etcd-metric:{{ .Hostname }}.crt -a \
-        -e /etc/ssl/etcd/system:etcd-metric:{{ .Hostname }}.key ] || \
-        kube-client-agent \
-          request \
-            --kubeconfig=/etc/kubernetes/kubeconfig \
-            --orgname=system:etcd-metrics \
-            --assetsdir=/etc/ssl/etcd \
-            --dnsnames={{.EtcdServerCertDNSNames}} \
-            --commonname=system:etcd-metric:{{ .Hostname }} \
-            --ipaddrs={{ .EtcdAddress.EscapedBootstrapIP }} \
-    terminationMessagePolicy: FallbackToLogsOnError
-    securityContext:
-      privileged: true
-    volumeMounts:
-    - name: discovery
-      mountPath: /run/etcd/
-    - name: certs
-      mountPath: /etc/ssl/etcd/
-    - name: kubeconfig
-      mountPath: /etc/kubernetes/kubeconfig
   containers:
   - name: etcd-member
     image: {{ .Images.Etcd }}
@@ -70,13 +18,13 @@ spec:
 
       exec etcd \
         --initial-advertise-peer-urls=https://{{ .EtcdAddress.EscapedBootstrapIP }}:2380 \
-        --cert-file=/etc/ssl/etcd/system:etcd-server:{{ .Hostname }}.crt \
-        --key-file=/etc/ssl/etcd/system:etcd-server:{{ .Hostname }}.key \
-        --trusted-ca-file=/etc/ssl/etcd/ca.crt \
+        --cert-file=/etc/ssl/etcd/etcd-all-serving/etcd-serving-{{ .Hostname }}.crt \
+        --key-file=/etc/ssl/etcd/etcd-all-serving/etcd-serving-{{ .Hostname }}.key \
+        --trusted-ca-file=/etc/openshift-tls/etcd-ca-bundle.crt \
         --client-cert-auth=true \
-        --peer-cert-file=/etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.crt \
-        --peer-key-file=/etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.key \
-        --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
+        --peer-cert-file=/etc/ssl/etcd/etcd-all-peer/etcd-peer-{{ .Hostname }}.crt \
+        --peer-key-file=/etc/ssl/etcd/etcd-all-peer/etcd-peer-{{ .Hostname }}.key \
+        --peer-trusted-ca-file=/etc/openshift-tls/etcd-ca-bundle.crt \
         --peer-client-cert-auth=true \
         --advertise-client-urls=https://{{ .EtcdAddress.EscapedBootstrapIP }}:2379 \
         --listen-client-urls=https://{{ .EtcdAddress.ListenClient }} \
@@ -94,6 +42,8 @@ spec:
       mountPath: /run/etcd/
     - name: certs
       mountPath: /etc/ssl/etcd/
+    - name: openshift-tls
+      mountPath: /etc/openshift-tls
     - name: data-dir
       mountPath: /var/lib/etcd/
     - name: conf
@@ -108,49 +58,20 @@ spec:
     - name: server
       containerPort: 2379
       protocol: TCP
-  - name: etcd-metrics
-    image: {{ .Images.Etcd }}
-    command:
-    - /bin/sh
-    - -c
-    - |
-      #!/bin/sh
-      set -euo pipefail
-
-      exec etcd grpc-proxy start \
-        --endpoints https://{{ .EtcdAddress.EscapedBootstrapIP }}:9978 \
-        --metrics-addr https://{{ .EtcdAddress.ListenMetricProxy }}\
-        --listen-addr {{ .EtcdAddress.LocalHost }}:9977 \
-        --key /etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.key \
-        --key-file /etc/ssl/etcd/system:etcd-metric:{{ .Hostname }}.key \
-        --cert /etc/ssl/etcd/system:etcd-peer:{{ .Hostname }}.crt \
-        --cert-file /etc/ssl/etcd/system:etcd-metric:{{ .Hostname }}.crt \
-        --cacert /etc/ssl/etcd/ca.crt \
-        --trusted-ca-file /etc/ssl/etcd/metric-ca.crt \
-    resources:
-      requests:
-        cpu: 5m
-    terminationMessagePolicy: FallbackToLogsOnError
-    securityContext:
-      privileged: true
-    volumeMounts:
-    - name: discovery
-      mountPath: /run/etcd/
-    - name: certs
-      mountPath: /etc/ssl/etcd/
-    ports:
-    - name: metric
-      containerPort: 9979
-      protocol: TCP
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"
   restartPolicy: Always
   volumes:
+  # TODO: update installer to copy the certs into /etc/kubernetes/static-pod-resources/etcd-member
   - name: certs
     hostPath:
-      path: /etc/kubernetes/static-pod-resources/etcd-member
+      path: /opt/openshift/etcd-bootstrap/bootstrap-manifests/secrets
+  # TODO: update installer to copy the ca into /etc/kubernetes/static-pod-resources/etcd-member
+  - name: openshift-tls
+    hostPath:
+      path: /opt/openshift/tls
   - name: kubeconfig
     hostPath:
       path: /etc/kubernetes/kubeconfig

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -2,12 +2,19 @@ package render
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"io"
 	"io/ioutil"
+	"math/big"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/render/options"
 )
@@ -243,6 +250,56 @@ func testRender(tc *testConfig) {
 		tc.t.Fatal(err)
 	}
 
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2020),
+		Subject: pkix.Name{
+			Organization: []string{"Red Hat"},
+			Country:      []string{"US"},
+			Province:     []string{""},
+			Locality:     []string{"Raleigh"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		tc.t.Fatal(err)
+	}
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		tc.t.Fatal(err)
+	}
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+	caPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(caPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+	})
+	caFile, err := ioutil.TempFile(dir, "etcd-ca.crt")
+	if err != nil {
+		tc.t.Fatal(err)
+	}
+	defer caFile.Close()
+	if err := writeFile(caPEM.String(), caFile); err != nil {
+		tc.t.Fatal(err)
+	}
+	keyFile, err := ioutil.TempFile(dir, "etcd-ca.key")
+	if err != nil {
+		tc.t.Fatal(err)
+	}
+	defer keyFile.Close()
+	if err := writeFile(caPrivKeyPEM.String(), keyFile); err != nil {
+		tc.t.Fatal(err)
+	}
+
 	generic := options.GenericOptions{
 		AssetInputDir:    dir,
 		AssetOutputDir:   dir,
@@ -257,6 +314,8 @@ func testRender(tc *testConfig) {
 		networkConfigFile:    clusterConfigFile.Name(),
 		infraConfigFile:      infraConfigFile.Name(),
 		clusterConfigMapFile: clusterConfigMapFile.Name(),
+		etcdCAFile:           caFile.Name(),
+		etcdCAKeyFile:        keyFile.Name(),
 	}
 
 	if err := render.Run(); err != nil {

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -3,18 +3,12 @@ package etcdcertsigner
 import (
 	"bytes"
 	"context"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"errors"
-	"fmt"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -23,20 +17,13 @@ import (
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/dnshelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
-)
-
-const (
-	EtcdCertValidity = 3 * 365 * 24 * time.Hour
-	peerOrg          = "system:etcd-peers"
-	serverOrg        = "system:etcd-servers"
-	metricOrg        = "system:etcd-metrics"
+	"github.com/openshift/cluster-etcd-operator/pkg/tlshelpers"
 )
 
 type EtcdCertSignerController struct {
@@ -127,43 +114,47 @@ func (c *EtcdCertSignerController) syncAllMasters(recorder events.Recorder) erro
 
 	// build the combined secrets that we're going to install
 	combinedPeerSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Namespace: operatorclient.TargetNamespace, Name: "etcd-all-peer"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: operatorclient.TargetNamespace, Name: tlshelpers.EtcdAllPeerSecretName},
 		Type:       corev1.SecretTypeOpaque,
 		Data:       map[string][]byte{},
 	}
 	combinedServingSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Namespace: operatorclient.TargetNamespace, Name: "etcd-all-serving"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: operatorclient.TargetNamespace, Name: tlshelpers.EtcdAllServingSecretName},
 		Type:       corev1.SecretTypeOpaque,
 		Data:       map[string][]byte{},
 	}
 	combinedServingMetricsSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Namespace: operatorclient.TargetNamespace, Name: "etcd-all-serving-metrics"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: operatorclient.TargetNamespace, Name: tlshelpers.EtcdAllServingMetricsSecretName},
 		Type:       corev1.SecretTypeOpaque,
 		Data:       map[string][]byte{},
 	}
 	for _, node := range nodes {
-		currPeer, err := c.secretLister.Secrets(operatorclient.TargetNamespace).Get(getPeerClientSecretNameForNode(node))
+		peerSecretName := tlshelpers.GetPeerClientSecretNameForNode(node.Name)
+		servingSecretName := tlshelpers.GetServingSecretNameForNode(node.Name)
+		servingMetricsSecretName := tlshelpers.GetServingMetricsSecretNameForNode(node.Name)
+
+		currPeer, err := c.secretLister.Secrets(operatorclient.TargetNamespace).Get(peerSecretName)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
-			combinedPeerSecret.Data[getPeerClientSecretNameForNode(node)+".crt"] = currPeer.Data["tls.crt"]
-			combinedPeerSecret.Data[getPeerClientSecretNameForNode(node)+".key"] = currPeer.Data["tls.key"]
+			combinedPeerSecret.Data[peerSecretName+".crt"] = currPeer.Data["tls.crt"]
+			combinedPeerSecret.Data[peerSecretName+".key"] = currPeer.Data["tls.key"]
 		}
 
-		currServing, err := c.secretLister.Secrets(operatorclient.TargetNamespace).Get(getServingSecretNameForNode(node))
+		currServing, err := c.secretLister.Secrets(operatorclient.TargetNamespace).Get(servingSecretName)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
-			combinedServingSecret.Data[getServingSecretNameForNode(node)+".crt"] = currServing.Data["tls.crt"]
-			combinedServingSecret.Data[getServingSecretNameForNode(node)+".key"] = currServing.Data["tls.key"]
+			combinedServingSecret.Data[servingSecretName+".crt"] = currServing.Data["tls.crt"]
+			combinedServingSecret.Data[servingSecretName+".key"] = currServing.Data["tls.key"]
 		}
 
-		currServingMetrics, err := c.secretLister.Secrets(operatorclient.TargetNamespace).Get(getServingMetricsSecretNameForNode(node))
+		currServingMetrics, err := c.secretLister.Secrets(operatorclient.TargetNamespace).Get(servingMetricsSecretName)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
-			combinedServingMetricsSecret.Data[getServingMetricsSecretNameForNode(node)+".crt"] = currServingMetrics.Data["tls.crt"]
-			combinedServingMetricsSecret.Data[getServingMetricsSecretNameForNode(node)+".key"] = currServingMetrics.Data["tls.key"]
+			combinedServingMetricsSecret.Data[servingMetricsSecretName+".crt"] = currServingMetrics.Data["tls.crt"]
+			combinedServingMetricsSecret.Data[servingMetricsSecretName+".key"] = currServingMetrics.Data["tls.key"]
 		}
 	}
 	if len(errs) > 0 {
@@ -187,20 +178,10 @@ func (c *EtcdCertSignerController) syncAllMasters(recorder events.Recorder) erro
 	return utilerrors.NewAggregate(errs)
 }
 
-func getPeerClientSecretNameForNode(node *corev1.Node) string {
-	return fmt.Sprintf("etcd-peer-%s", node.Name)
-}
-func getServingSecretNameForNode(node *corev1.Node) string {
-	return fmt.Sprintf("etcd-serving-%s", node.Name)
-}
-func getServingMetricsSecretNameForNode(node *corev1.Node) string {
-	return fmt.Sprintf("etcd-serving-metrics-%s", node.Name)
-}
-
 func (c *EtcdCertSignerController) createSecretForNode(node *corev1.Node, recorder events.Recorder) error {
-	etcdPeerClientCertName := getPeerClientSecretNameForNode(node)
-	etcdServingCertName := getServingSecretNameForNode(node)
-	metricsServingCertName := getServingMetricsSecretNameForNode(node)
+	etcdPeerClientCertName := tlshelpers.GetPeerClientSecretNameForNode(node.Name)
+	etcdServingCertName := tlshelpers.GetServingSecretNameForNode(node.Name)
+	metricsServingCertName := tlshelpers.GetServingMetricsSecretNameForNode(node.Name)
 
 	var err error
 	_, err = c.secretLister.Secrets(operatorclient.TargetNamespace).Get(etcdPeerClientCertName)
@@ -229,106 +210,25 @@ func (c *EtcdCertSignerController) createSecretForNode(node *corev1.Node, record
 	if err != nil {
 		return err
 	}
-	peerHostNames := append([]string{"localhost"}, nodeInternalIPs...)
-	serverHostNames := append([]string{
-		"localhost",
-		"etcd.kube-system.svc",
-		"etcd.kube-system.svc.cluster.local",
-		"etcd.openshift-etcd.svc",
-		"etcd.openshift-etcd.svc.cluster.local",
-		"127.0.0.1",
-		"::1",
-		"0:0:0:0:0:0:0:1",
-	}, nodeInternalIPs...)
-	// TODO debt left for @hexfusion or @sanchezl
-	fakePodFQDN := "etcd-client"
 
 	// create the certificates and update them in the API
-	pCert, pKey, err := createNewCombinedClientAndServingCerts(etcdCASecret.Data["tls.crt"], etcdCASecret.Data["tls.key"], fakePodFQDN, peerOrg, peerHostNames)
+	pCert, pKey, err := tlshelpers.CreatePeerCertKey(etcdCASecret.Data["tls.crt"], etcdCASecret.Data["tls.key"], nodeInternalIPs)
 	err = c.createSecret(etcdPeerClientCertName, pCert, pKey, recorder)
 	if err != nil {
 		return err
 	}
-	sCert, sKey, err := createNewCombinedClientAndServingCerts(etcdCASecret.Data["tls.crt"], etcdCASecret.Data["tls.key"], fakePodFQDN, serverOrg, serverHostNames)
+	sCert, sKey, err := tlshelpers.CreateServerCertKey(etcdCASecret.Data["tls.crt"], etcdCASecret.Data["tls.key"], nodeInternalIPs)
 	err = c.createSecret(etcdServingCertName, sCert, sKey, recorder)
 	if err != nil {
 		return err
 	}
-	metricCert, metricKey, err := createNewCombinedClientAndServingCerts(etcdMetricCASecret.Data["tls.crt"], etcdMetricCASecret.Data["tls.key"], fakePodFQDN, metricOrg, serverHostNames)
+	metricCert, metricKey, err := tlshelpers.CreateMetricCertKey(etcdMetricCASecret.Data["tls.crt"], etcdMetricCASecret.Data["tls.key"], nodeInternalIPs)
 	err = c.createSecret(metricsServingCertName, metricCert, metricKey, recorder)
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func createNewCombinedClientAndServingCerts(caCert, caKey []byte, podFQDN, org string, peerHostNames []string) (*bytes.Buffer, *bytes.Buffer, error) {
-	cn, err := getCommonNameFromOrg(org)
-	etcdCAKeyPair, err := crypto.GetCAFromBytes(caCert, caKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	certConfig, err := etcdCAKeyPair.MakeServerCertForDuration(sets.NewString(peerHostNames...), EtcdCertValidity, func(cert *x509.Certificate) error {
-
-		cert.Issuer = pkix.Name{
-			OrganizationalUnit: []string{"openshift"},
-			CommonName:         cn,
-		}
-		cert.Subject = pkix.Name{
-			Organization: []string{org},
-			CommonName:   strings.TrimSuffix(org, "s") + ":" + podFQDN,
-		}
-		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
-
-		// TODO: Extended Key Usage:
-		// All profiles expect a x509.ExtKeyUsageCodeSigning set on extended Key Usages
-		// need to investigage: https://github.com/etcd-io/etcd/issues/9398#issuecomment-435340312
-		// TODO: some extensions are missing form cfssl.
-		// e.g.
-		//	X509v3 Subject Key Identifier:
-		//		B7:30:0B:CF:47:4E:21:AE:13:60:74:42:B0:D9:C4:F3:26:69:63:03
-		//	X509v3 Authority Key Identifier:
-		//		keyid:9B:C0:6B:0C:8E:5C:73:6A:83:B1:E4:54:97:D3:62:18:8A:9C:BC:1E
-		// TODO: Change serial number logic, to something as follows.
-		// The following is taken from CFSSL library.
-		// If CFSSL is providing the serial numbers, it makes
-		// sense to use the max supported size.
-
-		//	serialNumber := make([]byte, 20)
-		//	_, err = io.ReadFull(rand.Reader, serialNumber)
-		//	if err != nil {
-		//		return err
-		//	}
-		//
-		//	// SetBytes interprets buf as the bytes of a big-endian
-		//	// unsigned integer. The leading byte should be masked
-		//	// off to ensure it isn't negative.
-		//	serialNumber[0] &= 0x7F
-		//	cert.SerialNumber = new(big.Int).SetBytes(serialNumber)
-		return nil
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	certBytes := &bytes.Buffer{}
-	keyBytes := &bytes.Buffer{}
-	if err := certConfig.WriteCertConfig(certBytes, keyBytes); err != nil {
-		return nil, nil, err
-	}
-	return certBytes, keyBytes, nil
-}
-
-func getCommonNameFromOrg(org string) (string, error) {
-	if strings.Contains(org, "peer") || strings.Contains(org, "server") {
-		return "etcd-signer", nil
-	}
-	if strings.Contains(org, "metric") {
-		return "etcd-metric-signer", nil
-	}
-	return "", errors.New("unable to recognise secret name")
 }
 
 func (c *EtcdCertSignerController) createSecret(secretName string, cert *bytes.Buffer, key *bytes.Buffer, recorder events.Recorder) error {

--- a/pkg/tlshelpers/tlshelpers.go
+++ b/pkg/tlshelpers/tlshelpers.go
@@ -1,0 +1,137 @@
+package tlshelpers
+
+import (
+	"bytes"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+const (
+	etcdCertValidity = 3 * 365 * 24 * time.Hour
+
+	peerOrg   = "system:etcd-peers"
+	serverOrg = "system:etcd-servers"
+	metricOrg = "system:etcd-metrics"
+
+	// TODO debt left for @hexfusion or @sanchezl
+	fakePodFQDN = "etcd-client"
+
+	EtcdAllPeerSecretName           = "etcd-all-peer"
+	EtcdAllServingSecretName        = "etcd-all-serving"
+	EtcdAllServingMetricsSecretName = "etcd-all-serving-metrics"
+)
+
+func GetPeerClientSecretNameForNode(nodeName string) string {
+	return fmt.Sprintf("etcd-peer-%s", nodeName)
+}
+func GetServingSecretNameForNode(nodeName string) string {
+	return fmt.Sprintf("etcd-serving-%s", nodeName)
+}
+func GetServingMetricsSecretNameForNode(nodeName string) string {
+	return fmt.Sprintf("etcd-serving-metrics-%s", nodeName)
+}
+
+func getPeerHostNames(nodeInternalIPs []string) []string {
+	return append([]string{"localhost"}, nodeInternalIPs...)
+}
+
+func getServerHostNames(nodeInternalIPs []string) []string {
+	return append([]string{
+		"localhost",
+		"etcd.kube-system.svc",
+		"etcd.kube-system.svc.cluster.local",
+		"etcd.openshift-etcd.svc",
+		"etcd.openshift-etcd.svc.cluster.local",
+		"127.0.0.1",
+		"::1",
+		"0:0:0:0:0:0:0:1",
+	}, nodeInternalIPs...)
+}
+
+func CreatePeerCertKey(caCert, caKey []byte, nodeInternalIPs []string) (*bytes.Buffer, *bytes.Buffer, error) {
+	return createNewCombinedClientAndServingCerts(caCert, caKey, fakePodFQDN, peerOrg, getPeerHostNames(nodeInternalIPs))
+}
+
+func CreateServerCertKey(caCert, caKey []byte, nodeInternalIPs []string) (*bytes.Buffer, *bytes.Buffer, error) {
+	return createNewCombinedClientAndServingCerts(caCert, caKey, fakePodFQDN, serverOrg, getServerHostNames(nodeInternalIPs))
+}
+
+func CreateMetricCertKey(caCert, caKey []byte, nodeInternalIPs []string) (*bytes.Buffer, *bytes.Buffer, error) {
+	return createNewCombinedClientAndServingCerts(caCert, caKey, fakePodFQDN, metricOrg, getServerHostNames(nodeInternalIPs))
+}
+
+func createNewCombinedClientAndServingCerts(caCert, caKey []byte, podFQDN, org string, hostNames []string) (*bytes.Buffer, *bytes.Buffer, error) {
+	cn, err := getCommonNameFromOrg(org)
+	etcdCAKeyPair, err := crypto.GetCAFromBytes(caCert, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certConfig, err := etcdCAKeyPair.MakeServerCertForDuration(sets.NewString(hostNames...), etcdCertValidity, func(cert *x509.Certificate) error {
+
+		cert.Issuer = pkix.Name{
+			OrganizationalUnit: []string{"openshift"},
+			CommonName:         cn,
+		}
+		cert.Subject = pkix.Name{
+			Organization: []string{org},
+			CommonName:   strings.TrimSuffix(org, "s") + ":" + podFQDN,
+		}
+		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+
+		// TODO: Extended Key Usage:
+		// All profiles expect a x509.ExtKeyUsageCodeSigning set on extended Key Usages
+		// need to investigage: https://github.com/etcd-io/etcd/issues/9398#issuecomment-435340312
+		// TODO: some extensions are missing form cfssl.
+		// e.g.
+		//	X509v3 Subject Key Identifier:
+		//		B7:30:0B:CF:47:4E:21:AE:13:60:74:42:B0:D9:C4:F3:26:69:63:03
+		//	X509v3 Authority Key Identifier:
+		//		keyid:9B:C0:6B:0C:8E:5C:73:6A:83:B1:E4:54:97:D3:62:18:8A:9C:BC:1E
+		// TODO: Change serial number logic, to something as follows.
+		// The following is taken from CFSSL library.
+		// If CFSSL is providing the serial numbers, it makes
+		// sense to use the max supported size.
+
+		//	serialNumber := make([]byte, 20)
+		//	_, err = io.ReadFull(rand.Reader, serialNumber)
+		//	if err != nil {
+		//		return err
+		//	}
+		//
+		//	// SetBytes interprets buf as the bytes of a big-endian
+		//	// unsigned integer. The leading byte should be masked
+		//	// off to ensure it isn't negative.
+		//	serialNumber[0] &= 0x7F
+		//	cert.SerialNumber = new(big.Int).SetBytes(serialNumber)
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes := &bytes.Buffer{}
+	keyBytes := &bytes.Buffer{}
+	if err := certConfig.WriteCertConfig(certBytes, keyBytes); err != nil {
+		return nil, nil, err
+	}
+	return certBytes, keyBytes, nil
+}
+
+func getCommonNameFromOrg(org string) (string, error) {
+	if strings.Contains(org, "peer") || strings.Contains(org, "server") {
+		return "etcd-signer", nil
+	}
+	if strings.Contains(org, "metric") {
+		return "etcd-metric-signer", nil
+	}
+	return "", errors.New("unable to recognise secret name")
+}


### PR DESCRIPTION
During render, generate the certificates necessary for the bootstrap member.

Update the bootstrap pod to use the rendered certificates.

After this change, the existing asynchronous client/server based bootstrap
certificate generation mechanism should be deleted.

Extracted from @markmc's work in https://github.com/openshift/cluster-etcd-operator/pull/410.