### PR TITLE
text change to create ci build image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # cluster-etcd-operator
 
+
 cluster-etcd-operator (CEO) is an operator that handles the scaling of etcd during cluster bootstrap and regular operation. The operator also manages provisioning etcd dependencies such as TLS certificates.
 
 # Developing the CEO


### PR DESCRIPTION
4.6 ci promotion is dead to the point where latest promoted images no longer exist. I am using this PR to build base images for custom payloads.