### PR TITLE
Converting cluster-backup and cluster-restore shell scripts as subcommands

### DIFF
--- a/cmd/cluster-etcd-operator/main.go
+++ b/cmd/cluster-etcd-operator/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/openshift/cluster-etcd-operator/pkg/cmd/backuprestore"
 	operatorcmd "github.com/openshift/cluster-etcd-operator/pkg/cmd/operator"
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/render"
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/waitforceo"
@@ -56,6 +57,8 @@ func NewSSCSCommand() *cobra.Command {
 	cmd.AddCommand(operatorcmd.NewOperator())
 	cmd.AddCommand(render.NewRenderCommand(os.Stderr))
 	cmd.AddCommand(render.NewBootstrapIPCommand(os.Stderr))
+	cmd.AddCommand(backuprestore.NewBackupCommand(os.Stderr))
+	cmd.AddCommand(backuprestore.NewRestoreCommand(os.Stderr))
 	cmd.AddCommand(installerpod.NewInstaller())
 	cmd.AddCommand(prune.NewPrune())
 	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))

--- a/pkg/cmd/backuprestore/backuprestore.go
+++ b/pkg/cmd/backuprestore/backuprestore.go
@@ -1,0 +1,119 @@
+package backuprestore
+
+import (
+	"errors"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"io"
+	"k8s.io/klog"
+)
+
+type backupOptions struct {
+	endpoints []string
+	configDir string
+	dataDir   string
+	backupDir string
+	errOut    io.Writer
+}
+
+func NewBackupCommand(errOut io.Writer) *cobra.Command {
+	backupOpts := &backupOptions{
+		errOut: errOut,
+	}
+	cmd := &cobra.Command{
+		Use:   "cluster-backup",
+		Short: "Backs up a snapshot of etcd database and static pod resources to a given directory",
+		Run: func(cmd *cobra.Command, args []string) {
+			must := func(fn func() error) {
+				if err := fn(); err != nil {
+					if cmd.HasParent() {
+						klog.Fatal(err)
+					}
+					fmt.Fprint(backupOpts.errOut, err.Error())
+				}
+			}
+
+			must(backupOpts.Validate)
+			must(backupOpts.Run)
+		},
+	}
+	backupOpts.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (r *backupOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.Set("logtostderr", "true")
+	fs.StringSliceVar(&r.endpoints, "endpoints", []string{"127.0.0.1:2379"}, "etcd endpoints")
+	fs.StringVar(&r.configDir, "config-dir", "/etc/kubernetes", "Path to the kubernetes config directory")
+	fs.StringVar(&r.dataDir, "data-dir", "/var/lib/etcd", "Path to the data directory")
+	fs.StringVar(&r.backupDir, "backup-dir", "", "Path to the directory where the backup is generated")
+}
+
+func (r *backupOptions) Validate() error {
+	if len(r.backupDir) == 0 {
+		return errors.New("missing required flag: --backup-dir")
+	}
+	return nil
+}
+
+func (r *backupOptions) Run() error {
+	if err := backup(r); err != nil {
+		klog.Errorf("run: backup failed: %v", err)
+	}
+	klog.Infof("config-dir is: %s", r.configDir)
+	return nil
+}
+
+type restoreOptions struct {
+	configDir string
+	dataDir   string
+	backupDir string
+	errOut    io.Writer
+}
+
+func NewRestoreCommand(errOut io.Writer) *cobra.Command {
+	restoreOpts := &restoreOptions{
+		errOut: errOut,
+	}
+	cmd := &cobra.Command{
+		Use:   "cluster-restore",
+		Short: "Restores a cluster backup from a given directory",
+		Run: func(cmd *cobra.Command, args []string) {
+			must := func(fn func() error) {
+				if err := fn(); err != nil {
+					if cmd.HasParent() {
+						klog.Fatal(err)
+					}
+					fmt.Fprint(restoreOpts.errOut, err.Error())
+				}
+			}
+
+			must(restoreOpts.Validate)
+			must(restoreOpts.Run)
+		},
+	}
+	restoreOpts.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (r *restoreOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.Set("logtostderr", "true")
+	fs.StringVar(&r.configDir, "config-dir", "/etc/kubernetes", "Path to the kubernetes config directory")
+	fs.StringVar(&r.dataDir, "data-dir", "/var/lib/etcd", "Path to the data directory")
+	fs.StringVar(&r.backupDir, "backup-dir", "", "Path to the directory where the backup is generated")
+}
+
+func (r *restoreOptions) Validate() error {
+	if len(r.backupDir) == 0 {
+		return errors.New("missing required flag: --backup-dir")
+	}
+	return nil
+}
+
+func (r *restoreOptions) Run() error {
+	if err := restore(r.configDir, r.dataDir, r.backupDir); err != nil {
+		klog.Errorf("run: restore failed: %v", err)
+	}
+	return nil
+}

--- a/pkg/cmd/backuprestore/backuputils.go
+++ b/pkg/cmd/backuprestore/backuputils.go
@@ -1,0 +1,66 @@
+package backuprestore
+
+import (
+	"fmt"
+	"k8s.io/klog"
+	"path/filepath"
+	"time"
+)
+
+//This backup mimics the functionality of cluster-backup.sh
+
+var backupResourcePodList = []string{
+	"kube-apiserver-pod",
+	"kube-controller-manager-pod",
+	"kube-scheduler-pod",
+	"etcd-pod",
+}
+
+func archiveLatestResources(configDir, backupFile string) error {
+	klog.Info("Static Pod Resources are being stored in: ", backupFile)
+
+	paths := []string{}
+	for _, podName := range backupResourcePodList {
+		latestPod, err := findTheLatestRevision(filepath.Join(configDir, "static-pod-resources"), podName, true)
+		if err != nil {
+			return fmt.Errorf("findTheLatestRevision failed: %w", err)
+		}
+		paths = append(paths, latestPod)
+		klog.Info("\tAdding the latest revision for podName ", podName, ": ", latestPod)
+	}
+
+	err := createTarball(backupFile, paths, configDir)
+	if err != nil {
+		return fmt.Errorf("Got error creating the tar archive: %w", err)
+	}
+	return nil
+}
+
+func backup(r *backupOptions) error {
+	cli, err := getEtcdClient(r.endpoints)
+	if err != nil {
+		return fmt.Errorf("backup: failed to get etcd client: %w", err)
+	}
+	defer cli.Close()
+
+	if err := checkAndCreateDir(r.backupDir); err != nil {
+		return fmt.Errorf("backup: checkAndCreateDir failed: %w", err)
+	}
+
+	// Trying to match the output file formats with the formats of the current cluster-backup.sh script
+	dateString := time.Now().Format("2006-01-02_150405")
+	outputArchive := "static_kuberesources_" + dateString + ".tar.gz"
+	snapshotOutFile := "snapshot_" + dateString + ".db"
+
+	// Save snapshot
+	if err := saveSnapshot(cli, filepath.Join(r.backupDir, snapshotOutFile)); err != nil {
+		return fmt.Errorf("saveSnapshot failed: %w", err)
+	}
+
+	// Save the corresponding static pod resources
+	if err := archiveLatestResources(r.configDir, filepath.Join(r.backupDir, outputArchive)); err != nil {
+		return fmt.Errorf("archiveLatestResources failed: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/backuprestore/etcdclientutils.go
+++ b/pkg/cmd/backuprestore/etcdclientutils.go
@@ -1,0 +1,74 @@
+package backuprestore
+
+import (
+	"context"
+	"fmt"
+	"google.golang.org/grpc"
+	"io"
+	"k8s.io/klog"
+	"os"
+	"time"
+
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/pkg/transport"
+)
+
+func getEtcdClient(endpoints []string) (*clientv3.Client, error) {
+	dialOptions := []grpc.DialOption{
+		grpc.WithBlock(), // block until the underlying connection is up
+	}
+
+	tlsInfo := transport.TLSInfo{
+		CertFile:      os.Getenv("ETCDCTL_CERT"),
+		KeyFile:       os.Getenv("ETCDCTL_KEY"),
+		TrustedCAFile: os.Getenv("ETCDCTL_CACERT"),
+	}
+	tlsConfig, err := tlsInfo.ClientConfig()
+
+	cfg := &clientv3.Config{
+		DialOptions: dialOptions,
+		Endpoints:   endpoints,
+		DialTimeout: 2 * time.Second,
+		TLS:         tlsConfig,
+	}
+
+	cli, err := clientv3.New(*cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make etcd client for endpoints %v: %w", endpoints, err)
+	}
+	return cli, nil
+}
+
+func saveSnapshot(cli *clientv3.Client, dbPath string) error {
+	partpath := dbPath + ".part"
+	defer os.RemoveAll(partpath)
+
+	f, err := os.OpenFile(partpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("could not open %s (%w)", partpath, err)
+	}
+
+	opBegin := time.Now()
+	var rd io.ReadCloser
+	rd, err = cli.Snapshot(context.Background())
+	if err != nil {
+		return fmt.Errorf("saveSnapshot failed: %w", err)
+	}
+
+	if _, err := io.Copy(f, rd); err != nil {
+		return fmt.Errorf("saveSnapshot failed: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("saveSnapshot failed: %w", err)
+	}
+	klog.Info(
+		"fetched snapshot. ",
+		"Time taken: ", time.Since(opBegin),
+	)
+
+	if err := os.Rename(partpath, dbPath); err != nil {
+		return fmt.Errorf("could not rename %s to %s (%v)", partpath, dbPath, err)
+	}
+	klog.Info("saved snapshot to path", dbPath)
+	return nil
+}

--- a/pkg/cmd/backuprestore/fileioutils.go
+++ b/pkg/cmd/backuprestore/fileioutils.go
@@ -1,0 +1,220 @@
+package backuprestore
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"k8s.io/klog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func dirExists(dirname string) (bool, error) {
+	info, err := os.Stat(dirname)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("dirExists: %s. Error=%w", dirname, err)
+	}
+	return info.IsDir(), nil
+}
+
+func fileExists(filename string) (bool, error) {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("fileExists: %s. Error=%w", filename, err)
+	}
+	return !info.IsDir(), nil
+}
+
+func safeDirRename(src, dest string, srcMayNotExist bool) error {
+	srcPresent, err := dirExists(src)
+
+	if err != nil {
+		return fmt.Errorf("safeDirRename: Unexpected error checking dir: %s. Error: %w", src, err)
+	}
+
+	if !srcPresent {
+		if !srcMayNotExist {
+			return fmt.Errorf("SafeDirRename: src dir %s does not exist", src)
+		} else {
+			return nil
+		}
+	}
+
+	destExists, err := dirExists(dest)
+	if err != nil {
+		return fmt.Errorf("safeDirRename: Unexpected error checking dir: %s. Error: %w", dest, err)
+	}
+
+	destToBeRemoved := dest + ".to_be_removed"
+	if destExists {
+		if exists, _ := dirExists(destToBeRemoved); exists {
+			if err := os.RemoveAll(destToBeRemoved); err != nil {
+				return fmt.Errorf("safeDirRename: failed to remove dir %s. Error: %w", destToBeRemoved, err)
+			}
+		}
+		if err := os.Rename(dest, destToBeRemoved); err != nil {
+			return fmt.Errorf("safeDirRename: got error renaming %s %s. Err: %w", dest, destToBeRemoved, err)
+		}
+	}
+
+	if err := os.Rename(src, dest); err != nil {
+		if destExists {
+			if err := os.Rename(destToBeRemoved, dest); err != nil {
+				klog.Errorf("safeDirRename: got error renaming %s to %s. Error: %v", destToBeRemoved, dest, err)
+			}
+		}
+		return fmt.Errorf("safeDirRename: got error renaming %s to %s. Err: %w", src, dest, err)
+	}
+
+	klog.Info("Successfully moved ", src, " to ", dest)
+
+	if err := os.RemoveAll(destToBeRemoved); err != nil {
+		klog.Errorf("safeDirRename: got error removing %s. Error: %v", destToBeRemoved, err)
+	}
+	return nil
+}
+
+func fileCopy(src, dst string) (int64, error) {
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return 0, err
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", src)
+	}
+
+	source, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer source.Close()
+
+	destination, err := os.Create(dst)
+	if err != nil {
+		return 0, err
+	}
+	defer destination.Close()
+	nBytes, err := io.Copy(destination, source)
+	return nBytes, err
+}
+
+func dumpDirs(dir string) error {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("DumpDirs: could not read dir %s: %w", dir, err)
+	}
+
+	klog.Infof("dumpDirs: Dumping currently saved directories in %s:", dir)
+	for _, f := range files {
+		if f.IsDir() {
+			dirname := filepath.Join(dir, f.Name())
+			if dirVersion, err := getVersion(dirname); err != nil {
+				klog.Errorf("dumpDirs: Could not dump dir %s. Error: %w", dirname, err)
+			} else {
+				klog.Infof("\t%s ClusterVersion: %s TimeStamp: %s", dirname, dirVersion.ClusterVersion, dirVersion.TimeStamp)
+			}
+		}
+	}
+	return nil
+}
+
+func findTheLatestRevision(dir, filePrefix string, isDir bool) (string, error) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+
+	var modTime time.Time
+	var latest string
+	found := false
+	for _, f := range files {
+		if f.IsDir() == isDir && strings.HasPrefix(f.Name(), filePrefix) {
+			if f.ModTime().After(modTime) {
+				modTime = f.ModTime()
+				latest = f.Name()
+				found = true
+			}
+		}
+	}
+	if !found {
+		return "", fmt.Errorf("Not found any resources with file prefix %s", filePrefix)
+	}
+	return filepath.Join(dir, latest), nil
+}
+
+type backupVersion struct {
+	ClusterVersion string `json:"ClusterVersion"`
+	TimeStamp      string `json:"TimeStamp"`
+}
+
+func versionChanged(dir1, dir2 string) bool {
+	dir1Version, err := getVersion(dir1)
+	if err != nil {
+		klog.Errorf("getVersion failed on %s", dir1)
+		return false
+	}
+	dir2Version, err := getVersion(dir2)
+	if err != nil {
+		klog.Errorf("getVersion failed on %s", dir2)
+		return false
+	}
+	klog.Infof("versionCheck: Dir: %s Version: %s", dir1, dir1Version.ClusterVersion)
+	klog.Infof("versionCheck: Dir: %s Version: %s", dir2, dir2Version.ClusterVersion)
+	if dir1Version.ClusterVersion != dir2Version.ClusterVersion {
+		klog.Infof("Version changed from %s to %s", dir1Version.ClusterVersion, dir2Version.ClusterVersion)
+	}
+	return (dir1Version.ClusterVersion != dir2Version.ClusterVersion)
+}
+
+func getVersion(dir string) (*backupVersion, error) {
+	version := backupVersion{}
+	jsonFile, err := ioutil.ReadFile(filepath.Join(dir, "backupenv.json"))
+	if err != nil {
+		return nil, fmt.Errorf("getVersion failed: %w", err)
+	}
+	if err := json.Unmarshal(jsonFile, &version); err != nil {
+		return nil, fmt.Errorf("getVersion: json unmarshal error: %w", err)
+	}
+
+	return &version, nil
+}
+
+func putVersion(c *backupVersion, dir string) error {
+	confBytes, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("putVersion json marshal error: %w", err)
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "backupenv.json"), confBytes, 0644); err != nil {
+		return fmt.Errorf("putVersion: writeFile failed: %w", err)
+	}
+
+	return nil
+}
+
+func checkAndCreateDir(dirName string) error {
+	_, err := os.Stat(dirName)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("checkAndCreateDir failed: %w", err)
+	}
+	// If dirName already exists, remove it
+	if err == nil {
+		if err := os.RemoveAll(dirName); err != nil {
+			return fmt.Errorf("checkAndCreateDir failed to remove %s: %w", dirName, err)
+		}
+	}
+	if err := os.MkdirAll(dirName, os.ModePerm); err != nil {
+		return fmt.Errorf("checkAndCreateDir failed: %w", err)
+	}
+	return nil
+}

--- a/pkg/cmd/backuprestore/restoreutils.go
+++ b/pkg/cmd/backuprestore/restoreutils.go
@@ -1,0 +1,108 @@
+package backuprestore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var static_pod_list = []string{
+	"etcd-pod.yaml",
+	"kube-apiserver-pod.yaml",
+	"kube-controller-manager-pod.yaml",
+	"kube-scheduler-pod.yaml",
+}
+
+func restore(configDir, dataDir, backupDir string) error {
+
+	var (
+		assetDir           = filepath.Join(configDir, "assets")
+		manifestDir        = filepath.Join(configDir, "manifests")
+		manifestStoppedDir = filepath.Join(assetDir, "manifests-stopped")
+		restoreEtcdPodYaml = filepath.Join(configDir, "static-pod-resources", "etcd-certs", "configmaps", "restore-etcd-pod", "pod.yaml")
+		dataDirBackup      = dataDir + "-backup"
+	)
+	fmt.Printf("configDir=%s,dataDir=%s,backupDir=%s\n", configDir, dataDir, backupDir)
+	// locate snapshot db and static pod resources archive
+	snapshotFile, err := findTheLatestRevision(backupDir, "snapshot_", false)
+	if err != nil {
+		return fmt.Errorf("restore: could not find snapshot db: %w", err)
+	}
+	resourcesArchive, err := findTheLatestRevision(backupDir, "static_kuberesources_", false)
+	if err != nil {
+		return fmt.Errorf("restore: could not find static pod resources: %w", err)
+	}
+
+	// Move manifests to manifests-stopped-dir
+	if err := checkAndCreateDir(manifestStoppedDir); err != nil {
+		return fmt.Errorf("restore: checkAndCreateDir failed: %w", err)
+	}
+	for _, podyaml := range static_pod_list {
+		err := os.Rename(filepath.Join(manifestDir, podyaml), filepath.Join(manifestStoppedDir, podyaml))
+		if err != nil {
+			return fmt.Errorf("restore: attempt to stop %s failed: %w", podyaml, err)
+		}
+	}
+
+	// TODO: Wait for static pods to stop
+	// crictl ps equivalent??
+	time.Sleep(180 * time.Second)
+
+	dataDirMember := filepath.Join(dataDir, "member")
+	dataDirMemberExists, err := dirExists(dataDirMember)
+	if err != nil {
+		return fmt.Errorf("restore: Unexpected error checking dir: %s. Error: %w", dataDirMember, err)
+	}
+	if dataDirMemberExists {
+		// backup data-dir to data-dir-backup
+		if err := checkAndCreateDir(dataDirBackup); err != nil {
+			return fmt.Errorf("restore: checkAndCreateDir failed: %w", err)
+		}
+		// check if data-dir-backup already exists
+		dataDirBackupMember := filepath.Join(dataDirBackup, "member")
+		backupMemberExists, err := dirExists(dataDirBackupMember)
+		if err != nil {
+			return fmt.Errorf("restore: Unexpected error checking dir: %s. Error: %w", dataDirBackupMember, err)
+		}
+		// if old backup exists, remove all
+		if backupMemberExists {
+			os.RemoveAll(dataDirBackupMember)
+		}
+		// Rename data-dir/member to data-dir-backup/member
+		if err := os.Rename(dataDirMember, dataDirBackupMember); err != nil {
+			return fmt.Errorf("restore: attempt to backup data-dir %s failed: %w", dataDir, err)
+		}
+	}
+
+	// Restore static pod resources
+	if err := extractFromTarGz(resourcesArchive, configDir); err != nil {
+		return fmt.Errorf("restore: attempt to extract static-pod-resources from archive %s failed: %w",
+			resourcesArchive, err)
+	}
+
+	// Copy snapshot to backupdir
+	etcdDataDirBackupSnapshot := dataDirBackup + "snapshot.db"
+	if _, err := fileCopy(snapshotFile, etcdDataDirBackupSnapshot); err != nil {
+		return fmt.Errorf("restore: attempt to copy snapshot %s failed: %w", snapshotFile, err)
+	}
+
+	// Copy restore etcd pod to manifest directory
+	if _, err := fileCopy(restoreEtcdPodYaml, filepath.Join(manifestDir, "etcd-pod.yaml")); err != nil {
+		return fmt.Errorf("restore: attempt to copy restore etcd %s failed: %w", restoreEtcdPodYaml, err)
+	}
+
+	// Restore remaining static pods
+	for _, podyaml := range static_pod_list {
+		if podyaml == "etcd-pod.yaml" {
+			continue
+		}
+		if err := extractFileFromTarGz(resourcesArchive, manifestDir, podyaml); err != nil {
+			return fmt.Errorf("restore: attempt to extract manifest file from archive %s for pod %s failed: %w",
+				resourcesArchive, podyaml, err)
+		}
+
+	}
+	return nil
+
+}

--- a/pkg/cmd/backuprestore/tarutils.go
+++ b/pkg/cmd/backuprestore/tarutils.go
@@ -1,0 +1,229 @@
+package backuprestore
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"k8s.io/klog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func createTarball(tarballFilePath string, filePaths []string, prefixTrim string) error {
+	file, err := os.OpenFile(tarballFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Could not create tarball file '%s', got error '%s'", tarballFilePath, err.Error()))
+	}
+	defer file.Close()
+
+	gzipWriter := gzip.NewWriter(file)
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	if prefixTrim != "" && !strings.HasSuffix(prefixTrim, "/") {
+		prefixTrim += "/"
+	}
+
+	for _, filePath := range filePaths {
+		err := addFileToTarWriter(filePath, tarWriter, prefixTrim)
+		if err != nil {
+			return errors.New(fmt.Sprintf("Could not add file '%s', to tarball, got error '%s'", filePath, err.Error()))
+		}
+	}
+
+	return nil
+}
+
+func addFileToTarWriter(src string, tarWriter *tar.Writer, prefixTrim string) error {
+
+	return filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
+
+		// return on any error
+		if err != nil {
+			return fmt.Errorf("addFileToTarWriter failed: %w", err)
+		}
+
+		// return on non-regular files
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
+
+		header := &tar.Header{
+			Name:    file,
+			Size:    fi.Size(),
+			Mode:    int64(fi.Mode()),
+			ModTime: fi.ModTime(),
+		}
+
+		// update the name to correctly reflect the desired destination when untaring
+		header.Name = strings.TrimPrefix(file, prefixTrim)
+
+		// write the header
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return fmt.Errorf("addFileToTarWriter: WriteHeader failed: %w", err)
+		}
+
+		// open files for taring
+		f, err := os.Open(file)
+		if err != nil {
+			return fmt.Errorf("addFileToTarWriter: file open failed: %w", err)
+		}
+
+		// copy file data into tar writer
+		if _, err := io.Copy(tarWriter, f); err != nil {
+			return fmt.Errorf("addFileToTarWriter: file write failed: %w", err)
+		}
+
+		// manually close here after each file operation; defering would cause each file close
+		// to wait until all operations have completed.
+		f.Close()
+
+		return nil
+	})
+
+}
+
+func extractFromTarGz(tarball, target string) (err error) {
+	r, err := os.Open(tarball)
+	if err != nil {
+		return err
+	}
+	t0 := time.Now()
+	nFiles := 0
+	madeDir := map[string]bool{}
+	defer func() {
+		td := time.Since(t0)
+		if err == nil {
+			klog.Infof("extracted tarball into %s: %d files, %d dirs (%v)", target, nFiles, len(madeDir), td)
+		} else {
+			klog.Infof("error extracting tarball into %s after %d files, %d dirs, %v: %v", target, nFiles, len(madeDir), td, err)
+		}
+	}()
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("requires gzip-compressed body: %v", err)
+	}
+	tr := tar.NewReader(zr)
+	for {
+		f, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			klog.Errorf("tar reading error: %v", err)
+			return fmt.Errorf("tar error: %v", err)
+		}
+		if !validRelPath(f.Name) {
+			return fmt.Errorf("tar contained invalid name error %q", f.Name)
+		}
+		rel := filepath.FromSlash(f.Name)
+		abs := filepath.Join(target, rel)
+
+		fi := f.FileInfo()
+		mode := fi.Mode()
+		switch {
+		case mode.IsRegular():
+			// Make the directory. This is redundant because it should
+			// already be made by a directory entry in the tar
+			// beforehand. Thus, don't check for errors; the next
+			// write will fail with the same error.
+			dir := filepath.Dir(abs)
+			if !madeDir[dir] {
+				if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
+					return err
+				}
+				madeDir[dir] = true
+			}
+			wf, err := os.OpenFile(abs, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
+			if err != nil {
+				return err
+			}
+			n, err := io.Copy(wf, tr)
+			if closeErr := wf.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				return fmt.Errorf("error writing to %s: %v", abs, err)
+			}
+			if n != f.Size {
+				return fmt.Errorf("only wrote %d bytes to %s; expected %d", n, abs, f.Size)
+			}
+			nFiles++
+		case mode.IsDir():
+			if err := os.MkdirAll(abs, 0755); err != nil {
+				return err
+			}
+			madeDir[abs] = true
+		default:
+			return fmt.Errorf("tar file entry %s contained unsupported file type %v", f.Name, mode)
+		}
+	}
+	return nil
+}
+
+func extractFileFromTarGz(tarball, targetdir, filebasename string) (err error) {
+	r, err := os.Open(tarball)
+	if err != nil {
+		return err
+	}
+	nFiles := 0
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("requires gzip-compressed body: %v", err)
+	}
+	tr := tar.NewReader(zr)
+	for {
+		f, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			klog.Errorf("tar reading error: %v", err)
+			return fmt.Errorf("tar error: %v", err)
+		}
+		if !validRelPath(f.Name) {
+			return fmt.Errorf("tar contained invalid name error %q", f.Name)
+		}
+		if filepath.Base(f.Name) != filebasename {
+			continue
+		}
+		targetFile := filepath.Join(targetdir, filebasename)
+
+		fi := f.FileInfo()
+		mode := fi.Mode()
+		switch {
+		case mode.IsRegular():
+			wf, err := os.OpenFile(targetFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
+			if err != nil {
+				return err
+			}
+			n, err := io.Copy(wf, tr)
+			if closeErr := wf.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				return fmt.Errorf("error writing to %s: %v", targetFile, err)
+			}
+			if n != f.Size {
+				return fmt.Errorf("only wrote %d bytes to %s; expected %d", n, targetFile, f.Size)
+			}
+			nFiles++
+		default:
+			return fmt.Errorf("tar file entry %s contained unsupported file type %v", f.Name, mode)
+		}
+	}
+	return nil
+}
+
+func validRelPath(p string) bool {
+	if p == "" || strings.Contains(p, `\`) || strings.HasPrefix(p, "/") || strings.Contains(p, "../") {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Converting the bash scripts into Golang as subcommands to cluster-etcd-operator.

This supersedes the previous PR #398. 