### PR TITLE
Clean up bootstrap member cert references

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -20,11 +20,11 @@ spec:
         --initial-advertise-peer-urls=https://{{ .EtcdAddress.EscapedBootstrapIP }}:2380 \
         --cert-file=/etc/ssl/etcd/etcd-all-serving/etcd-serving-{{ .Hostname }}.crt \
         --key-file=/etc/ssl/etcd/etcd-all-serving/etcd-serving-{{ .Hostname }}.key \
-        --trusted-ca-file=/etc/openshift-tls/etcd-ca-bundle.crt \
+        --trusted-ca-file=/etc/ssl/etcd/ca.crt \
         --client-cert-auth=true \
         --peer-cert-file=/etc/ssl/etcd/etcd-all-peer/etcd-peer-{{ .Hostname }}.crt \
         --peer-key-file=/etc/ssl/etcd/etcd-all-peer/etcd-peer-{{ .Hostname }}.key \
-        --peer-trusted-ca-file=/etc/openshift-tls/etcd-ca-bundle.crt \
+        --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
         --peer-client-cert-auth=true \
         --advertise-client-urls=https://{{ .EtcdAddress.EscapedBootstrapIP }}:2379 \
         --listen-client-urls=https://{{ .EtcdAddress.ListenClient }} \
@@ -42,8 +42,6 @@ spec:
       mountPath: /run/etcd/
     - name: certs
       mountPath: /etc/ssl/etcd/
-    - name: openshift-tls
-      mountPath: /etc/openshift-tls
     - name: data-dir
       mountPath: /var/lib/etcd/
     - name: conf
@@ -64,14 +62,9 @@ spec:
   - operator: "Exists"
   restartPolicy: Always
   volumes:
-  # TODO: update installer to copy the certs into /etc/kubernetes/static-pod-resources/etcd-member
   - name: certs
     hostPath:
-      path: /opt/openshift/etcd-bootstrap/bootstrap-manifests/secrets
-  # TODO: update installer to copy the ca into /etc/kubernetes/static-pod-resources/etcd-member
-  - name: openshift-tls
-    hostPath:
-      path: /opt/openshift/tls
+      path: /etc/kubernetes/static-pod-resources/etcd-member
   - name: kubeconfig
     hostPath:
       path: /etc/kubernetes/kubeconfig

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -38,7 +38,6 @@ type renderOpts struct {
 	errOut                   io.Writer
 	etcdCAFile               string
 	etcdCAKeyFile            string
-	unusedEtcdMetricCAFile   string
 	etcdDiscoveryDomain      string
 	etcdImage                string
 	clusterEtcdOperatorImage string
@@ -125,10 +124,8 @@ func (r *renderOpts) AddFlags(fs *pflag.FlagSet) {
 	r.manifest.AddFlags(fs, "etcd")
 	r.generic.AddFlags(fs)
 
-	fs.StringVar(&r.etcdCAFile, "etcd-ca", r.etcdCAFile, "path to etcd CA certificate")
+	fs.StringVar(&r.etcdCAFile, "etcd-ca", "/assets/tls/etcd-ca-bundle.crt", "path to etcd CA certificate")
 	fs.StringVar(&r.etcdCAKeyFile, "etcd-ca-key", "/assets/tls/etcd-signer.key", "path to etcd CA certificate key")
-	// deprecated
-	fs.StringVar(&r.unusedEtcdMetricCAFile, "etcd-metric-ca", r.unusedEtcdMetricCAFile, "path to etcd metric CA certificate")
 	fs.StringVar(&r.etcdImage, "manifest-etcd-image", r.etcdImage, "etcd manifest image")
 	fs.StringVar(&r.clusterEtcdOperatorImage, "manifest-cluster-etcd-operator-image", r.clusterEtcdOperatorImage, "cluster-etcd-operator manifest image")
 	fs.StringVar(&r.kubeClientAgentImage, "manifest-kube-client-agent-image", r.kubeClientAgentImage, "kube-client-agent manifest image")


### PR DESCRIPTION
Adjusts the bootstrap member pod's certificate references to use the
bootkube render output paths now that the installer has been updated
to put the rendered output in the expected locations.

Remove deprecated metrics CA flag.