### PR TITLE
Bug 1850057: etcd-pod: Use ionice -c2 -n0

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -151,7 +151,8 @@ ${COMPUTED_ENV_VARS}
         env | grep ETCD | grep -v NODE
 
         set -x
-        exec etcd \
+        # See https://etcd.io/docs/v3.4.0/tuning/ for why we use ionice
+        exec ionice -c2 -n0 etcd \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key \

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -590,7 +590,8 @@ ${COMPUTED_ENV_VARS}
         env | grep ETCD | grep -v NODE
 
         set -x
-        exec etcd \
+        # See https://etcd.io/docs/v3.4.0/tuning/ for why we use ionice
+        exec ionice -c2 -n0 etcd \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key \


### PR DESCRIPTION
This will have no currect effect with the default I/O scheduler
of `mq-deadline`, but I think it will help once we switch to `bfq`
as part of https://github.com/openshift/machine-config-operator/pull/1946