### PR TITLE
pkg/etcdenvvar: enable pprof by default

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -29,6 +29,7 @@ var FixedEtcdEnvVars = map[string]string{
 	"ETCD_DATA_DIR":              "/var/lib/etcd",
 	"ETCD_QUOTA_BACKEND_BYTES":   "7516192768", // 7 gig
 	"ETCD_INITIAL_CLUSTER_STATE": "existing",
+	"ETCD_ENABLE_PPROF":          "true",
 }
 
 type envVarFunc func(envVarContext envVarContext) (map[string]string, error)


### PR DESCRIPTION
This PR turns on the go profiling handler by default. My intial concern with enabling this was overhead but in speaking with Clayton and further research overhead is pretty much nothing unless the handler is used.

usage example fort debugging heap.

```
oc rsh -T -n openshift-etcd etcd-ip-10-0-155-214.us-west-1.compute.internal  sh -c 'curl --cert $ETCDCTL_CERT --key $ETCDCTL_KEY --cacert $ETCDCTL_CACERT https://localhost:2379/debug/pprof/heap' > /tmp/heap

PROF_BINARY_PATH=/tmp go tool pprof /tmp/heap
```
