### PR TITLE
pkg/etcdenvvar: enable zap as default logger

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -10,6 +10,22 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
+    - name: setup
+      terminationMessagePolicy: FallbackToLogsOnError
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+        - mountPath: /var/log/etcd
+          name: log-dir
+      command:
+        - /bin/sh
+        - -c
+        - |
+          #!/bin/sh
+          echo -n "Fixing zap log permissions."
+          chmod 0700 /var/log/etcd && touch /var/log/etcd/etcd.log && chmod 0600 /var/log/etcd/*
+      securityContext:
+        privileged: true
     - name: etcd-ensure-env-vars
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
@@ -181,6 +197,8 @@ ${COMPUTED_ENV_VARS}
         name: cert-dir
       - mountPath: /var/lib/etcd/
         name: data-dir
+      - mountPath: /var/log/etcd
+        name: log-dir
   - name: etcd-metrics
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -35,6 +35,9 @@ var FixedEtcdEnvVars = map[string]string{
 	"ETCD_ENABLE_PPROF":                                "true",
 	"ETCD_CIPHER_SUITES":                               getDefaultCipherSuites(),
 	"ETCD_EXPERIMENTAL_WATCH_PROGRESS_NOTIFY_INTERVAL": "5s",
+	"ETCD_LOGGER":                                      "zap",
+	"ETCD_LOG_OUTPUTS":                                 "stderr,/var/log/etcd/etcd.log", // testing only, depends on log rotation efforts upstream.
+	"ETCD_LOG_LEVEL":                                   "debug",                         //testing only TODO fix logLevel as part of this PR.
 }
 
 type envVarFunc func(envVarContext envVarContext) (map[string]string, error)

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -474,6 +474,22 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
+    - name: setup
+      terminationMessagePolicy: FallbackToLogsOnError
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+        - mountPath: /var/log/etcd
+          name: log-dir
+      command:
+        - /bin/sh
+        - -c
+        - |
+          #!/bin/sh
+          echo -n "Fixing zap log permissions."
+          chmod 0700 /var/log/etcd && touch /var/log/etcd/etcd.log && chmod 0600 /var/log/etcd/*
+      securityContext:
+        privileged: true
     - name: etcd-ensure-env-vars
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
@@ -645,6 +661,8 @@ ${COMPUTED_ENV_VARS}
         name: cert-dir
       - mountPath: /var/lib/etcd/
         name: data-dir
+      - mountPath: /var/log/etcd
+        name: log-dir
   - name: etcd-metrics
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This PR makes zap the default logger for OCP 4.6. This gives us much more flexibility with log tuning log levels and general aggregation. 
