### PR TITLE
Bug 1840358: etcd-quorum-guard remove toleration timeouts

### DIFF
--- a/manifests/0000_12_etcd-operator_08_etcdquorumguard_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_08_etcdquorumguard_deployment.yaml
@@ -43,11 +43,9 @@ spec:
         - key: node.kubernetes.io/not-ready
           effect: NoExecute
           operator: Exists
-          tolerationSeconds: 120
         - key: node.kubernetes.io/unreachable
           effect: NoExecute
           operator: Exists
-          tolerationSeconds: 120
         - key: node-role.kubernetes.io/etcd
           operator: Exists
           effect: NoSchedule


### PR DESCRIPTION
This commit removes timeouts for NoExecute
and NoSchedule tolerations.  This results in the
pods not being marked deleted and rescheduled in
case of a kubelet going unreachable.