### PR TITLE
static-pod-installer: remove deadlock by recreating installers that disappear

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20200723134351-89de68875e7c
 	github.com/openshift/build-machinery-go v0.0.0-20200713135615-1f43d26dccc7
 	github.com/openshift/client-go v0.0.0-20200722173614-5a1b0aaeff15
-	github.com/openshift/library-go v0.0.0-20200730074834-b4288351763c
+	github.com/openshift/library-go v0.0.0-20200825134320-3926cf368e59
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200713135615-1f43d26dccc7 h1:iP
 github.com/openshift/build-machinery-go v0.0.0-20200713135615-1f43d26dccc7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200722173614-5a1b0aaeff15 h1:b2QkHrmaYtY6kzy2VrYLc+KBmCuTpJjgvBahPqpt6V0=
 github.com/openshift/client-go v0.0.0-20200722173614-5a1b0aaeff15/go.mod h1:yd4Zpcdk+8JyMWi6v+h78jPqK0FvXbJY41Wq3SZxl+c=
-github.com/openshift/library-go v0.0.0-20200730074834-b4288351763c h1:MGgrUHiD7MI/PJ0DIq2RnpQ6HEGOTxrJyVuxEgtE0LY=
-github.com/openshift/library-go v0.0.0-20200730074834-b4288351763c/go.mod h1:q7ebJwBFgDx4nP5jGhd+K9XgOIpKaNVh4RWpKmW61Gg=
+github.com/openshift/library-go v0.0.0-20200825134320-3926cf368e59 h1:eY84qLTdJ7sYdlJKE9C/vacFemjFvksUJ6kDj391vbQ=
+github.com/openshift/library-go v0.0.0-20200825134320-3926cf368e59/go.mod h1:q7ebJwBFgDx4nP5jGhd+K9XgOIpKaNVh4RWpKmW61Gg=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/version.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/version.go
@@ -19,6 +19,7 @@ type versionGetter struct {
 }
 
 const (
+	operandImageEnvVarName         = "IMAGE"
 	operandImageVersionEnvVarName  = "OPERAND_IMAGE_VERSION"
 	operatorImageVersionEnvVarName = "OPERATOR_IMAGE_VERSION"
 )
@@ -62,6 +63,10 @@ func (v *versionGetter) VersionChangedChannel() <-chan struct{} {
 	channel := make(chan struct{}, 50)
 	v.notificationChannels = append(v.notificationChannels, channel)
 	return channel
+}
+
+func ImageForOperandFromEnv() string {
+	return os.Getenv(operandImageEnvVarName)
 }
 
 func VersionForOperandFromEnv() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -173,7 +173,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20200730074834-b4288351763c
+# github.com/openshift/library-go v0.0.0-20200825134320-3926cf368e59
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/config/client
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers


### PR DESCRIPTION
Pulling in openshift/library-go#871.