### PR TITLE
Bug 1858763: bump(*): vendor update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20200723134351-89de68875e7c
 	github.com/openshift/build-machinery-go v0.0.0-20200713135615-1f43d26dccc7
 	github.com/openshift/client-go v0.0.0-20200722173614-5a1b0aaeff15
-	github.com/openshift/library-go v0.0.0-20200730074834-b4288351763c
+	github.com/openshift/library-go v0.0.0-20200826135324-025aa3f9ff11
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.10.0
@@ -28,3 +28,5 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20200720150651-0bdb4ca86cbc
 )
+
+replace vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsouza/go-dockerclient v0.0.0-20171004212419-da3951ba2e9e/go.mod h1:KpcjM623fQYE9MZiTGzKhjfxXAV9wbyX2C1cyRHfhl0=
+github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787 h1:AfLWrOEtyI9WI9aaDF0GN/6FQu+rNvl2YUeizB6FYuk=
+github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787/go.mod h1:AlRx4sdoz6EdWGYPMeunQWYf46cKnq7J4iVvLgyb5cY=
 github.com/getsentry/raven-go v0.0.0-20190513200303-c977f96e1095 h1:F2m41rgyxoveZKD+Z6xwyAbtdNeVvhpi9BpQLvt5oRU=
 github.com/getsentry/raven-go v0.0.0-20190513200303-c977f96e1095/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -353,8 +355,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200713135615-1f43d26dccc7 h1:iP
 github.com/openshift/build-machinery-go v0.0.0-20200713135615-1f43d26dccc7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200722173614-5a1b0aaeff15 h1:b2QkHrmaYtY6kzy2VrYLc+KBmCuTpJjgvBahPqpt6V0=
 github.com/openshift/client-go v0.0.0-20200722173614-5a1b0aaeff15/go.mod h1:yd4Zpcdk+8JyMWi6v+h78jPqK0FvXbJY41Wq3SZxl+c=
-github.com/openshift/library-go v0.0.0-20200730074834-b4288351763c h1:MGgrUHiD7MI/PJ0DIq2RnpQ6HEGOTxrJyVuxEgtE0LY=
-github.com/openshift/library-go v0.0.0-20200730074834-b4288351763c/go.mod h1:q7ebJwBFgDx4nP5jGhd+K9XgOIpKaNVh4RWpKmW61Gg=
+github.com/openshift/library-go v0.0.0-20200826135324-025aa3f9ff11 h1:rU3Z1lT9lyePfdGVxhTAlpSNDWGMhRbsm5KtbjZ52Qs=
+github.com/openshift/library-go v0.0.0-20200826135324-025aa3f9ff11/go.mod h1:q7ebJwBFgDx4nP5jGhd+K9XgOIpKaNVh4RWpKmW61Gg=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -737,5 +739,3 @@ sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787 h1:O69FD9pJA4WUZlEwYatBEEkRWKQ5cKodWpdKTrCS/iQ=
-vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/version.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/version.go
@@ -19,6 +19,7 @@ type versionGetter struct {
 }
 
 const (
+	operandImageEnvVarName         = "IMAGE"
 	operandImageVersionEnvVarName  = "OPERAND_IMAGE_VERSION"
 	operatorImageVersionEnvVarName = "OPERATOR_IMAGE_VERSION"
 )
@@ -62,6 +63,10 @@ func (v *versionGetter) VersionChangedChannel() <-chan struct{} {
 	channel := make(chan struct{}, 50)
 	v.notificationChannels = append(v.notificationChannels, channel)
 	return channel
+}
+
+func ImageForOperandFromEnv() string {
+	return os.Getenv(operandImageEnvVarName)
 }
 
 func VersionForOperandFromEnv() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -173,7 +173,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20200730074834-b4288351763c
+# github.com/openshift/library-go v0.0.0-20200826135324-025aa3f9ff11
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/config/client
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers


### PR DESCRIPTION
* openshift/library-go@71b63d85: adds audit policy configuration config map
* openshift/library-go@19c5b991: add audit policy path getter
* openshift/library-go@918750c9: allows for specifying a name for the audit policies config map
* openshift/library-go@0f5f426b: allows for specifying a path for NewAuditPolicyPathGetter function
* openshift/library-go@e26b9e23: exposes GetAuditPolicies for getting a stronly typed object
* openshift/library-go@a943da34: prefix nested observer condition to avoid racing
* openshift/library-go@e68ef472: bump(*)
* openshift/library-go@22e2f2b9: connectivitycheckcontroller: add to library-go
* openshift/library-go@07787078: csi: remove csidrivercontroller
* openshift/library-go@35c2f0bd: csi: split CSIDriverController into two
* openshift/library-go@af060510: static pod operator should not update versions until the image is new
* openshift/library-go@35b150a9: pkg/manifest: Delegate to update-approvers
* openshift/library-go@d37e5538: csi: report Available and Progressin conditions in credentialsrequestcontroller
* openshift/library-go@0d21ea36: pkg/verify: Delegate to update-approvers
* openshift/library-go@29a26d30: bump(crypto) to pick up openpgp
* openshift/library-go@c43c2cb2: Create a resuable verify package for image release verification
* openshift/library-go@2e4ba913: static-pod-installer: recreate installers that disappeared