### PR TITLE
Bug 1876858: manifests: rename operator container to be more descriptive

### DIFF
--- a/manifests/0000_12_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_06_deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       serviceAccountName: etcd-operator
       containers:
-      - name: operator
+      - name: etcd-operator
         image: quay.io/openshift/origin-cluster-etcd-operator
         imagePullPolicy: IfNotPresent
         ports:


### PR DESCRIPTION
Rename the operator container to allow for more reasonable debugging.

![operator](https://user-images.githubusercontent.com/1249749/92472976-2a9db600-f1a8-11ea-95f6-33bb3e0397fd.png)

# others

- [ ] insights-operator
- [ ] support-operator
- [ ] service-ca-operator: https://github.com/openshift/service-ca-operator/blob/master/manifests/05_deploy.yaml
- [ ] cluster-openshift-controller-manager-operator: https://github.com/openshift/cluster-openshift-controller-manager-operator/blob/master/manifests/09_deployment.yaml#L23
- [ ] cluster-authentication-operator: https://github.com/openshift/cluster-authentication-operator/blob/master/manifests/07_deployment.yaml#L24
- [ ] service-ca-operator: https://github.com/openshift/service-ca-operator/blob/master/manifests/05_deploy.yaml#L21
- [ ] csi-snapshot-controller-operator: 



Signed-off-by: Sam Batschelet <sbatsche@redhat.com>