### PR TITLE
Bug 1837540: Use restore pod yaml from the backup when restoring

### DIFF
--- a/bindata/etcd/cluster-restore.sh
+++ b/bindata/etcd/cluster-restore.sh
@@ -7,17 +7,26 @@ set -o pipefail
 set -o errtrace
 
 # example
-# ./cluster-restore.sh $path-to-backup 
+# ./cluster-restore.sh $path-to-backup
 
 if [[ $EUID -ne 0 ]]; then
   echo "This script must be run as root"
   exit 1
 fi
 
-source /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
-source /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
+function source_required_dependency {
+  local path="$1"
+  if [ ! -f "${path}" ]; then
+    echo "required dependencies not found, please ensure this script is run on a node with a functional etcd static pod"
+    exit 1
+  fi
+  # shellcheck disable=SC1090
+  source "${path}"
+}
+source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
+source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
 
-function usage {
+function usage() {
   echo 'Path to the directory containing backup files is required: ./cluster-restore.sh <path-to-backup>'
   echo 'The backup directory is expected to be contain two files:'
   echo '        1. etcd snapshot'
@@ -34,23 +43,36 @@ function restore_static_pods() {
   STATIC_PODS=("$@")
 
   for POD_FILE_NAME in "${STATIC_PODS[@]}"; do
-    BACKUP_POD_PATH=$(tar -tvf ${BACKUP_FILE} "*${POD_FILE_NAME}" | awk '{ print $6 }') || true
+    BACKUP_POD_PATH=$(tar -tvf "${BACKUP_FILE}" "*${POD_FILE_NAME}" | awk '{ print $6 }') || true
     if [ -z "${BACKUP_POD_PATH}" ]; then
       echo "${POD_FILE_NAME} does not exist in ${BACKUP_FILE}"
       exit 1
     fi
 
     echo "starting ${POD_FILE_NAME}"
-    tar -xvf ${BACKUP_FILE} --strip-components=2 -C ${MANIFEST_DIR}/ ${BACKUP_POD_PATH}
+    tar -xvf "${BACKUP_FILE}" --strip-components=2 -C "${MANIFEST_DIR}"/ "${BACKUP_POD_PATH}"
   done
 }
+
+function extract_and_start_restore_etcd_pod() {
+  POD_FILE_NAME="restore-etcd-pod/pod.yaml"
+   BACKUP_POD_PATH=$(tar -tvf "${BACKUP_FILE}" "*${POD_FILE_NAME}" | awk '{ print $6 }') || true
+   if [ -z "${BACKUP_POD_PATH}" ]; then
+     echo "${POD_FILE_NAME} does not exist in ${BACKUP_FILE}"
+     exit 1
+   fi
+
+   echo "starting restored etcd-pod.yaml"
+   tar -O -xvf "${BACKUP_FILE}" -C "${MANIFEST_DIR}"/ "${BACKUP_POD_PATH}" > "${MANIFEST_DIR}"/etcd-pod.yaml
+}
+
 
 function wait_for_containers_to_stop() {
   CONTAINERS=("$@")
 
   for NAME in "${CONTAINERS[@]}"; do
     echo "Waiting for container ${NAME} to stop"
-    while [ ! -z "$(crictl ps --label io.kubernetes.container.name=${NAME} -q)" ]; do
+    while [[ -n $(crictl ps --label io.kubernetes.container.name="${NAME}" -q) ]]; do
       echo -n "."
       sleep 1
     done
@@ -59,10 +81,12 @@ function wait_for_containers_to_stop() {
 }
 
 BACKUP_DIR="$1"
+# shellcheck disable=SC2012
 BACKUP_FILE=$(ls -vd "${BACKUP_DIR}"/static_kuberesources*.tar.gz | tail -1) || true
+# shellcheck disable=SC2012
 SNAPSHOT_FILE=$(ls -vd "${BACKUP_DIR}"/snapshot*.db | tail -1) || true
 STATIC_POD_LIST=("kube-apiserver-pod.yaml" "kube-controller-manager-pod.yaml" "kube-scheduler-pod.yaml")
-STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "kube-controller-manager" "kube-apiserver" "kube-scheduler") 
+STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "kube-controller-manager" "kube-apiserver" "kube-scheduler")
 
 if [ ! -f "${SNAPSHOT_FILE}" ]; then
   echo "etcd snapshot ${SNAPSHOT_FILE} does not exist"
@@ -71,7 +95,7 @@ fi
 
 # Move manifests and stop static pods
 if [ ! -d "$MANIFEST_STOPPED_DIR" ]; then
-  mkdir -p $MANIFEST_STOPPED_DIR
+  mkdir -p "$MANIFEST_STOPPED_DIR"
 fi
 
 # Move static pod manifests out of MANIFEST_DIR
@@ -84,28 +108,28 @@ done
 # wait for every static pod container to stop
 wait_for_containers_to_stop "${STATIC_POD_CONTAINERS[@]}"
 
-if [ ! -d ${ETCD_DATA_DIR_BACKUP} ]; then
-  mkdir -p ${ETCD_DATA_DIR_BACKUP}
+if [ ! -d "${ETCD_DATA_DIR_BACKUP}" ]; then
+  mkdir -p "${ETCD_DATA_DIR_BACKUP}"
 fi
 
 # backup old data-dir
 if [ -d "${ETCD_DATA_DIR}/member" ]; then
   if [ -d "${ETCD_DATA_DIR_BACKUP}/member" ]; then
     echo "removing previous backup ${ETCD_DATA_DIR_BACKUP}/member"
-    rm -rf ${ETCD_DATA_DIR_BACKUP}/member
+    rm -rf "${ETCD_DATA_DIR_BACKUP}"/member
   fi
   echo "Moving etcd data-dir ${ETCD_DATA_DIR}/member to ${ETCD_DATA_DIR_BACKUP}"
-  mv ${ETCD_DATA_DIR}/member ${ETCD_DATA_DIR_BACKUP}/
+  mv "${ETCD_DATA_DIR}"/member "${ETCD_DATA_DIR_BACKUP}"/
 fi
 
 # Restore static pod resources
-tar -C ${CONFIG_FILE_DIR} -xzf ${BACKUP_FILE} static-pod-resources
+tar -C "${CONFIG_FILE_DIR}" -xzf "${BACKUP_FILE}" static-pod-resources
 
 # Copy snapshot to backupdir
-cp -p ${SNAPSHOT_FILE} ${ETCD_DATA_DIR_BACKUP}/snapshot.db
+cp -p "${SNAPSHOT_FILE}" "${ETCD_DATA_DIR_BACKUP}"/snapshot.db
 
-echo "starting restore-etcd static pod"
-cp -p ${RESTORE_ETCD_POD_YAML} ${MANIFEST_DIR}/etcd-pod.yaml
+# Extract and start restore-etcd pod.yaml
+extract_and_start_restore_etcd_pod
 
 # start remaining static pods
 restore_static_pods "${STATIC_POD_LIST[@]}"

--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -5,7 +5,6 @@ MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
 ETCD_DATA_DIR="/var/lib/etcd"
 ETCD_DATA_DIR_BACKUP="/var/lib/etcd-backup"
 MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
-RESTORE_ETCD_POD_YAML="${CONFIG_FILE_DIR}/static-pod-resources/etcd-certs/configmaps/restore-etcd-pod/pod.yaml"
 ETCDCTL_BIN_DIR="${CONFIG_FILE_DIR}/static-pod-resources/bin"
 PATH=${PATH}:${ETCDCTL_BIN_DIR}
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -174,17 +174,26 @@ set -o pipefail
 set -o errtrace
 
 # example
-# ./cluster-restore.sh $path-to-backup 
+# ./cluster-restore.sh $path-to-backup
 
 if [[ $EUID -ne 0 ]]; then
   echo "This script must be run as root"
   exit 1
 fi
 
-source /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
-source /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
+function source_required_dependency {
+  local path="$1"
+  if [ ! -f "${path}" ]; then
+    echo "required dependencies not found, please ensure this script is run on a node with a functional etcd static pod"
+    exit 1
+  fi
+  # shellcheck disable=SC1090
+  source "${path}"
+}
+source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
+source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
 
-function usage {
+function usage() {
   echo 'Path to the directory containing backup files is required: ./cluster-restore.sh <path-to-backup>'
   echo 'The backup directory is expected to be contain two files:'
   echo '        1. etcd snapshot'
@@ -201,23 +210,36 @@ function restore_static_pods() {
   STATIC_PODS=("$@")
 
   for POD_FILE_NAME in "${STATIC_PODS[@]}"; do
-    BACKUP_POD_PATH=$(tar -tvf ${BACKUP_FILE} "*${POD_FILE_NAME}" | awk '{ print $6 }') || true
+    BACKUP_POD_PATH=$(tar -tvf "${BACKUP_FILE}" "*${POD_FILE_NAME}" | awk '{ print $6 }') || true
     if [ -z "${BACKUP_POD_PATH}" ]; then
       echo "${POD_FILE_NAME} does not exist in ${BACKUP_FILE}"
       exit 1
     fi
 
     echo "starting ${POD_FILE_NAME}"
-    tar -xvf ${BACKUP_FILE} --strip-components=2 -C ${MANIFEST_DIR}/ ${BACKUP_POD_PATH}
+    tar -xvf "${BACKUP_FILE}" --strip-components=2 -C "${MANIFEST_DIR}"/ "${BACKUP_POD_PATH}"
   done
 }
+
+function extract_and_start_restore_etcd_pod() {
+  POD_FILE_NAME="restore-etcd-pod/pod.yaml"
+   BACKUP_POD_PATH=$(tar -tvf "${BACKUP_FILE}" "*${POD_FILE_NAME}" | awk '{ print $6 }') || true
+   if [ -z "${BACKUP_POD_PATH}" ]; then
+     echo "${POD_FILE_NAME} does not exist in ${BACKUP_FILE}"
+     exit 1
+   fi
+
+   echo "starting restored etcd-pod.yaml"
+   tar -O -xvf "${BACKUP_FILE}" -C "${MANIFEST_DIR}"/ "${BACKUP_POD_PATH}" > "${MANIFEST_DIR}"/etcd-pod.yaml
+}
+
 
 function wait_for_containers_to_stop() {
   CONTAINERS=("$@")
 
   for NAME in "${CONTAINERS[@]}"; do
     echo "Waiting for container ${NAME} to stop"
-    while [ ! -z "$(crictl ps --label io.kubernetes.container.name=${NAME} -q)" ]; do
+    while [[ -n $(crictl ps --label io.kubernetes.container.name="${NAME}" -q) ]]; do
       echo -n "."
       sleep 1
     done
@@ -226,10 +248,12 @@ function wait_for_containers_to_stop() {
 }
 
 BACKUP_DIR="$1"
+# shellcheck disable=SC2012
 BACKUP_FILE=$(ls -vd "${BACKUP_DIR}"/static_kuberesources*.tar.gz | tail -1) || true
+# shellcheck disable=SC2012
 SNAPSHOT_FILE=$(ls -vd "${BACKUP_DIR}"/snapshot*.db | tail -1) || true
 STATIC_POD_LIST=("kube-apiserver-pod.yaml" "kube-controller-manager-pod.yaml" "kube-scheduler-pod.yaml")
-STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "kube-controller-manager" "kube-apiserver" "kube-scheduler") 
+STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "kube-controller-manager" "kube-apiserver" "kube-scheduler")
 
 if [ ! -f "${SNAPSHOT_FILE}" ]; then
   echo "etcd snapshot ${SNAPSHOT_FILE} does not exist"
@@ -238,7 +262,7 @@ fi
 
 # Move manifests and stop static pods
 if [ ! -d "$MANIFEST_STOPPED_DIR" ]; then
-  mkdir -p $MANIFEST_STOPPED_DIR
+  mkdir -p "$MANIFEST_STOPPED_DIR"
 fi
 
 # Move static pod manifests out of MANIFEST_DIR
@@ -251,28 +275,28 @@ done
 # wait for every static pod container to stop
 wait_for_containers_to_stop "${STATIC_POD_CONTAINERS[@]}"
 
-if [ ! -d ${ETCD_DATA_DIR_BACKUP} ]; then
-  mkdir -p ${ETCD_DATA_DIR_BACKUP}
+if [ ! -d "${ETCD_DATA_DIR_BACKUP}" ]; then
+  mkdir -p "${ETCD_DATA_DIR_BACKUP}"
 fi
 
 # backup old data-dir
 if [ -d "${ETCD_DATA_DIR}/member" ]; then
   if [ -d "${ETCD_DATA_DIR_BACKUP}/member" ]; then
     echo "removing previous backup ${ETCD_DATA_DIR_BACKUP}/member"
-    rm -rf ${ETCD_DATA_DIR_BACKUP}/member
+    rm -rf "${ETCD_DATA_DIR_BACKUP}"/member
   fi
   echo "Moving etcd data-dir ${ETCD_DATA_DIR}/member to ${ETCD_DATA_DIR_BACKUP}"
-  mv ${ETCD_DATA_DIR}/member ${ETCD_DATA_DIR_BACKUP}/
+  mv "${ETCD_DATA_DIR}"/member "${ETCD_DATA_DIR_BACKUP}"/
 fi
 
 # Restore static pod resources
-tar -C ${CONFIG_FILE_DIR} -xzf ${BACKUP_FILE} static-pod-resources
+tar -C "${CONFIG_FILE_DIR}" -xzf "${BACKUP_FILE}" static-pod-resources
 
 # Copy snapshot to backupdir
-cp -p ${SNAPSHOT_FILE} ${ETCD_DATA_DIR_BACKUP}/snapshot.db
+cp -p "${SNAPSHOT_FILE}" "${ETCD_DATA_DIR_BACKUP}"/snapshot.db
 
-echo "starting restore-etcd static pod"
-cp -p ${RESTORE_ETCD_POD_YAML} ${MANIFEST_DIR}/etcd-pod.yaml
+# Extract and start restore-etcd pod.yaml
+extract_and_start_restore_etcd_pod
 
 # start remaining static pods
 restore_static_pods "${STATIC_POD_LIST[@]}"
@@ -343,7 +367,6 @@ MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
 ETCD_DATA_DIR="/var/lib/etcd"
 ETCD_DATA_DIR_BACKUP="/var/lib/etcd-backup"
 MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
-RESTORE_ETCD_POD_YAML="${CONFIG_FILE_DIR}/static-pod-resources/etcd-certs/configmaps/restore-etcd-pod/pod.yaml"
 ETCDCTL_BIN_DIR="${CONFIG_FILE_DIR}/static-pod-resources/bin"
 PATH=${PATH}:${ETCDCTL_BIN_DIR}
 

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -267,6 +267,7 @@ var RevisionConfigMaps = []revision.RevisionResource{
 	{Name: "etcd-peer-client-ca"},
 	{Name: "etcd-metrics-proxy-serving-ca"},
 	{Name: "etcd-metrics-proxy-client-ca"},
+	{Name: "restore-etcd-pod"},
 }
 
 // RevisionSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.
@@ -277,7 +278,6 @@ var RevisionSecrets = []revision.RevisionResource{
 }
 
 var CertConfigMaps = []revision.RevisionResource{
-	{Name: "restore-etcd-pod"},
 	{Name: "etcd-scripts"},
 	{Name: "etcd-serving-ca"},
 	{Name: "etcd-peer-client-ca"},


### PR DESCRIPTION
Currently when we restore a cluster from backup, we use restore-pod.yaml from the currently installed image. This is problematic especially when switching across releases (minor or micro release versions).

