### PR TITLE
Bug 1881082: remove erroneously specified label drop rules

### DIFF
--- a/manifests/0000_90_etcd-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_etcd-operator_03_servicemonitor.yaml
@@ -9,15 +9,6 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
-    metricRelabelings:
-    - action: drop
-      regex: etcd_(debugging|disk|request|server).*
-      sourceLabels:
-      - __name__
-    - action: drop
-      regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
-      sourceLabels:
-      - __name__
     port: https
     scheme: https
     tlsConfig:


### PR DESCRIPTION
This patch removes Prometheus label drop rules which were erroneously carried
over from etcd or the apiserver. These rules caused debugging metrics exposed by
the operator to be inadvertently dropped.