### PR TITLE
Bug 1883610: Use more reliable ss in place of lsof

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -142,7 +142,7 @@ ${COMPUTED_ENV_VARS}
         # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
         # so we do the detection in etcd container itsefl.
         echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
-        while [ -n "$(lsof -ni :2379)$(lsof -ni :2380)$(lsof -ni :9978)" ]; do
+        while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 or sport = 9978 )')" ]; do
           echo -n "."
           sleep 1
         done

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -604,7 +604,7 @@ ${COMPUTED_ENV_VARS}
         # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
         # so we do the detection in etcd container itsefl.
         echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
-        while [ -n "$(lsof -ni :2379)$(lsof -ni :2380)$(lsof -ni :9978)" ]; do
+        while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 or sport = 9978 )')" ]; do
           echo -n "."
           sleep 1
         done


### PR DESCRIPTION
`lsof` doesn't output ports in TIME_WAIT but `ss` does. Therefore, it is more reliable to use `ss` to detect the port condition.