### PR TITLE
Bug 1883772: pkg/operator/clustermembercontroller: resync every minute

### DIFF
--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -56,7 +56,7 @@ func NewClusterMemberController(
 		kubeInformers.InformersFor("").Core().V1().Nodes().Informer(),
 		networkInformer.Informer(),
 		operatorClient.Informer(),
-	).WithSync(c.sync).ToController("ClusterMemberController", eventRecorder.WithComponentSuffix("cluster-member-controller"))
+	).WithSync(c.sync).ResyncEvery(time.Minute).ToController("ClusterMemberController", eventRecorder.WithComponentSuffix("cluster-member-controller"))
 }
 
 func (c *ClusterMemberController) sync(ctx context.Context, syncCtx factory.SyncContext) error {


### PR DESCRIPTION
In certain circumstances such as transient client failure followed by the operator process being killed (leader election lost) the operator can get in a situation where we forget to retry scaling members.

In this case we see the caches sync but scaling was not retried.

```
I0929 07:50:39.362608       1 shared_informer.go:223] Waiting for caches to sync for ClusterMemberController
I0929 07:50:40.862752       1 shared_informer.go:230] Caches are synced for ClusterMemberController
```

This PR ensures that we revisit membership in the case of a leaked event or unexpected cache to make sure we don't have any further work to do.