### PR TITLE
*: enable pprof profiler for operator

### DIFF
--- a/manifests/0000_12_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_06_deployment.yaml
@@ -60,6 +60,8 @@ spec:
           value: "0.0.1-snapshot"
         - name: OPERAND_IMAGE_VERSION
           value: "0.0.1-snapshot"
+        - name: OPENSHIFT_PROFILE
+          value: "web"
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
enable profiler by default so we can dig deeper into performance improvements with the operator itself without any change to running operator spec or log level. pprof has no perf impact when not used so I don't see any downside to enabling by default.

usage example

```
oc rsh -n openshift-etcd-operator etcd-operator-5d46b88565-lfwdh curl --output - http://127.0.0.1:6060/debug/pprof/heap > heap
```

