### PR TITLE
Revert "Bug 1840358: etcd-quorum-guard remove toleration timeouts"

### DIFF
--- a/manifests/0000_12_etcd-operator_08_etcdquorumguard_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_08_etcdquorumguard_deployment.yaml
@@ -44,9 +44,11 @@ spec:
         - key: node.kubernetes.io/not-ready
           effect: NoExecute
           operator: Exists
+          tolerationSeconds: 120
         - key: node.kubernetes.io/unreachable
           effect: NoExecute
           operator: Exists
+          tolerationSeconds: 120
         - key: node-role.kubernetes.io/etcd
           operator: Exists
           effect: NoSchedule


### PR DESCRIPTION
Reverts openshift/cluster-etcd-operator#426

Not 100% certain yet this is required but it could be related to https://bugzilla.redhat.com/show_bug.cgi?id=1883521#c1