### PR TITLE
Bug 1882176: Validate certs for the current IP address of the node

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -1,0 +1,300 @@
+package etcdcertsigner
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"github.com/openshift/library-go/pkg/crypto"
+	"math/big"
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"go.etcd.io/etcd/pkg/mock/mockserver"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+	u "github.com/openshift/cluster-etcd-operator/pkg/testutils"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+var (
+	rootcaPublicKey  *rsa.PublicKey
+	rootcaPrivateKey *rsa.PrivateKey
+	publicKeyHash    []byte
+	DummyPrivateKey  []byte
+	DummyCertificate []byte
+)
+
+func initialize(t *testing.T) {
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	rootcaPublicKey = &privateKey.PublicKey
+	rootcaPrivateKey = privateKey
+	if err == nil {
+		hash := sha1.New()
+		hash.Write(rootcaPublicKey.N.Bytes())
+		publicKeyHash = hash.Sum(nil)
+	}
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2020),
+		Subject: pkix.Name{
+			Organization: []string{"Red Hat"},
+			Country:      []string{"US"},
+			Province:     []string{""},
+			Locality:     []string{"Raleigh"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, rootcaPublicKey, rootcaPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+	caPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(caPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(rootcaPrivateKey),
+	})
+	DummyCertificate = caPEM.Bytes()
+	DummyPrivateKey = caPrivKeyPEM.Bytes()
+
+}
+
+func TestValidateSAN(t *testing.T) {
+	initialize(t)
+	mockEtcd, err := mockserver.StartMockServers(3)
+	if err != nil {
+		t.Fatalf("failed to start mock servers: %s", err)
+	}
+	defer mockEtcd.Stop()
+	scenarios := []struct {
+		name            string
+		objects         []runtime.Object
+		staticPodStatus *operatorv1.StaticPodOperatorStatus
+		wantErr         bool
+		validateFunc    func(ts *testing.T, actions []clientgotesting.Action)
+	}{
+		{
+			// All secrets match the node and IP address configuration.
+			name: "NormalSteadyState",
+			objects: []runtime.Object{
+				u.FakeNode("master-0", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.1")),
+				u.FakeNode("master-1", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.2")),
+				u.FakeNode("master-2", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.3")),
+				u.EndpointsConfigMap(
+					u.WithAddress("10.0.0.1"),
+					u.WithAddress("10.0.0.2"),
+					u.WithAddress("10.0.0.3"),
+				),
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "openshift-config",
+						Name:      "etcd-signer",
+					},
+					Data: map[string][]byte{
+						"tls.crt": DummyCertificate,
+						"tls.key": DummyPrivateKey,
+					},
+				},
+
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "openshift-config",
+						Name:      "etcd-metric-signer",
+					},
+					Data: map[string][]byte{
+						"tls.crt": DummyCertificate,
+						"tls.key": DummyPrivateKey,
+					},
+				},
+				u.FakeSecret("openshift-etcd", "etcd-peer-master-0", makeCerts(t, []string{"localhost", "10.0.0.1"})),
+				u.FakeSecret("openshift-etcd", "etcd-peer-master-1", makeCerts(t, []string{"localhost", "10.0.0.2"})),
+				u.FakeSecret("openshift-etcd", "etcd-peer-master-2", makeCerts(t, []string{"localhost", "10.0.0.3"})),
+
+				u.FakeSecret("openshift-etcd", "etcd-serving-master-0", makeCerts(t, []string{"localhost", "10.0.0.1"})),
+				u.FakeSecret("openshift-etcd", "etcd-serving-master-1", makeCerts(t, []string{"localhost", "10.0.0.2"})),
+				u.FakeSecret("openshift-etcd", "etcd-serving-master-2", makeCerts(t, []string{"localhost", "10.0.0.3"})),
+
+				u.FakeSecret("openshift-etcd", "etcd-serving-metrics-master-0", makeCerts(t, []string{"localhost", "10.0.0.1"})),
+				u.FakeSecret("openshift-etcd", "etcd-serving-metrics-master-1", makeCerts(t, []string{"localhost", "10.0.0.2"})),
+				u.FakeSecret("openshift-etcd", "etcd-serving-metrics-master-2", makeCerts(t, []string{"localhost", "10.0.0.3"})),
+			},
+			staticPodStatus: u.StaticPodOperatorStatus(
+				u.WithLatestRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+			),
+			wantErr: false,
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
+				for _, action := range actions {
+					if action.Matches("update", "secrets") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						actual := updateAction.GetObject().(*corev1.Secret)
+						ts.Errorf("unexpected secret update: %#v", actual)
+					}
+				}
+			},
+		},
+
+		{
+			// IP addresses do not match the SAN configured in the certificates.
+			// master-2 has a new IP addr (10.0.0.33) but certs still have old SAN (10.0.0.3).
+			name: "IPMismatch",
+			objects: []runtime.Object{
+				u.FakeNode("master-0", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.1")),
+				u.FakeNode("master-1", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.2")),
+				u.FakeNode("master-2", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.33")),
+				u.EndpointsConfigMap(
+					u.WithAddress("10.0.0.1"),
+					u.WithAddress("10.0.0.2"),
+					u.WithAddress("10.0.0.33"),
+				),
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "openshift-config",
+						Name:      "etcd-signer",
+					},
+					Data: map[string][]byte{
+						"tls.crt": DummyCertificate,
+						"tls.key": DummyPrivateKey,
+					},
+				},
+
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "openshift-config",
+						Name:      "etcd-metric-signer",
+					},
+					Data: map[string][]byte{
+						"tls.crt": DummyCertificate,
+						"tls.key": DummyPrivateKey,
+					},
+				},
+				u.FakeSecret("openshift-etcd", "etcd-peer-master-0", makeCerts(t, []string{"localhost", "10.0.0.1"})),
+				u.FakeSecret("openshift-etcd", "etcd-peer-master-1", makeCerts(t, []string{"localhost", "10.0.0.2"})),
+				u.FakeSecret("openshift-etcd", "etcd-peer-master-2", makeCerts(t, []string{"localhost", "10.0.0.3"})),
+
+				u.FakeSecret("openshift-etcd", "etcd-serving-master-0", makeCerts(t, []string{"localhost", "10.0.0.1"})),
+				u.FakeSecret("openshift-etcd", "etcd-serving-master-1", makeCerts(t, []string{"localhost", "10.0.0.2"})),
+				u.FakeSecret("openshift-etcd", "etcd-serving-master-2", makeCerts(t, []string{"localhost", "10.0.0.3"})),
+
+				u.FakeSecret("openshift-etcd", "etcd-serving-metrics-master-0", makeCerts(t, []string{"localhost", "10.0.0.1"})),
+				u.FakeSecret("openshift-etcd", "etcd-serving-metrics-master-1", makeCerts(t, []string{"localhost", "10.0.0.2"})),
+				u.FakeSecret("openshift-etcd", "etcd-serving-metrics-master-2", makeCerts(t, []string{"localhost", "10.0.0.3"})),
+			},
+			staticPodStatus: u.StaticPodOperatorStatus(
+				u.WithLatestRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+			),
+			wantErr: true,
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				&operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+				},
+				scenario.staticPodStatus,
+				nil,
+				nil,
+			)
+
+			fakeKubeClient := fake.NewSimpleClientset(scenario.objects...)
+			eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events(operatorclient.TargetNamespace), "test-etcdendpointscontroller", &corev1.ObjectReference{})
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, obj := range scenario.objects {
+				if err := indexer.Add(obj); err != nil {
+					t.Fatal(err)
+				}
+			}
+			controller := &EtcdCertSignerController{
+				kubeClient:           fakeKubeClient,
+				operatorClient:       fakeOperatorClient,
+				infrastructureLister: configlistersv1.NewInfrastructureLister(indexer),
+				secretLister:         corev1listers.NewSecretLister(indexer),
+				nodeLister:           corev1listers.NewNodeLister(indexer),
+				secretClient:         fakeKubeClient.CoreV1(),
+			}
+
+			err := controller.sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
+			if (err != nil) != scenario.wantErr {
+				t.Fatal(err)
+			}
+			if scenario.validateFunc != nil {
+				scenario.validateFunc(t, fakeKubeClient.Actions())
+			}
+		})
+	}
+}
+
+func makeCerts(t *testing.T, hosts []string) map[string][]byte {
+
+	ipAddrs, dnsAddrs := crypto.IPAddressesDNSNames(hosts)
+	rootcaTemplate := &x509.Certificate{
+		Subject:               pkix.Name{CommonName: fmt.Sprintf("etcd-cert-signer_@%d", time.Now().Unix())},
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		SerialNumber:          big.NewInt(1),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           ipAddrs,
+		DNSNames:              dnsAddrs,
+		AuthorityKeyId:        publicKeyHash,
+		SubjectKeyId:          publicKeyHash,
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, rootcaTemplate, rootcaTemplate, rootcaPublicKey, rootcaPrivateKey)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+	caPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(caPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(rootcaPrivateKey),
+	})
+	return map[string][]byte{"tls.crt": caPEM.Bytes(), "tls.key": caPrivKeyPEM.Bytes()}
+}

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
@@ -2,8 +2,6 @@ package etcdendpointscontroller
 
 import (
 	"context"
-	"encoding/base64"
-	"fmt"
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -11,7 +9,6 @@ import (
 	"go.etcd.io/etcd/pkg/mock/mockserver"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -21,6 +18,7 @@ import (
 
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+	u "github.com/openshift/cluster-etcd-operator/pkg/testutils"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -44,27 +42,27 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 			// and all nodes have converged on a revision.
 			name: "NewClusterBootstrapRemoval",
 			objects: []runtime.Object{
-				node("master-0", withMasterLabel(), withNodeInternalIP("10.0.0.1")),
-				node("master-1", withMasterLabel(), withNodeInternalIP("10.0.0.2")),
-				node("master-2", withMasterLabel(), withNodeInternalIP("10.0.0.3")),
-				bootstrapConfigMap(withBootstrapStatus("complete")),
-				endpointsConfigMap(
-					withBootstrapIP("192.0.2.1"),
-					withAddress("10.0.0.1"),
-					withAddress("10.0.0.2"),
-					withAddress("10.0.0.3"),
+				u.FakeNode("master-0", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.1")),
+				u.FakeNode("master-1", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.2")),
+				u.FakeNode("master-2", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.3")),
+				u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
+				u.EndpointsConfigMap(
+					u.WithBootstrapIP("192.0.2.1"),
+					u.WithAddress("10.0.0.1"),
+					u.WithAddress("10.0.0.2"),
+					u.WithAddress("10.0.0.3"),
 				),
 			},
-			staticPodStatus: staticPodOperatorStatus(
-				withLatestRevision(3),
-				withNodeStatusAtCurrentRevision(3),
-				withNodeStatusAtCurrentRevision(3),
-				withNodeStatusAtCurrentRevision(3),
+			staticPodStatus: u.StaticPodOperatorStatus(
+				u.WithLatestRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
 			),
 			etcdMembers: []*etcdserverpb.Member{
-				etcdMember(0, mockEtcd.Servers),
-				etcdMember(1, mockEtcd.Servers),
-				etcdMember(2, mockEtcd.Servers),
+				u.FakeEtcdMember(0, mockEtcd.Servers),
+				u.FakeEtcdMember(1, mockEtcd.Servers),
+				u.FakeEtcdMember(2, mockEtcd.Servers),
 			},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
 				wasValidated := false
@@ -72,10 +70,10 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 					if action.Matches("update", "configmaps") {
 						updateAction := action.(clientgotesting.UpdateAction)
 						actual := updateAction.GetObject().(*corev1.ConfigMap)
-						expected := endpointsConfigMap(
-							withAddress("10.0.0.1"),
-							withAddress("10.0.0.2"),
-							withAddress("10.0.0.3"),
+						expected := u.EndpointsConfigMap(
+							u.WithAddress("10.0.0.1"),
+							u.WithAddress("10.0.0.2"),
+							u.WithAddress("10.0.0.3"),
 						)
 						if !equality.Semantic.DeepEqual(actual, expected) {
 							ts.Errorf(diff.ObjectDiff(expected, actual))
@@ -94,22 +92,22 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 			// reports complete, the nodes are still progressing towards a revision.
 			name: "NewClusterBootstrapNodesProgressing",
 			objects: []runtime.Object{
-				node("master-0", withMasterLabel(), withNodeInternalIP("10.0.0.1")),
-				node("master-1", withMasterLabel(), withNodeInternalIP("10.0.0.2")),
-				node("master-2", withMasterLabel(), withNodeInternalIP("10.0.0.3")),
-				bootstrapConfigMap(withBootstrapStatus("complete")),
-				endpointsConfigMap(
-					withBootstrapIP("192.0.2.1"),
-					withAddress("10.0.0.1"),
-					withAddress("10.0.0.2"),
-					withAddress("10.0.0.3"),
+				u.FakeNode("master-0", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.1")),
+				u.FakeNode("master-1", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.2")),
+				u.FakeNode("master-2", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.3")),
+				u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
+				u.EndpointsConfigMap(
+					u.WithBootstrapIP("192.0.2.1"),
+					u.WithAddress("10.0.0.1"),
+					u.WithAddress("10.0.0.2"),
+					u.WithAddress("10.0.0.3"),
 				),
 			},
-			staticPodStatus: staticPodOperatorStatus(
-				withLatestRevision(3),
-				withNodeStatusAtCurrentRevision(3),
-				withNodeStatusAtCurrentRevision(2),
-				withNodeStatusAtCurrentRevision(3),
+			staticPodStatus: u.StaticPodOperatorStatus(
+				u.WithLatestRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(2),
+				u.WithNodeStatusAtCurrentRevision(3),
 			),
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
 				for _, action := range actions {
@@ -126,22 +124,22 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 			// to have converged on a revision, bootstrap reports incomplete.
 			name: "NewClusterBootstrapProgressing",
 			objects: []runtime.Object{
-				node("master-0", withMasterLabel(), withNodeInternalIP("10.0.0.1")),
-				node("master-1", withMasterLabel(), withNodeInternalIP("10.0.0.2")),
-				node("master-2", withMasterLabel(), withNodeInternalIP("10.0.0.3")),
-				bootstrapConfigMap(withBootstrapStatus("progressing")),
-				endpointsConfigMap(
-					withBootstrapIP("192.0.2.1"),
-					withAddress("10.0.0.1"),
-					withAddress("10.0.0.2"),
-					withAddress("10.0.0.3"),
+				u.FakeNode("master-0", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.1")),
+				u.FakeNode("master-1", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.2")),
+				u.FakeNode("master-2", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.3")),
+				u.BootstrapConfigMap(u.WithBootstrapStatus("progressing")),
+				u.EndpointsConfigMap(
+					u.WithBootstrapIP("192.0.2.1"),
+					u.WithAddress("10.0.0.1"),
+					u.WithAddress("10.0.0.2"),
+					u.WithAddress("10.0.0.3"),
 				),
 			},
-			staticPodStatus: staticPodOperatorStatus(
-				withLatestRevision(3),
-				withNodeStatusAtCurrentRevision(3),
-				withNodeStatusAtCurrentRevision(3),
-				withNodeStatusAtCurrentRevision(3),
+			staticPodStatus: u.StaticPodOperatorStatus(
+				u.WithLatestRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
 			),
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
 				for _, action := range actions {
@@ -157,21 +155,21 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 			// The configmap should remain intact because there are no changes.
 			name: "NewClusterSteadyState",
 			objects: []runtime.Object{
-				node("master-0", withMasterLabel(), withNodeInternalIP("10.0.0.1")),
-				node("master-1", withMasterLabel(), withNodeInternalIP("10.0.0.2")),
-				node("master-2", withMasterLabel(), withNodeInternalIP("10.0.0.3")),
-				bootstrapConfigMap(withBootstrapStatus("complete")),
-				endpointsConfigMap(
-					withAddress("10.0.0.1"),
-					withAddress("10.0.0.2"),
-					withAddress("10.0.0.3"),
+				u.FakeNode("master-0", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.1")),
+				u.FakeNode("master-1", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.2")),
+				u.FakeNode("master-2", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.3")),
+				u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
+				u.EndpointsConfigMap(
+					u.WithAddress("10.0.0.1"),
+					u.WithAddress("10.0.0.2"),
+					u.WithAddress("10.0.0.3"),
 				),
 			},
-			staticPodStatus: staticPodOperatorStatus(
-				withLatestRevision(3),
-				withNodeStatusAtCurrentRevision(3),
-				withNodeStatusAtCurrentRevision(3),
-				withNodeStatusAtCurrentRevision(3),
+			staticPodStatus: u.StaticPodOperatorStatus(
+				u.WithLatestRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
 			),
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
 				for _, action := range actions {
@@ -192,16 +190,16 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 			// for is the configmap being deleted before bootstrapping is complete.
 			name: "UpgradedClusterCreateConfigmap",
 			objects: []runtime.Object{
-				node("master-0", withMasterLabel(), withNodeInternalIP("10.0.0.1")),
-				node("master-1", withMasterLabel(), withNodeInternalIP("10.0.0.2")),
-				node("master-2", withMasterLabel(), withNodeInternalIP("10.0.0.3")),
-				bootstrapConfigMap(withBootstrapStatus("complete")),
+				u.FakeNode("master-0", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.1")),
+				u.FakeNode("master-1", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.2")),
+				u.FakeNode("master-2", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.3")),
+				u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
 			},
-			staticPodStatus: staticPodOperatorStatus(
-				withLatestRevision(3),
-				withNodeStatusAtCurrentRevision(3),
-				withNodeStatusAtCurrentRevision(3),
-				withNodeStatusAtCurrentRevision(3),
+			staticPodStatus: u.StaticPodOperatorStatus(
+				u.WithLatestRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
 			),
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action) {
 				wasValidated := false
@@ -209,10 +207,10 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 					if action.Matches("create", "configmaps") {
 						createAction := action.(clientgotesting.CreateAction)
 						actual := createAction.GetObject().(*corev1.ConfigMap)
-						expected := endpointsConfigMap(
-							withAddress("10.0.0.1"),
-							withAddress("10.0.0.2"),
-							withAddress("10.0.0.3"),
+						expected := u.EndpointsConfigMap(
+							u.WithAddress("10.0.0.1"),
+							u.WithAddress("10.0.0.2"),
+							u.WithAddress("10.0.0.3"),
 						)
 						if !equality.Semantic.DeepEqual(actual, expected) {
 							ts.Errorf(diff.ObjectDiff(expected, actual))
@@ -265,121 +263,5 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 				scenario.validateFunc(t, fakeKubeClient.Actions())
 			}
 		})
-	}
-}
-
-func bootstrapConfigMap(configs ...func(bootstrap *corev1.ConfigMap)) *corev1.ConfigMap {
-	bootstrap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bootstrap",
-			Namespace: "kube-system",
-		},
-		Data: map[string]string{},
-	}
-	for _, config := range configs {
-		config(bootstrap)
-	}
-	return bootstrap
-}
-
-func withBootstrapStatus(status string) func(*corev1.ConfigMap) {
-	return func(bootstrap *corev1.ConfigMap) {
-		bootstrap.Data["status"] = status
-	}
-}
-
-func staticPodOperatorStatus(configs ...func(status *operatorv1.StaticPodOperatorStatus)) *operatorv1.StaticPodOperatorStatus {
-	status := &operatorv1.StaticPodOperatorStatus{
-		OperatorStatus: operatorv1.OperatorStatus{
-			Conditions: []operatorv1.OperatorCondition{},
-		},
-		NodeStatuses: []operatorv1.NodeStatus{},
-	}
-	for _, config := range configs {
-		config(status)
-	}
-	return status
-}
-
-func withLatestRevision(latest int32) func(status *operatorv1.StaticPodOperatorStatus) {
-	return func(status *operatorv1.StaticPodOperatorStatus) {
-		status.LatestAvailableRevision = latest
-	}
-}
-
-func withNodeStatusAtCurrentRevision(current int32) func(*operatorv1.StaticPodOperatorStatus) {
-	return func(status *operatorv1.StaticPodOperatorStatus) {
-		status.NodeStatuses = append(status.NodeStatuses, operatorv1.NodeStatus{
-			CurrentRevision: current,
-		})
-	}
-}
-
-func endpointsConfigMap(configs ...func(endpoints *corev1.ConfigMap)) *corev1.ConfigMap {
-	endpoints := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "etcd-endpoints",
-			Namespace: operatorclient.TargetNamespace,
-		},
-		Data: map[string]string{},
-	}
-	for _, config := range configs {
-		config(endpoints)
-	}
-	return endpoints
-}
-
-func withBootstrapIP(ip string) func(*corev1.ConfigMap) {
-	return func(endpoints *corev1.ConfigMap) {
-		if endpoints.Annotations == nil {
-			endpoints.Annotations = map[string]string{}
-		}
-		endpoints.Annotations[etcdcli.BootstrapIPAnnotationKey] = ip
-	}
-}
-
-func withAddress(ip string) func(*corev1.ConfigMap) {
-	return func(endpoints *corev1.ConfigMap) {
-		endpoints.Data[base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(ip))] = ip
-	}
-}
-
-func node(name string, configs ...func(node *corev1.Node)) *corev1.Node {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}
-	for _, config := range configs {
-		config(node)
-	}
-	return node
-}
-
-func withMasterLabel() func(*corev1.Node) {
-	return func(node *corev1.Node) {
-		if node.Labels == nil {
-			node.Labels = map[string]string{}
-		}
-		node.Labels["node-role.kubernetes.io/master"] = ""
-	}
-}
-
-func withNodeInternalIP(ip string) func(*corev1.Node) {
-	return func(node *corev1.Node) {
-		if node.Status.Addresses == nil {
-			node.Status.Addresses = []corev1.NodeAddress{}
-		}
-		node.Status.Addresses = append(node.Status.Addresses, corev1.NodeAddress{
-			Type:    corev1.NodeInternalIP,
-			Address: ip,
-		})
-	}
-}
-
-func etcdMember(member int, etcdMock []*mockserver.MockServer) *etcdserverpb.Member {
-	return &etcdserverpb.Member{
-		Name:       fmt.Sprintf("etcd-%d", member),
-		ClientURLs: []string{etcdMock[member].Address},
 	}
 }

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -1,0 +1,142 @@
+package testutils
+
+import (
+	"encoding/base64"
+	"fmt"
+	"go.etcd.io/etcd/etcdserver/etcdserverpb"
+	"go.etcd.io/etcd/pkg/mock/mockserver"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+)
+
+func FakeNode(name string, configs ...func(node *corev1.Node)) *corev1.Node {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	for _, config := range configs {
+		config(node)
+	}
+	return node
+}
+
+func WithMasterLabel() func(*corev1.Node) {
+	return func(node *corev1.Node) {
+		if node.Labels == nil {
+			node.Labels = map[string]string{}
+		}
+		node.Labels["node-role.kubernetes.io/master"] = ""
+	}
+}
+
+func WithNodeInternalIP(ip string) func(*corev1.Node) {
+	return func(node *corev1.Node) {
+		if node.Status.Addresses == nil {
+			node.Status.Addresses = []corev1.NodeAddress{}
+		}
+		node.Status.Addresses = append(node.Status.Addresses, corev1.NodeAddress{
+			Type:    corev1.NodeInternalIP,
+			Address: ip,
+		})
+	}
+}
+
+func FakeSecret(namespace, name string, cert map[string][]byte) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: cert,
+	}
+	return secret
+}
+
+func EndpointsConfigMap(configs ...func(endpoints *corev1.ConfigMap)) *corev1.ConfigMap {
+	endpoints := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd-endpoints",
+			Namespace: operatorclient.TargetNamespace,
+		},
+		Data: map[string]string{},
+	}
+	for _, config := range configs {
+		config(endpoints)
+	}
+	return endpoints
+}
+
+func BootstrapConfigMap(configs ...func(bootstrap *corev1.ConfigMap)) *corev1.ConfigMap {
+	bootstrap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bootstrap",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{},
+	}
+	for _, config := range configs {
+		config(bootstrap)
+	}
+	return bootstrap
+}
+
+func WithBootstrapStatus(status string) func(*corev1.ConfigMap) {
+	return func(bootstrap *corev1.ConfigMap) {
+		bootstrap.Data["status"] = status
+	}
+}
+
+func StaticPodOperatorStatus(configs ...func(status *operatorv1.StaticPodOperatorStatus)) *operatorv1.StaticPodOperatorStatus {
+	status := &operatorv1.StaticPodOperatorStatus{
+		OperatorStatus: operatorv1.OperatorStatus{
+			Conditions: []operatorv1.OperatorCondition{},
+		},
+		NodeStatuses: []operatorv1.NodeStatus{},
+	}
+	for _, config := range configs {
+		config(status)
+	}
+	return status
+}
+
+func WithBootstrapIP(ip string) func(*corev1.ConfigMap) {
+	return func(endpoints *corev1.ConfigMap) {
+		if endpoints.Annotations == nil {
+			endpoints.Annotations = map[string]string{}
+		}
+		endpoints.Annotations[etcdcli.BootstrapIPAnnotationKey] = ip
+	}
+}
+
+func WithAddress(ip string) func(*corev1.ConfigMap) {
+	return func(endpoints *corev1.ConfigMap) {
+		endpoints.Data[base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(ip))] = ip
+	}
+}
+
+func WithLatestRevision(latest int32) func(status *operatorv1.StaticPodOperatorStatus) {
+	return func(status *operatorv1.StaticPodOperatorStatus) {
+		status.LatestAvailableRevision = latest
+	}
+}
+
+func WithNodeStatusAtCurrentRevision(current int32) func(*operatorv1.StaticPodOperatorStatus) {
+	return func(status *operatorv1.StaticPodOperatorStatus) {
+		status.NodeStatuses = append(status.NodeStatuses, operatorv1.NodeStatus{
+			CurrentRevision: current,
+		})
+	}
+}
+
+func FakeEtcdMember(member int, etcdMock []*mockserver.MockServer) *etcdserverpb.Member {
+	return &etcdserverpb.Member{
+		Name:       fmt.Sprintf("etcd-%d", member),
+		ClientURLs: []string{etcdMock[member].Address},
+	}
+}


### PR DESCRIPTION
Currently cluster-etcd-operator only checks the existence of the certificates, but doesn't verify the SAN configured in the certs against the current node IP address (hostname).

This PR fixes the problem by parsing the certificate to validate the SAN. If there is a SAN mismatch, it generates a new set of certificates.