### PR TITLE
flowschema for etcd operator traffic

### DIFF
--- a/manifests/0000_12_etcd-operator_10_flowschema.yaml
+++ b/manifests/0000_12_etcd-operator_10_flowschema.yaml
@@ -1,0 +1,26 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-etcd-operator
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 2000
+  priorityLevelConfiguration:
+    name: openshift-control-plane-operators
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: etcd-operator
+        namespace: openshift-etcd-operator


### PR DESCRIPTION
Traffic from control plane operators are important (kas-o, oas-o, auth operator, etcd operator), they have a dedicated concurrency pool now.

See https://github.com/openshift/cluster-kube-apiserver-operator/pull/966 for more details.