### PR TITLE
Bug 1884568: wip: proof liveness probe

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -181,6 +181,12 @@ ${COMPUTED_ENV_VARS}
       periodSeconds: 5
       successThreshold: 1
       timeoutSeconds: 5
+    livenessProbe:
+      httpGet:
+        port: 9989
+        path: health
+      initialDelaySeconds: 3
+      timeoutSeconds: 5
     securityContext:
       privileged: true
     volumeMounts:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -643,6 +643,12 @@ ${COMPUTED_ENV_VARS}
       periodSeconds: 5
       successThreshold: 1
       timeoutSeconds: 5
+    livenessProbe:
+      httpGet:
+        port: 9989
+        path: health
+      initialDelaySeconds: 3
+      timeoutSeconds: 5
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
It is possible for etcd process to become wedged in a failure state that would not result in the process restarting. To reproduce we can send SIGSTOP to etcd process. While quorum-gaurd and the operator would observe this health failure no action would be take to restart the etcd container.  Lets test this situation and see if it is warranted.

sudo kill -SIGSTOP $PID

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>