### PR TITLE
Allow rollbackcopier pod to be disabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	k8s.io/cri-api v0.18.6
 	k8s.io/klog/v2 v2.3.0
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -126,6 +126,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		os.Getenv("IMAGE"),
 		os.Getenv("OPERATOR_IMAGE"),
 		operatorClient,
+		operatorConfigClient,
 		kubeInformersForNamespaces.InformersFor("openshift-etcd"),
 		kubeInformersForNamespaces,
 		configInformers.Config().V1().Infrastructures(),

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -1,0 +1,86 @@
+package targetconfigcontroller
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/utils/diff"
+)
+
+func Test_ensureRollbackCopier(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		config   *operatorv1.Etcd
+		expected *corev1.Pod
+	}{
+		{
+			name:     "copier enabled, preserve copier",
+			pod:      newPod().WithContainers(rollbackCopierContainerName, "etcd").Build(),
+			config:   newEtcdConfig().Build(),
+			expected: newPod().WithContainers(rollbackCopierContainerName, "etcd").Build(),
+		},
+		{
+			name:     "copier disabled, remove copier",
+			pod:      newPod().WithContainers(rollbackCopierContainerName, "etcd").Build(),
+			config:   newEtcdConfig().WithAnnotation(disableRollbackCopierAnnotation, "").Build(),
+			expected: newPod().WithContainers("etcd").Build(),
+		},
+		{
+			name:     "copier disabled, noop",
+			pod:      newPod().WithContainers("etcd").Build(),
+			config:   newEtcdConfig().WithAnnotation(disableRollbackCopierAnnotation, "").Build(),
+			expected: newPod().WithContainers("etcd").Build(),
+		},
+		{
+			name:     "copier enabled, noop",
+			pod:      newPod().WithContainers("etcd").Build(),
+			config:   newEtcdConfig().Build(),
+			expected: newPod().WithContainers("etcd").Build(),
+		},
+	}
+
+	for _, tc := range tests {
+		actual := ensureRollbackCopier(tc.pod, tc.config)
+		if !equality.Semantic.DeepEqual(actual, tc.expected) {
+			t.Errorf(diff.ObjectDiff(tc.expected, actual))
+		}
+	}
+}
+
+type podBuilder struct {
+	corev1.Pod
+}
+
+func newPod() *podBuilder { return &podBuilder{} }
+
+func (b *podBuilder) WithContainers(names ...string) *podBuilder {
+	for _, name := range names {
+		b.Spec.Containers = append(b.Spec.Containers, corev1.Container{Name: name})
+	}
+	return b
+}
+
+func (b *podBuilder) Build() *corev1.Pod {
+	return &b.Pod
+}
+
+type etcdConfigBuilder struct {
+	operatorv1.Etcd
+}
+
+func newEtcdConfig() *etcdConfigBuilder { return &etcdConfigBuilder{} }
+
+func (b *etcdConfigBuilder) WithAnnotation(k, v string) *etcdConfigBuilder {
+	if b.Annotations == nil {
+		b.Annotations = map[string]string{}
+	}
+	b.Annotations[k] = v
+	return b
+}
+
+func (b *etcdConfigBuilder) Build() *operatorv1.Etcd {
+	return &b.Etcd
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -933,5 +933,6 @@ sigs.k8s.io/structured-merge-diff/v4/schema
 sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
 # vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787


### PR DESCRIPTION
Allow the `rollbackcopier` container in the etcd pod to to be disabled using a
`openshift.io/disable-rollbackcopier` annotation. The `rollbackcopier` container
is only present in versions 4.4 and 4.5. This patch is implemented in such a way
that the disable function can be introduced in the latest release and
backported. The new code should effectively no-op in releases where
`rollbackcopier` is not present.