### PR TITLE
WIP: Allow rollbackcopier pod to be disabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,5 @@ require (
 	k8s.io/component-base v0.18.6
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -128,6 +128,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		os.Getenv("IMAGE"),
 		os.Getenv("OPERATOR_IMAGE"),
 		operatorClient,
+		operatorConfigClient,
 		kubeInformersForNamespaces.InformersFor("openshift-etcd"),
 		kubeInformersForNamespaces,
 		configInformers.Config().V1().Infrastructures(),

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
@@ -14,10 +16,13 @@ import (
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/yaml"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
+	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -31,11 +36,17 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/version"
 )
 
+const (
+	disableRollbackCopierAnnotation = "openshift.io/disable-rollbackcopier"
+	rollbackCopierContainerName     = "rollbackcopier"
+)
+
 type TargetConfigController struct {
 	targetImagePullSpec   string
 	operatorImagePullSpec string
 
-	operatorClient v1helpers.StaticPodOperatorClient
+	operatorClient       v1helpers.StaticPodOperatorClient
+	operatorConfigClient operatorversionedclient.Interface
 
 	kubeClient           kubernetes.Interface
 	infrastructureLister configv1listers.InfrastructureLister
@@ -51,6 +62,7 @@ type TargetConfigController struct {
 func NewTargetConfigController(
 	targetImagePullSpec, operatorImagePullSpec string,
 	operatorClient v1helpers.StaticPodOperatorClient,
+	operatorConfigClient operatorversionedclient.Interface,
 	kubeInformersForOpenshiftEtcdNamespace informers.SharedInformerFactory,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	infrastructureInformer configv1informers.InfrastructureInformer,
@@ -64,6 +76,7 @@ func NewTargetConfigController(
 		operatorImagePullSpec: operatorImagePullSpec,
 
 		operatorClient:       operatorClient,
+		operatorConfigClient: operatorConfigClient,
 		kubeClient:           kubeClient,
 		infrastructureLister: infrastructureInformer.Lister(),
 		networkLister:        networkInformer.Lister(),
@@ -120,7 +133,7 @@ func createTargetConfig(c TargetConfigController, recorder events.Recorder, oper
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/config", err))
 	}
-	_, _, err = c.manageStandardPod(contentReplacer, c.kubeClient.CoreV1(), recorder, operatorSpec)
+	_, _, err = c.manageStandardPod(contentReplacer, c.kubeClient.CoreV1(), c.operatorConfigClient.OperatorV1(), recorder, operatorSpec)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/etcd-pod", err))
 	}
@@ -220,15 +233,48 @@ func (c *TargetConfigController) manageRecoveryPod(substitutionReplacer *strings
 	return resourceapply.ApplyConfigMap(client, recorder, podConfigMap)
 }
 
-func (c *TargetConfigController) manageStandardPod(substitutionReplacer *strings.Replacer, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec) (*corev1.ConfigMap, bool, error) {
+func (c *TargetConfigController) manageStandardPod(substitutionReplacer *strings.Replacer, client coreclientv1.ConfigMapsGetter, etcdsClient operatorclientv1.EtcdsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec) (*corev1.ConfigMap, bool, error) {
 	podBytes := etcd_assets.MustAsset("etcd/pod.yaml")
 	substitutedPodString := substitutionReplacer.Replace(string(podBytes))
+
+	// Remove the rollbackcopier container if desired.
+	etcdConfig, err := etcdsClient.Etcds().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, false, err
+	}
+	pod := &corev1.Pod{}
+	if err := yaml.Unmarshal(podBytes, pod); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal etcd pod: %w", err)
+	}
+	updatedPod := ensureRollbackCopier(pod, etcdConfig)
+	if !equality.Semantic.DeepEqual(pod, updatedPod) {
+		newPodBytes, err := yaml.Marshal(updatedPod)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to marshal etcd pod: %w", err)
+		}
+		podBytes = newPodBytes
+	}
 
 	podConfigMap := resourceread.ReadConfigMapV1OrDie(etcd_assets.MustAsset("etcd/pod-cm.yaml"))
 	podConfigMap.Data["pod.yaml"] = substitutedPodString
 	podConfigMap.Data["forceRedeploymentReason"] = operatorSpec.ForceRedeploymentReason
 	podConfigMap.Data["version"] = version.Get().String()
 	return resourceapply.ApplyConfigMap(client, recorder, podConfigMap)
+}
+
+func ensureRollbackCopier(etcdPod *corev1.Pod, etcdConfig *operatorv1.Etcd) *corev1.Pod {
+	_, rollbackCopierDisabled := etcdConfig.Annotations[disableRollbackCopierAnnotation]
+	if !rollbackCopierDisabled {
+		return etcdPod
+	}
+	updated := etcdPod.DeepCopy()
+	for i, container := range updated.Spec.Containers {
+		if container.Name == rollbackCopierContainerName {
+			updated.Spec.Containers = append(updated.Spec.Containers[:i], updated.Spec.Containers[i+1:]...)
+			break
+		}
+	}
+	return updated
 }
 
 func (c *TargetConfigController) Enqueue() {

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -1,0 +1,86 @@
+package targetconfigcontroller
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/utils/diff"
+)
+
+func Test_ensureRollbackCopier(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		config   *operatorv1.Etcd
+		expected *corev1.Pod
+	}{
+		{
+			name:     "copier enabled, preserve copier",
+			pod:      newPod().WithContainers(rollbackCopierContainerName, "etcd").Build(),
+			config:   newEtcdConfig().Build(),
+			expected: newPod().WithContainers(rollbackCopierContainerName, "etcd").Build(),
+		},
+		{
+			name:     "copier disabled, remove copier",
+			pod:      newPod().WithContainers(rollbackCopierContainerName, "etcd").Build(),
+			config:   newEtcdConfig().WithAnnotation(disableRollbackCopierAnnotation, "").Build(),
+			expected: newPod().WithContainers("etcd").Build(),
+		},
+		{
+			name:     "copier disabled, noop",
+			pod:      newPod().WithContainers("etcd").Build(),
+			config:   newEtcdConfig().WithAnnotation(disableRollbackCopierAnnotation, "").Build(),
+			expected: newPod().WithContainers("etcd").Build(),
+		},
+		{
+			name:     "copier enabled, noop",
+			pod:      newPod().WithContainers("etcd").Build(),
+			config:   newEtcdConfig().Build(),
+			expected: newPod().WithContainers("etcd").Build(),
+		},
+	}
+
+	for _, tc := range tests {
+		actual := ensureRollbackCopier(tc.pod, tc.config)
+		if !equality.Semantic.DeepEqual(actual, tc.expected) {
+			t.Errorf(diff.ObjectDiff(tc.expected, actual))
+		}
+	}
+}
+
+type podBuilder struct {
+	corev1.Pod
+}
+
+func newPod() *podBuilder { return &podBuilder{} }
+
+func (b *podBuilder) WithContainers(names ...string) *podBuilder {
+	for _, name := range names {
+		b.Spec.Containers = append(b.Spec.Containers, corev1.Container{Name: name})
+	}
+	return b
+}
+
+func (b *podBuilder) Build() *corev1.Pod {
+	return &b.Pod
+}
+
+type etcdConfigBuilder struct {
+	operatorv1.Etcd
+}
+
+func newEtcdConfig() *etcdConfigBuilder { return &etcdConfigBuilder{} }
+
+func (b *etcdConfigBuilder) WithAnnotation(k, v string) *etcdConfigBuilder {
+	if b.Annotations == nil {
+		b.Annotations = map[string]string{}
+	}
+	b.Annotations[k] = v
+	return b
+}
+
+func (b *etcdConfigBuilder) Build() *operatorv1.Etcd {
+	return &b.Etcd
+}


### PR DESCRIPTION
Allow the `rollbackcopier` container in the etcd pod to to be disabled using a
`openshift.io/disable-rollbackcopier` annotation.