### PR TITLE
Bug 1894267: Remove the rollbackcopier

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -233,34 +233,6 @@ ${COMPUTED_ENV_VARS}
         name: cert-dir
       - mountPath: /var/lib/etcd/
         name: data-dir
-  - name: rollbackcopier
-    image: ${OPERATOR_IMAGE}
-    imagePullPolicy: IfNotPresent
-    terminationMessagePolicy: FallbackToLogsOnError
-    command:
-      - /bin/sh
-      - -c
-      - |
-        #!/bin/sh
-        set -euo pipefail
-
-        export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
-        exec cluster-etcd-operator rollbackcopy
-    resources:
-      requests:
-        memory: 60Mi
-        cpu: 30m
-    securityContext:
-      privileged: true
-    volumeMounts:
-      - mountPath: /etc/kubernetes/rollbackcopy
-        name: rollbackcopy
-      - mountPath: /etc/kubernetes/static-pod-resources
-        name: full-resource-dir
-      - mountPath: /etc/kubernetes/static-pod-certs
-        name: cert-dir
-    env:
-${COMPUTED_ENV_VARS}
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -276,12 +248,6 @@ ${COMPUTED_ENV_VARS}
         path: /etc/kubernetes/static-pod-resources/etcd-pod-REVISION
       name: resource-dir
     - hostPath:
-        path: /etc/kubernetes/static-pod-resources
-      name: full-resource-dir
-    - hostPath:
-        path: /etc/kubernetes/rollbackcopy
-      name: rollbackcopy
-    - hostPath:
         path: /etc/kubernetes/static-pod-resources/etcd-certs
       name: cert-dir
     - hostPath:
@@ -291,4 +257,3 @@ ${COMPUTED_ENV_VARS}
     - hostPath:
         path: /usr/local/bin
       name: usr-local-bin
-

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -700,34 +700,6 @@ ${COMPUTED_ENV_VARS}
         name: cert-dir
       - mountPath: /var/lib/etcd/
         name: data-dir
-  - name: rollbackcopier
-    image: ${OPERATOR_IMAGE}
-    imagePullPolicy: IfNotPresent
-    terminationMessagePolicy: FallbackToLogsOnError
-    command:
-      - /bin/sh
-      - -c
-      - |
-        #!/bin/sh
-        set -euo pipefail
-
-        export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
-        exec cluster-etcd-operator rollbackcopy
-    resources:
-      requests:
-        memory: 60Mi
-        cpu: 30m
-    securityContext:
-      privileged: true
-    volumeMounts:
-      - mountPath: /etc/kubernetes/rollbackcopy
-        name: rollbackcopy
-      - mountPath: /etc/kubernetes/static-pod-resources
-        name: full-resource-dir
-      - mountPath: /etc/kubernetes/static-pod-certs
-        name: cert-dir
-    env:
-${COMPUTED_ENV_VARS}
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -743,12 +715,6 @@ ${COMPUTED_ENV_VARS}
         path: /etc/kubernetes/static-pod-resources/etcd-pod-REVISION
       name: resource-dir
     - hostPath:
-        path: /etc/kubernetes/static-pod-resources
-      name: full-resource-dir
-    - hostPath:
-        path: /etc/kubernetes/rollbackcopy
-      name: rollbackcopy
-    - hostPath:
         path: /etc/kubernetes/static-pod-resources/etcd-certs
       name: cert-dir
     - hostPath:
@@ -758,7 +724,6 @@ ${COMPUTED_ENV_VARS}
     - hostPath:
         path: /usr/local/bin
       name: usr-local-bin
-
 `)
 
 func etcdPodYamlBytes() ([]byte, error) {


### PR DESCRIPTION
The rollbackcopier container exists to support a 4.4->4.5 upgrade. Once
4.5 is running, the container is no longer needed provided a 4.4 backup
exists prior to the upgrade, which the rollbackcopier basically assures.

The copier itself incurs a performance penalty that 4.5 users shouldn't
be subject to once the upgrade is complete.