### PR TITLE
Bug 1897543: DR: Make restore pod yaml specific to restoring node

### DIFF
--- a/bindata/etcd/cluster-restore.sh
+++ b/bindata/etcd/cluster-restore.sh
@@ -53,6 +53,42 @@ function restore_static_pods() {
     tar -xvf "${BACKUP_FILE}" --strip-components=2 -C "${MANIFEST_DIR}"/ "${BACKUP_POD_PATH}"
   done
 }
+function replace_node_specific_parameters() {
+
+  pod_file="$1"
+  declare -A SUBS_MAP
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['export ETCD_NAME=.*$']='export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['export ETCD_INITIAL_CLUSTER=.*$']='export ETCD_INITIAL_CLUSTER="${ETCD_NAME}=https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:2380"'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['export ETCD_NODE_PEER_URL=.*$']='export ETCD_NODE_PEER_URL=https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:2380'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--initial-advertise-peer-urls .*$']='--initial-advertise-peer-urls $ETCD_NODE_PEER_URL \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--initial-advertise-peer-urls=.*$']='--initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--cert-file=.*$']='--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.crt \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--key-file=.*$']='--key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--peer-cert-file=.*$']='--peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--peer-key-file=.*$']='--peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--advertise-client-urls=.*$']='--advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \\'
+
+  for pattern in "${!SUBS_MAP[@]}"; do
+    # check if the pattern exists, and return with error if it doesn't
+    if ! grep -- "$pattern" "$pod_file" > /dev/null 2>&1; then
+      echo "Warning: restore pod extraction failed: expected pattern \"$pattern\" not found."
+      return 1
+    fi
+    # replace the pattern
+    sed -i "s,$pattern,${SUBS_MAP[$pattern]},g"  "$pod_file"
+  done
+}
+
 
 function extract_and_start_restore_etcd_pod() {
   POD_FILE_NAME="restore-etcd-pod/pod.yaml"
@@ -64,6 +100,13 @@ function extract_and_start_restore_etcd_pod() {
 
    echo "starting restored etcd-pod.yaml"
    tar -O -xvf "${BACKUP_FILE}" -C "${MANIFEST_DIR}"/ "${BACKUP_POD_PATH}" > "${MANIFEST_DIR}"/etcd-pod.yaml
+
+   # Since the backup could have been taken on any node, we need to replace the node specific values in the restore pod.
+   echo "replacing node specific parameters in restore etcd-pod.yaml"
+   if ! replace_node_specific_parameters "${MANIFEST_DIR}"/etcd-pod.yaml; then
+     return 1
+   fi
+
    return 0
 }
 
@@ -132,7 +175,13 @@ cp -p "${SNAPSHOT_FILE}" "${ETCD_DATA_DIR_BACKUP}"/snapshot.db
 # Extract and start restore-etcd pod.yaml
 if ! extract_and_start_restore_etcd_pod; then
   # If backup doesn't have restore-pod.yaml, copy it from local disk
-  cp -p ${RESTORE_ETCD_POD_YAML} ${MANIFEST_DIR}/etcd-pod.yaml
+  echo "Warning: could not extract restore pod. Using the restore pod manifest on the disk."
+  if [ ! -f "${RESTORE_ETCD_POD_YAML}" ]; then
+    echo "Error: failed to create restore pod yaml. Exiting!"
+    exit 1
+  fi
+
+  cp -p "${RESTORE_ETCD_POD_YAML}" "${MANIFEST_DIR}/etcd-pod.yaml"
 fi
 
 # start remaining static pods

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -220,6 +220,42 @@ function restore_static_pods() {
     tar -xvf "${BACKUP_FILE}" --strip-components=2 -C "${MANIFEST_DIR}"/ "${BACKUP_POD_PATH}"
   done
 }
+function replace_node_specific_parameters() {
+
+  pod_file="$1"
+  declare -A SUBS_MAP
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['export ETCD_NAME=.*$']='export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['export ETCD_INITIAL_CLUSTER=.*$']='export ETCD_INITIAL_CLUSTER="${ETCD_NAME}=https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:2380"'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['export ETCD_NODE_PEER_URL=.*$']='export ETCD_NODE_PEER_URL=https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:2380'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--initial-advertise-peer-urls .*$']='--initial-advertise-peer-urls $ETCD_NODE_PEER_URL \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--initial-advertise-peer-urls=.*$']='--initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--cert-file=.*$']='--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.crt \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--key-file=.*$']='--key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--peer-cert-file=.*$']='--peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--peer-key-file=.*$']='--peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key \\'
+# shellcheck disable=SC2016,SC1003
+  SUBS_MAP['--advertise-client-urls=.*$']='--advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \\'
+
+  for pattern in "${!SUBS_MAP[@]}"; do
+    # check if the pattern exists, and return with error if it doesn't
+    if ! grep -- "$pattern" "$pod_file" > /dev/null 2>&1; then
+      echo "Warning: restore pod extraction failed: expected pattern \"$pattern\" not found."
+      return 1
+    fi
+    # replace the pattern
+    sed -i "s,$pattern,${SUBS_MAP[$pattern]},g"  "$pod_file"
+  done
+}
+
 
 function extract_and_start_restore_etcd_pod() {
   POD_FILE_NAME="restore-etcd-pod/pod.yaml"
@@ -231,6 +267,13 @@ function extract_and_start_restore_etcd_pod() {
 
    echo "starting restored etcd-pod.yaml"
    tar -O -xvf "${BACKUP_FILE}" -C "${MANIFEST_DIR}"/ "${BACKUP_POD_PATH}" > "${MANIFEST_DIR}"/etcd-pod.yaml
+
+   # Since the backup could have been taken on any node, we need to replace the node specific values in the restore pod.
+   echo "replacing node specific parameters in restore etcd-pod.yaml"
+   if ! replace_node_specific_parameters "${MANIFEST_DIR}"/etcd-pod.yaml; then
+     return 1
+   fi
+
    return 0
 }
 
@@ -299,7 +342,13 @@ cp -p "${SNAPSHOT_FILE}" "${ETCD_DATA_DIR_BACKUP}"/snapshot.db
 # Extract and start restore-etcd pod.yaml
 if ! extract_and_start_restore_etcd_pod; then
   # If backup doesn't have restore-pod.yaml, copy it from local disk
-  cp -p ${RESTORE_ETCD_POD_YAML} ${MANIFEST_DIR}/etcd-pod.yaml
+  echo "Warning: could not extract restore pod. Using the restore pod manifest on the disk."
+  if [ ! -f "${RESTORE_ETCD_POD_YAML}" ]; then
+    echo "Error: failed to create restore pod yaml. Exiting!"
+    exit 1
+  fi
+
+  cp -p "${RESTORE_ETCD_POD_YAML}" "${MANIFEST_DIR}/etcd-pod.yaml"
 fi
 
 # start remaining static pods


### PR DESCRIPTION
The current restore pod yaml has node specific URLs which makes it not usable across the cluster on any node to restore.

This PR replaces node specific values in the backup at the time of restore with the values relevant to the node on which it is being restored.