### PR TITLE
Bug 1844727: Use socket readiness probe to avoid generating zombies

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -163,11 +163,8 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      exec:
-        command:
-          - /bin/sh
-          - -ec
-          - "lsof -n -i :2380 | grep LISTEN"
+      tcpSocket:
+        port: 2380
       failureThreshold: 3
       initialDelaySeconds: 3
       periodSeconds: 5

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -83,11 +83,8 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      exec:
-        command:
-          - /bin/sh
-          - -ec
-          - "lsof -n -i :2380 | grep LISTEN"
+      tcpSocket:
+        port: 2380
       failureThreshold: 3
       initialDelaySeconds: 3
       periodSeconds: 5

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -593,11 +593,8 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      exec:
-        command:
-          - /bin/sh
-          - -ec
-          - "lsof -n -i :2380 | grep LISTEN"
+      tcpSocket:
+        port: 2380
       failureThreshold: 3
       initialDelaySeconds: 3
       periodSeconds: 5
@@ -800,11 +797,8 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      exec:
-        command:
-          - /bin/sh
-          - -ec
-          - "lsof -n -i :2380 | grep LISTEN"
+      tcpSocket:
+        port: 2380
       failureThreshold: 3
       initialDelaySeconds: 3
       periodSeconds: 5


### PR DESCRIPTION
Replace the `exec` etcd readiness probe with a `tcpSocket` probe because
the `exec` version generates zombie processes in the container. The new
probe should be functionally equivalent.