### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_12_etcd-operator_00_namespace.yaml
+++ b/manifests/0000_12_etcd-operator_00_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_12_etcd-operator_01_operator.cr.yaml
+++ b/manifests/0000_12_etcd-operator_01_operator.cr.yaml
@@ -7,5 +7,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed

--- a/manifests/0000_12_etcd-operator_02_service.yaml
+++ b/manifests/0000_12_etcd-operator_02_service.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: etcd-operator-serving-cert
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: etcd-operator
   name: metrics

--- a/manifests/0000_12_etcd-operator_03_configmap.yaml
+++ b/manifests/0000_12_etcd-operator_03_configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1
@@ -20,6 +21,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: etcd-ca-bundle
   namespace: openshift-etcd-operator
 ---
@@ -32,5 +34,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
     service.beta.openshift.io/inject-cabundle: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: etcd-service-ca-bundle
   namespace: openshift-etcd-operator

--- a/manifests/0000_12_etcd-operator_03_secret.yaml
+++ b/manifests/0000_12_etcd-operator_03_secret.yaml
@@ -7,5 +7,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: etcd-client
   namespace: openshift-etcd-operator

--- a/manifests/0000_12_etcd-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_12_etcd-operator_04_clusterrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/0000_12_etcd-operator_05_serviceaccount.yaml
+++ b/manifests/0000_12_etcd-operator_05_serviceaccount.yaml
@@ -7,3 +7,4 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/0000_12_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_06_deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: etcd-operator
 spec:

--- a/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
+++ b/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}
 status:
   versions:

--- a/manifests/0000_12_etcd-operator_08_etcdquorumguard_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_08_etcdquorumguard_deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 3
   selector:

--- a/manifests/0000_12_etcd-operator_09_etcdquorumguard_pdb.yaml
+++ b/manifests/0000_12_etcd-operator_09_etcdquorumguard_pdb.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   maxUnavailable: 1
   selector:

--- a/manifests/0000_12_etcd-operator_10_flowschema.yaml
+++ b/manifests/0000_12_etcd-operator_10_flowschema.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   distinguisherMethod:
     type: ByUser

--- a/manifests/0000_90_etcd-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_etcd-operator_01_prometheusrole.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_etcd-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_90_etcd-operator_02_prometheusrolebinding.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_etcd-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_etcd-operator_03_servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.