### PR TITLE
switch to v1beta1 for the p&f APIs

### DIFF
--- a/manifests/0000_12_etcd-operator_10_flowschema.yaml
+++ b/manifests/0000_12_etcd-operator_10_flowschema.yaml
@@ -1,4 +1,4 @@
-apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta1
 kind: FlowSchema
 metadata:
   name: openshift-etcd-operator


### PR DESCRIPTION
Important Note: We support upgrade and downgrade - 4.7 to 4.6 downgrade would behave very badly (in a skew case). So we should NOT back port to 4.7
