### PR TITLE
Bug 1851810: *: ensure etcd listens on strong ciphers

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -2,8 +2,6 @@ package etcdenvvar
 
 import (
 	"fmt"
-	"github.com/openshift/library-go/pkg/crypto"
-	"go.etcd.io/etcd/pkg/tlsutil"
 	"runtime"
 	"strings"
 
@@ -13,6 +11,8 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
+	"go.etcd.io/etcd/pkg/tlsutil"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 )

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -2,15 +2,19 @@ package etcdenvvar
 
 import (
 	"fmt"
+	"github.com/openshift/library-go/pkg/crypto"
+	"go.etcd.io/etcd/pkg/tlsutil"
 	"runtime"
 	"strings"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/dnshelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
 )
 
 type envVarContext struct {
@@ -29,6 +33,7 @@ var FixedEtcdEnvVars = map[string]string{
 	"ETCD_QUOTA_BACKEND_BYTES":   "7516192768", // 7 gig
 	"ETCD_INITIAL_CLUSTER_STATE": "existing",
 	"ETCD_ENABLE_PPROF":          "true",
+	"ETCD_CIPHER_SUITES":         getDefaultCipherSuites(),
 }
 
 type envVarFunc func(envVarContext envVarContext) (map[string]string, error)
@@ -257,4 +262,28 @@ func getUnsupportedArch(envVarContext envVarContext) (map[string]string, error) 
 	return map[string]string{
 		"ETCD_UNSUPPORTED_ARCH": arch,
 	}, nil
+}
+
+//TODO replace with TLS security policy observer
+func getDefaultCipherSuites() string {
+	profileSpec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	// whitelist ciphers for use with etcd
+	cipherSuites := whitelistEtcdCipherSuites(crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers))
+	return strings.Join(cipherSuites, ",")
+}
+
+// whitelistEtcdCipherSuites ensures ciphers are valid for use with etcd.
+// TODO move upstream
+func whitelistEtcdCipherSuites(cipherSuites []string) []string {
+	whitelist := []string{}
+	for _, cipher := range cipherSuites {
+		_, ok := tlsutil.GetCipherSuite(cipher)
+		if !ok {
+			// skip and log unsupported ciphers
+			klog.Warningf("cipher is not supported for use with etcd: %q", cipher)
+			continue
+		}
+		whitelist = append(whitelist, cipher)
+	}
+	return whitelist
 }

--- a/pkg/etcdenvvar/etcd_env_test.go
+++ b/pkg/etcdenvvar/etcd_env_test.go
@@ -1,0 +1,40 @@
+package etcdenvvar
+
+import (
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+// TestWhitelistEtcdCipherSuites this test is intended to ensure the ciphers we support is explicitly understood overtime.
+// As etcd minor versions increment golang versions will as well, so this test will need to be maintained against changes
+// to the etcd whitelist[1] and or TLSProfileIntermediateType.
+//[1] https://github.com/etcd-io/etcd/blob/release-3.4/pkg/tlsutil/cipher_suites.go
+func TestWhitelistEtcdCipherSuites(t *testing.T) {
+	tests := []struct {
+		name    string
+		ciphers []string
+		want    []string
+	}{
+		{
+			name:    "test TLS v1.2 (current supported runtime)",
+			ciphers: crypto.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
+			want: []string{
+				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", // https://ciphersuite.info/cs/TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256/
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",   // https://ciphersuite.info/cs/TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256/
+				"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", // https://ciphersuite.info/cs/TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384/
+				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",   // https://ciphersuite.info/cs/TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384/
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := whitelistEtcdCipherSuites(test.ciphers)
+			if !reflect.DeepEqual(test.want, got) {
+				t.Errorf("want %v got %v", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Today etcd will accept any cipher that was part of golang 1.12 unfortunately some of these ciphers are considered weak exposing us to vulnerabilities such as SWEET32. This PR resolved the issue by defining a default using the `TLSProfileIntermediateType`[1]. These ciphers are available in golang 1.12 -> 1.15 so apiserver will have 100% compatibility and are considered strong tls v1.2.

Currently, etcd does not provide an explicit cipher suite, the result is etcd is exposed to various exploits on week ciphers such as SWEET32.

The plans are to supersede this PR by adding a TLS observer, but we have a problem with using the kube-apiservers default for various reasons including lack of default support for tls 1.3.

[1] https://github.com/openshift/api/blob/release-4.6/config/v1/types_tlssecurityprofile.go
[2] https://github.com/openshift/cluster-etcd-operator/pull/480

