### PR TITLE
[wip] test enable tls1.3 support for etcd

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -29,11 +29,11 @@ type envVarContext struct {
 }
 
 var FixedEtcdEnvVars = map[string]string{
-	"ETCD_DATA_DIR":              "/var/lib/etcd",
-	"ETCD_QUOTA_BACKEND_BYTES":   "7516192768", // 7 gig
-	"ETCD_INITIAL_CLUSTER_STATE": "existing",
-	"ETCD_ENABLE_PPROF":          "true",
-	"GODEBUG":                    "tls13=1",
+	"ETCD_DATA_DIR":                                 "/var/lib/etcd",
+	"ETCD_QUOTA_BACKEND_BYTES":                      "7516192768", // 7 gig
+	"ETCD_INITIAL_CLUSTER_STATE":                    "existing",
+	"ETCD_ENABLE_PPROF":                             "true",
+	"ETCD_EXPERIMENTAL_BACKEND_BBOLT_FREELIST_TYPE": "map",
 }
 
 type envVarFunc func(envVarContext envVarContext) (map[string]string, error)

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -33,7 +33,7 @@ var FixedEtcdEnvVars = map[string]string{
 	"ETCD_QUOTA_BACKEND_BYTES":   "7516192768", // 7 gig
 	"ETCD_INITIAL_CLUSTER_STATE": "existing",
 	"ETCD_ENABLE_PPROF":          "true",
-	"ETCD_CIPHER_SUITES":         getDefaultCipherSuites(),
+	"GODEBUG":                    "tls13=1",
 }
 
 type envVarFunc func(envVarContext envVarContext) (map[string]string, error)

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -216,9 +216,12 @@ func getHeartbeatInterval(envVarContext envVarContext) (map[string]string, error
 
 	if status := infrastructure.Status.PlatformStatus; status != nil {
 		switch {
+		case status.AWS != nil:
+			heartbeat = "10"
 		case status.Azure != nil:
 			heartbeat = "500"
 		}
+
 	}
 
 	return map[string]string{


### PR DESCRIPTION
etcd is compiled with golang 1.12 which does not enable tls 1.3 by default this is a test for enabling it.[1]

[1] https://golang.org/doc/go1.12#tls_1_3