### PR TITLE
Bug 1907872: Make dual stack bootstrapping more reliable

### DIFF
--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -447,8 +447,12 @@ func getMachineCIDR(installConfig map[string]interface{}, isSingleStackIPv6 bool
 		return "", fmt.Errorf("unrecognized data structure in networking field")
 	}
 
-	for _, network := range networking["machineNetwork"].([]interface{})[0].(map[string]interface{}) {
-		machineCIDR := fmt.Sprintf("%v", network)
+	for _, machineNetwork := range networking["machineNetwork"].([]interface{}) {
+		network := machineNetwork.(map[string]interface{})
+		machineCIDR := fmt.Sprintf("%v", network["cidr"])
+		if len(machineCIDR) == 0 {
+			return "", fmt.Errorf("malformed machineNetwork entry is missing the cidr field: %#v", network)
+		}
 		broadcast, _, err := net.ParseCIDR(machineCIDR)
 		if err != nil {
 			return "", err

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghodss/yaml"
+
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/render/options"
 )
 
@@ -487,4 +489,107 @@ type fakeBootstrapIPLocator struct {
 
 func (f *fakeBootstrapIPLocator) getBootstrapIP(ipv6 bool, machineCIDR string, excludedIPs []string) (net.IP, error) {
 	return f.ip, nil
+}
+
+const installConfigSingleStackIPv4 = `
+apiVersion: v1
+metadata:
+  name: my-cluster
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineCIDR: 10.0.0.0/16
+  machineNetwork:
+  - foo: bar
+    cidr: 10.0.0.0/16
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+`
+
+const installConfigDualStack = `
+apiVersion: v1
+metadata:
+  name: my-cluster
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineCIDR: 10.0.0.0/16
+  machineNetwork:
+  - foo: bar
+    cidr: 2620:52:0:1302::/64
+  - cidr: 10.0.0.0/16
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+`
+
+const installConfigSingleStackIPv6 = `
+apiVersion: v1
+metadata:
+  name: my-cluster
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineCIDR: 10.0.0.0/16
+  machineNetwork:
+  - foo: bar
+    cidr: 2620:52:0:1302::/64
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+`
+
+func Test_getMachineCIDR(t *testing.T) {
+	tests := map[string]struct {
+		installConfig     string
+		isSingleStackIPv6 bool
+		expectedCIDR      string
+		expectedErr       error
+	}{
+		"should locate the ipv4 cidr in a single stack ipv4 config": {
+			installConfig:     installConfigSingleStackIPv4,
+			isSingleStackIPv6: false,
+			expectedCIDR:      "10.0.0.0/16",
+			expectedErr:       nil,
+		},
+		"should locate the ipv4 cidr in a dual stack config": {
+			installConfig:     installConfigDualStack,
+			isSingleStackIPv6: false,
+			expectedCIDR:      "10.0.0.0/16",
+			expectedErr:       nil,
+		},
+		"should locate the ipv6 cidr in a single stack ipv6 config": {
+			installConfig:     installConfigSingleStackIPv6,
+			isSingleStackIPv6: true,
+			expectedCIDR:      "2620:52:0:1302::/64",
+			expectedErr:       nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var installConfig map[string]interface{}
+			if err := yaml.Unmarshal([]byte(test.installConfig), &installConfig); err != nil {
+				panic(err)
+			}
+			cidr, err := getMachineCIDR(installConfig, test.isSingleStackIPv6)
+			if err != nil {
+				if test.expectedErr == nil {
+					t.Errorf("unexpected error: %w", err)
+					return
+				}
+			} else {
+				if test.expectedErr != nil {
+					t.Errorf("expected but didn't get an error")
+				}
+			}
+			if cidr != test.expectedCIDR {
+				t.Errorf("expected CIDR %q, got %q", test.expectedCIDR, cidr)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Due to a parsing bug, the bootstrap rendering logic fails to detect a usable
machine network CIDR when using IPv6 dual stack mode unless the IPv4 CIDR is the
first element in the install config's machineNetwork array, which is brittle.

This patch fixes the parsing mistake so that the IPv4 address can be located
amongst the machineNetwork CIDRs in dual stack mode.

Although ideally etcd would detect and bind to the "preferred" family and that
family would be again located here during bootstrap CIDR detection, such a
change would be more invasive. The scope of this fix is to get dual stack
reliably working even if it means using IPv4 inconsistently during bootstrapping
when IPv6 would be more consistent.