### PR TITLE
Bug 1925586: pkg/operator/metriccontroller: cleanup transports

### DIFF
--- a/pkg/operator/metriccontroller/fsync_controller.go
+++ b/pkg/operator/metriccontroller/fsync_controller.go
@@ -34,7 +34,13 @@ func NewFSyncController(operatorClient operatorv1helpers.OperatorClient, infraCl
 }
 
 func (c *FSyncController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	client, err := getPrometheusClient(ctx, c.secretClient)
+	transport, err := getTransport()
+	if err != nil {
+		return err
+	}
+	defer transport.CloseIdleConnections()
+
+	client, err := getPrometheusClient(ctx, c.secretClient, transport)
 	if errors.IsNotFound(err) {
 		return nil
 	}


### PR DESCRIPTION
4.7.0-0.nightly-2021-02-02-223803
![20210205_10h26m18s_grim](https://user-images.githubusercontent.com/1249749/107056719-9f4d3e80-67a0-11eb-8735-d53cb73f2032.png)

4.7.0-0.nightly-2021-02-05-105159 CI
![latest-4 7-nightly](https://user-images.githubusercontent.com/1249749/107057000-f05d3280-67a0-11eb-9302-1f6e1aca7351.png)

This PR
![transport-cleanup](https://user-images.githubusercontent.com/1249749/107057034-ff43e500-67a0-11eb-95c0-1bf9c39f94e6.png)


Closes https://github.com/openshift/cluster-etcd-operator/issues/533
