### PR TITLE
Bug 1920159: CPU requests overstate actual needs

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -42,7 +42,7 @@ spec:
       resources:
         requests:
           memory: 60Mi
-          cpu: 30m
+          cpu: 10m
       securityContext:
         privileged: true
       env:
@@ -68,7 +68,7 @@ ${COMPUTED_ENV_VARS}
       resources:
         requests:
           memory: 60Mi
-          cpu: 30m
+          cpu: 10m
       securityContext:
         privileged: true
       volumeMounts:
@@ -92,7 +92,7 @@ ${COMPUTED_ENV_VARS}
     resources:
       requests:
         memory: 60Mi
-        cpu: 30m
+        cpu: 10m
     volumeMounts:
       - mountPath: /etc/kubernetes/manifests
         name: static-pod-dir
@@ -209,7 +209,7 @@ ${COMPUTED_ENV_VARS}
     resources:
       requests:
         memory: 200Mi
-        cpu: 100m
+        cpu: 40m
     securityContext:
       privileged: true
     volumeMounts:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -505,7 +505,7 @@ spec:
       resources:
         requests:
           memory: 60Mi
-          cpu: 30m
+          cpu: 10m
       securityContext:
         privileged: true
       env:
@@ -531,7 +531,7 @@ ${COMPUTED_ENV_VARS}
       resources:
         requests:
           memory: 60Mi
-          cpu: 30m
+          cpu: 10m
       securityContext:
         privileged: true
       volumeMounts:
@@ -555,7 +555,7 @@ ${COMPUTED_ENV_VARS}
     resources:
       requests:
         memory: 60Mi
-        cpu: 30m
+        cpu: 10m
     volumeMounts:
       - mountPath: /etc/kubernetes/manifests
         name: static-pod-dir
@@ -672,7 +672,7 @@ ${COMPUTED_ENV_VARS}
     resources:
       requests:
         memory: 200Mi
-        cpu: 100m
+        cpu: 40m
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
In production environments etcd is over requested for actual use.
The bulk of that over-requesting comes from the sidecars which
overstate their actual needs. Adjust them based on the calculations
from prod clusters to request roughly 100m less CPU than before.

/hold

While we review these changes together