### PR TITLE
Bug 1924913: A valid etcd endpoint should have the URL scheme prepended.

### DIFF
--- a/pkg/cmd/rollbackcopy/backuputils.go
+++ b/pkg/cmd/rollbackcopy/backuputils.go
@@ -38,7 +38,7 @@ func archiveLatestResources(configDir, backupFile string) error {
 }
 
 func backup(configDir string) error {
-	cli, err := getEtcdClient([]string{"localhost:2379"})
+	cli, err := getEtcdClient([]string{"https://localhost:2379"})
 	if err != nil {
 		return fmt.Errorf("backup: failed to get etcd client: %w", err)
 	}

--- a/pkg/cmd/rollbackcopy/etcdclientutils.go
+++ b/pkg/cmd/rollbackcopy/etcdclientutils.go
@@ -76,7 +76,7 @@ func getClusterVersionAndUpgradeInfo(cli *clientv3.Client) (string, bool, error)
 }
 
 func checkLeadership(name string) (bool, error) {
-	cli, err := getEtcdClient([]string{"localhost:2379"})
+	cli, err := getEtcdClient([]string{"https://localhost:2379"})
 	if err != nil {
 		return false, fmt.Errorf("checkLeadership: failed to get etcd client: %w", err)
 	}


### PR DESCRIPTION
A valid etcd endpoint should have a valid URL scheme prefixed. 

The only reason it continues to work is because etcd client was disregarding this setting, and getting a subconn based on the environment variables.