### PR TITLE
Bug 1929359: pkg/operator/quorumguardcontroller: use cli image from release payload

### DIFF
--- a/manifests/0000_12_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_06_deployment.yaml
@@ -57,6 +57,8 @@ spec:
           value: quay.io/openshift/origin-etcd
         - name: OPERATOR_IMAGE
           value: quay.io/openshift/origin-cluster-etcd-operator
+        - name: CLI_IMAGE
+          value: quay.io/openshift/origin-cli
         - name: OPERATOR_IMAGE_VERSION
           value: "0.0.1-snapshot"
         - name: OPERAND_IMAGE_VERSION

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -13,4 +13,4 @@ spec:
   - name: cli
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-cli:latest
+      name: quay.io/openshift/origin-cli

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -226,6 +226,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		kubeInformersForNamespaces,
 		controllerContext.EventRecorder,
 		configInformers.Config().V1().Infrastructures().Lister(),
+		os.Getenv("CLI_IMAGE"),
 	)
 
 	unsupportedConfigOverridesController := unsupportedconfigoverridescontroller.NewUnsupportedConfigOverridesController(


### PR DESCRIPTION
During the migration of quorum-guard from CVO to controller managed we forgot to populate the image with an explicit image ref from the release payload. 