### PR TITLE
WIP: manifests/0000_12_etcd-operator_07_clusteroperator: Touch relatedObjects

### DIFF
--- a/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
+++ b/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
@@ -27,5 +27,5 @@ status:
       name: openshift-etcd-operator
       resource: namespaces
     - group: ""
-      name: openshift-etcd
+      name: the-cvo-will-not-add-this-for-you
       resource: namespaces


### PR DESCRIPTION
I'm pretty sure the CVO will not update this for you, either by adding new entries or removing old entries on updates.  The CVO will create the ClusterOperator for you if it doesn't exist, but after that, managing it is up to the 2nd-level operator.