### PR TITLE
Migrate tls bootstrap from the installer

### DIFF
--- a/bindata/bootkube/manifests/etcd-ca-bundle-configmap.yaml
+++ b/bindata/bootkube/manifests/etcd-ca-bundle-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-ca-bundle
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+    {{ .EtcdCaBundle | indent 4 }}

--- a/bindata/bootkube/manifests/etcd-client-secret.yaml
+++ b/bindata/bootkube/manifests/etcd-client-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-client
+  namespace: openshift-config
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .EtcdSignerClientCert | base64 }}
+  tls.key: {{ .EtcdSignerClientKey | base64 }}

--- a/bindata/bootkube/manifests/etcd-metric-client-secret.yaml
+++ b/bindata/bootkube/manifests/etcd-metric-client-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-metric-client
+  namespace: openshift-config
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .EtcdMetricSignerClientCert | base64 }}
+  tls.key: {{ .EtcdMetricSignerClientKey | base64 }}

--- a/bindata/bootkube/manifests/etcd-metric-serving-ca-configmap.yaml
+++ b/bindata/bootkube/manifests/etcd-metric-serving-ca-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-metric-serving-ca
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+    {{ .EtcdMetricCaBundle | indent 4 }}

--- a/bindata/bootkube/manifests/etcd-metric-signer-secret.yaml
+++ b/bindata/bootkube/manifests/etcd-metric-signer-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-metric-signer
+  namespace: openshift-config
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .EtcdMetricSignerCert | base64 }}
+  tls.key: {{ .EtcdMetricSignerKey | base64 }}

--- a/bindata/bootkube/manifests/etcd-serving-ca-configmap.yaml
+++ b/bindata/bootkube/manifests/etcd-serving-ca-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-serving-ca
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+    {{ .EtcdCaBundle | indent 4 }}

--- a/bindata/bootkube/manifests/etcd-signer-secret.yaml
+++ b/bindata/bootkube/manifests/etcd-signer-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-signer
+  namespace: openshift-config
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .EtcdSignerCert | base64 }}
+  tls.key: {{ .EtcdSignerKey | base64 }}

--- a/bindata/bootkube/manifests/openshift-etcd-svc.yaml
+++ b/bindata/bootkube/manifests/openshift-etcd-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+  namespace: openshift-etcd
+  labels:
+    # this label is used to indicate that it should be scraped by prometheus
+    k8s-app: etcd
+spec:
+  selector:
+    k8s-app: etcd
+  ports:
+  - name: etcd
+    port: 2379
+    protocol: TCP
+  - name: etcd-metrics
+    port: 9979
+    protocol: TCP

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.3.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/grpc-gateway v1.14.6 // indirect
 	github.com/openshift/api v0.0.0-20210208192252-670ac3fc997c
 	github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
@@ -26,6 +27,7 @@ require (
 	k8s.io/api v0.20.1
 	k8s.io/apiextensions-apiserver v0.20.1
 	k8s.io/apimachinery v0.20.1
+	k8s.io/apiserver v0.20.1
 	k8s.io/client-go v0.20.1
 	k8s.io/component-base v0.20.1
 	k8s.io/cri-api v0.18.6

--- a/pkg/cmd/render/certs.go
+++ b/pkg/cmd/render/certs.go
@@ -1,0 +1,69 @@
+package render
+
+import (
+	"crypto/x509/pkix"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/openshift/library-go/pkg/crypto"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// keyMaterial simplifies handling of the key data produced by createKeyMaterial
+type keyMaterial struct {
+	caCert     []byte
+	caKey      []byte
+	caBundle   []byte
+	clientCert []byte
+	clientKey  []byte
+}
+
+// createKeyMaterial returns the key material for a self-signed CA, its CA bundle,
+// and a client cert signed by the CA.
+func createKeyMaterial(signerName, clientName string) (*keyMaterial, error) {
+	// CA
+	caSubject := pkix.Name{CommonName: signerName, OrganizationalUnit: []string{"openshift"}}
+	caExpiryDays := 10 * 365 // 10 years
+	signerCAConfig, err := crypto.MakeSelfSignedCAConfigForSubject(caSubject, caExpiryDays)
+	if err != nil {
+		return nil, err
+	}
+	caCert, caKey, err := signerCAConfig.GetPEMBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	// Bundle
+	caBundle, err := crypto.EncodeCertificates(signerCAConfig.Certs[0])
+	if err != nil {
+		return nil, err
+	}
+
+	// Client cert
+	ca := &crypto.CA{
+		Config:          signerCAConfig,
+		SerialGenerator: &crypto.RandomSerialGenerator{},
+	}
+	clientUser := &user.DefaultInfo{
+		Name:   clientName,
+		UID:    uuid.New().String(),
+		Groups: []string{clientName},
+	}
+	clientCertDuration := time.Hour * 24 * 365 * 10 // 10 years
+	clientCertConfig, err := ca.MakeClientCertificateForDuration(clientUser, clientCertDuration)
+	if err != nil {
+		return nil, err
+	}
+	clientCert, clientKey, err := clientCertConfig.GetPEMBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	return &keyMaterial{
+		caCert:     caCert,
+		caKey:      caKey,
+		caBundle:   caBundle,
+		clientCert: clientCert,
+		clientKey:  clientKey,
+	}, nil
+}

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -122,15 +122,9 @@ func (r *renderOpts) AddFlags(fs *pflag.FlagSet) {
 	r.manifest.AddFlags(fs, "etcd")
 	r.generic.AddFlags(fs)
 
-	// TODO: update bootkube.sh in the installer and then remove this
-	var deprecatedClusterEtcdOperatorImage string
-
 	fs.StringVar(&r.etcdCAFile, "etcd-ca", "/assets/tls/etcd-ca-bundle.crt", "path to etcd CA certificate")
 	fs.StringVar(&r.etcdCAKeyFile, "etcd-ca-key", "/assets/tls/etcd-signer.key", "path to etcd CA certificate key")
 	fs.StringVar(&r.etcdImage, "manifest-etcd-image", r.etcdImage, "etcd manifest image")
-	fs.StringVar(&deprecatedClusterEtcdOperatorImage, "manifest-cluster-etcd-operator-image", "", "deprecated, unused")
-	// TODO: Remove this after updating bootkube.sh in the installer.
-	fs.StringVar(&r.networkConfigFile, "cluster-config-file", r.networkConfigFile, "(deprecated) File containing the network.config.openshift.io manifest.")
 	fs.StringVar(&r.networkConfigFile, "network-config-file", r.networkConfigFile, "File containing the network.config.openshift.io manifest.")
 	fs.StringVar(&r.clusterConfigMapFile, "cluster-configmap-file", "/assets/manifests/cluster-config.yaml", "File containing the cluster-config-v1 configmap.")
 	fs.StringVar(&r.infraConfigFile, "infra-config-file", "/assets/manifests/cluster-infrastructure-02-config.yml", "File containing infrastructure.config.openshift.io manifest.")

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -1,7 +1,6 @@
 package render
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,8 +35,6 @@ type renderOpts struct {
 	generic  options.GenericOptions
 
 	errOut               io.Writer
-	etcdCAFile           string
-	etcdCAKeyFile        string
 	etcdImage            string
 	networkConfigFile    string
 	clusterConfigMapFile string
@@ -122,9 +119,14 @@ func (r *renderOpts) AddFlags(fs *pflag.FlagSet) {
 	r.manifest.AddFlags(fs, "etcd")
 	r.generic.AddFlags(fs)
 
-	fs.StringVar(&r.etcdCAFile, "etcd-ca", "/assets/tls/etcd-ca-bundle.crt", "path to etcd CA certificate")
-	fs.StringVar(&r.etcdCAKeyFile, "etcd-ca-key", "/assets/tls/etcd-signer.key", "path to etcd CA certificate key")
+	// No longer used. Remove once the installer no longer references these args.
+	var etcdCAFile string
+	var etcdCAKeyFile string
+	fs.StringVar(&etcdCAFile, "etcd-ca", "/assets/tls/etcd-ca-bundle.crt", "path to etcd CA certificate")
+	fs.StringVar(&etcdCAKeyFile, "etcd-ca-key", "/assets/tls/etcd-signer.key", "path to etcd CA certificate key")
 	fs.StringVar(&r.etcdImage, "manifest-etcd-image", r.etcdImage, "etcd manifest image")
+
+	fs.StringVar(&r.etcdImage, "etcd-image", r.etcdImage, "etcd manifest image")
 	fs.StringVar(&r.networkConfigFile, "network-config-file", r.networkConfigFile, "File containing the network.config.openshift.io manifest.")
 	fs.StringVar(&r.clusterConfigMapFile, "cluster-configmap-file", "/assets/manifests/cluster-config.yaml", "File containing the cluster-config-v1 configmap.")
 	fs.StringVar(&r.infraConfigFile, "infra-config-file", "/assets/manifests/cluster-infrastructure-02-config.yml", "File containing infrastructure.config.openshift.io manifest.")
@@ -140,11 +142,8 @@ func (r *renderOpts) Validate() error {
 	if err := r.generic.Validate(); err != nil {
 		return err
 	}
-	if len(r.etcdCAFile) == 0 {
-		return errors.New("missing required flag: --etcd-ca")
-	}
 	if len(r.etcdImage) == 0 {
-		return errors.New("missing required flag: --manifest-etcd-image")
+		return errors.New("missing required flag: --etcd-image")
 	}
 	if len(r.networkConfigFile) == 0 {
 		return errors.New("missing required flag: --cluster-config-file")
@@ -172,6 +171,28 @@ type TemplateData struct {
 
 	EtcdServerCertDNSNames string
 	EtcdPeerCertDNSNames   string
+
+	// CA
+	EtcdSignerCert []byte
+	EtcdSignerKey  []byte
+
+	// CA bundle
+	EtcdCaBundle []byte
+
+	// Client cert
+	EtcdSignerClientCert []byte
+	EtcdSignerClientKey  []byte
+
+	// Metrics CA
+	EtcdMetricSignerCert []byte
+	EtcdMetricSignerKey  []byte
+
+	// Metrics CA bundle
+	EtcdMetricCaBundle []byte
+
+	// Metrics client cert
+	EtcdMetricSignerClientCert []byte
+	EtcdMetricSignerClientKey  []byte
 
 	// ClusterCIDR is the IP range for pod IPs.
 	ClusterCIDR []string
@@ -289,6 +310,28 @@ func newTemplateData(opts *renderOpts) (*TemplateData, error) {
 		klog.Infof("using delayed HA bootstrap scaling strategy due to presence of marker file %s", opts.delayedHABootstrapScalingStrategyMarker)
 	}
 
+	// Signer key material
+	caKeyMaterial, err := createKeyMaterial("etcd-signer", "etcd")
+	if err != nil {
+		return nil, err
+	}
+	templateData.EtcdSignerCert = caKeyMaterial.caCert
+	templateData.EtcdSignerKey = caKeyMaterial.caKey
+	templateData.EtcdCaBundle = caKeyMaterial.caBundle
+	templateData.EtcdSignerClientCert = caKeyMaterial.clientCert
+	templateData.EtcdSignerClientKey = caKeyMaterial.clientKey
+
+	// Metric key material
+	metricKeyMaterial, err := createKeyMaterial("etcd-metric-signer", "etcd-metric")
+	if err != nil {
+		return nil, err
+	}
+	templateData.EtcdMetricSignerCert = metricKeyMaterial.caCert
+	templateData.EtcdMetricSignerKey = metricKeyMaterial.caKey
+	templateData.EtcdMetricCaBundle = metricKeyMaterial.caBundle
+	templateData.EtcdMetricSignerClientCert = metricKeyMaterial.clientCert
+	templateData.EtcdMetricSignerClientKey = metricKeyMaterial.clientKey
+
 	return &templateData, nil
 }
 
@@ -303,39 +346,74 @@ func (r *renderOpts) Run() error {
 		return err
 	}
 
-	bootstrapManifestsDir := filepath.Join(r.generic.AssetOutputDir, "bootstrap-manifests")
+	// Base path for bootstrap configuration
+	etcKubernetesDir := filepath.Join(r.generic.AssetOutputDir, "etc-kubernetes")
 
-	secretDir := path.Join(bootstrapManifestsDir, "secrets", tlshelpers.EtcdAllCertsSecretName)
+	// Path for bootstrap etcd member configuration
+	memberDir := filepath.Join(etcKubernetesDir, "static-pod-resources", "etcd-member")
 
-	err = os.MkdirAll(secretDir, 0755)
+	// Path for certs used by the bootstrap etcd member
+	certDir := filepath.Join(memberDir, "etcd-all-certs")
+
+	// Creating the cert dir recursively will create the base path too
+	err = os.MkdirAll(certDir, 0755)
 	if err != nil {
-		return fmt.Errorf("failed to create %s directory: %w", tlshelpers.EtcdAllCertsSecretName, err)
+		return fmt.Errorf("failed to create directory %s: %w", memberDir, err)
 	}
 
-	caCertData, err := ioutil.ReadFile(r.etcdCAFile)
-	if err != nil {
-		return fmt.Errorf("failed to read CA cert: %w", err)
-	}
-
-	caKeyData, err := ioutil.ReadFile(r.etcdCAKeyFile)
-	if err != nil {
-		return fmt.Errorf("failed to read CA key: %w", err)
-	}
-
-	certData, keyData, err := tlshelpers.CreateServerCertKey(caCertData, caKeyData, []string{templateData.BootstrapIP})
-	if err != nil {
-		return err
-	}
-	err = writeCertKeyFiles(secretDir, tlshelpers.GetServingSecretNameForNode(templateData.Hostname), certData, keyData)
+	// Write the ca bundle required by the bootstrap etcd member
+	err = writeCertFile(memberDir, "ca", []byte(templateData.EtcdCaBundle))
 	if err != nil {
 		return err
 	}
 
-	certData, keyData, err = tlshelpers.CreatePeerCertKey(caCertData, caKeyData, []string{templateData.BootstrapIP})
+	// Write the serving and peer certs for the bootstrap etcd member
+	caCertData := templateData.EtcdSignerCert
+	caKeyData := templateData.EtcdSignerKey
+	serverCertData, serverKeyData, err := tlshelpers.CreateServerCertKey(caCertData, caKeyData, []string{templateData.BootstrapIP})
 	if err != nil {
 		return err
 	}
-	err = writeCertKeyFiles(secretDir, tlshelpers.GetPeerClientSecretNameForNode(templateData.Hostname), certData, keyData)
+	err = writeCertKeyFiles(certDir, tlshelpers.GetServingSecretNameForNode(templateData.Hostname), serverCertData.Bytes(), serverKeyData.Bytes())
+	if err != nil {
+		return err
+	}
+	peerCertData, peerKeyData, err := tlshelpers.CreatePeerCertKey(caCertData, caKeyData, []string{templateData.BootstrapIP})
+	if err != nil {
+		return err
+	}
+	err = writeCertKeyFiles(certDir, tlshelpers.GetPeerClientSecretNameForNode(templateData.Hostname), peerCertData.Bytes(), peerKeyData.Bytes())
+	if err != nil {
+		return err
+	}
+
+	// Write the ca bundle and client cert pair for bootkube.sh and the bootstrap apiserver
+	secretsDir := filepath.Join(etcKubernetesDir, "bootstrap-secrets")
+	err = os.MkdirAll(secretsDir, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", secretsDir, err)
+	}
+	err = writeCertFile(secretsDir, "etcd-ca-bundle", []byte(templateData.EtcdCaBundle))
+	if err != nil {
+		return err
+	}
+	err = writeCertKeyFiles(secretsDir, "etcd-client", templateData.EtcdSignerClientCert, templateData.EtcdSignerClientKey)
+	if err != nil {
+		return err
+	}
+
+	// Write the ca bundle and client cert pair for bootkube.sh
+	// TODO(marun) Remove once https://github.com/openshift/installer/pull/4691 merges.
+	tlsDir := filepath.Join(r.generic.AssetOutputDir, "tls")
+	err = os.MkdirAll(tlsDir, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", tlsDir, err)
+	}
+	err = writeCertFile(tlsDir, "etcd-ca-bundle", []byte(templateData.EtcdCaBundle))
+	if err != nil {
+		return err
+	}
+	err = writeCertKeyFiles(tlsDir, "etcd-client", templateData.EtcdSignerClientCert, templateData.EtcdSignerClientKey)
 	if err != nil {
 		return err
 	}
@@ -343,16 +421,27 @@ func (r *renderOpts) Run() error {
 	return WriteFiles(&r.generic, &templateData.FileConfig, templateData)
 }
 
-func writeCertKeyFiles(dir, nodeSecretName string, certData, keyData *bytes.Buffer) error {
-	err := ioutil.WriteFile(path.Join(dir, nodeSecretName+".crt"), certData.Bytes(), 0600)
+func writeCertKeyFiles(dir, name string, certData, keyData []byte) error {
+	err := writeCertFile(dir, name, certData)
 	if err != nil {
-		return fmt.Errorf("failed to write %s cert: %w", nodeSecretName, err)
+		return err
 	}
-	err = ioutil.WriteFile(path.Join(dir, nodeSecretName+".key"), keyData.Bytes(), 0600)
-	if err != nil {
-		return fmt.Errorf("failed to write %s key: %w", nodeSecretName, err)
-	}
+	return writeKeyFile(dir, name, keyData)
+}
 
+func writeCertFile(dir, name string, certData []byte) error {
+	err := ioutil.WriteFile(path.Join(dir, name+".crt"), certData, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to write %s cert: %w", name, err)
+	}
+	return nil
+}
+
+func writeKeyFile(dir, name string, keyData []byte) error {
+	err := ioutil.WriteFile(path.Join(dir, name+".key"), keyData, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to write %s key: %w", name, err)
+	}
 	return nil
 }
 
@@ -533,20 +622,22 @@ func (t *TemplateData) setComputedEnvVars(platform string) error {
 
 // WriteFiles writes the manifests and the bootstrap config file.
 func WriteFiles(opt *options.GenericOptions, fileConfig *options.FileConfig, templateData interface{}, additionalPredicates ...assets.FileInfoPredicate) error {
-	// write assets
-	for _, manifestDir := range []string{"bootstrap-manifests", "manifests"} {
+	assetPaths := map[string]string{
+		// The etc-kubernetes path will be copied recursively by the installer to /etc/kubernetes/
+		"bootstrap-manifests": filepath.Join("etc-kubernetes", "manifests"),
+		// The contents of the manifests path will be copied by the installer to manifests/
+		"manifests": "manifests",
+	}
+
+	for manifestDir, destinationDir := range assetPaths {
 		manifests, err := assets.New(filepath.Join(opt.TemplatesDir, manifestDir), templateData, append(additionalPredicates, assets.OnlyYaml)...)
 		if err != nil {
 			return fmt.Errorf("failed rendering assets: %v", err)
 		}
-		if err := manifests.WriteFiles(filepath.Join(opt.AssetOutputDir, manifestDir)); err != nil {
-			return fmt.Errorf("failed writing assets to %q: %v", filepath.Join(opt.AssetOutputDir, manifestDir), err)
+		destinationPath := filepath.Join(opt.AssetOutputDir, destinationDir)
+		if err := manifests.WriteFiles(destinationPath); err != nil {
+			return fmt.Errorf("failed writing assets to %q: %v", destinationPath, err)
 		}
-	}
-
-	// create bootstrap configuration
-	if err := ioutil.WriteFile(opt.ConfigOutputFile, fileConfig.BootstrapConfig, 0644); err != nil {
-		return fmt.Errorf("failed to write merged config to %q: %v", opt.ConfigOutputFile, err)
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -71,6 +71,7 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/google/gofuzz
 github.com/google/gofuzz/bytesource
 # github.com/google/uuid v1.1.2
+## explicit
 github.com/google/uuid
 # github.com/googleapis/gnostic v0.4.1
 github.com/googleapis/gnostic/compiler
@@ -559,6 +560,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/apiserver v0.20.1
+## explicit
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/configuration
 k8s.io/apiserver/pkg/admission/initializer


### PR DESCRIPTION
Migrate tls bootstrap from the installer to ensure that changes to bootstrap, recovery or rotation of tls assets can be validated directly in ceo CI without requiring changes to the installer.

/cc @hexfusion @retroflexer 