### PR TITLE
Bug 1931658: render: refactor scaling strategies

### DIFF
--- a/bindata/bootkube/manifests/00_etcd-endpoints-cm.yaml
+++ b/bindata/bootkube/manifests/00_etcd-endpoints-cm.yaml
@@ -3,5 +3,10 @@ kind: ConfigMap
 metadata:
   name: etcd-endpoints
   namespace: openshift-etcd
+{{- if ne .BootstrapScalingStrategy "BootstrapInPlaceStrategy" }}
   annotations:
     alpha.installer.openshift.io/etcd-bootstrap: {{ .BootstrapIP }}
+{{- else }}
+data:
+  {{ .EtcdEndpointConfigmapData }}
+{{- end }}

--- a/pkg/operator/ceohelpers/bootstrap.go
+++ b/pkg/operator/ceohelpers/bootstrap.go
@@ -33,6 +33,15 @@ const (
 	// annotation to the openshift-etcd namesapce.
 	DelayedHAScalingStrategy BootstrapScalingStrategy = "DelayedHAScalingStrategy"
 
+	// BootstrapInPlaceStrategy means that the bootstrap node will never exist
+	// during the lifecycle of the cluster. Bootkube will run on a live iso
+	// afterwards the node will pivot into the manifests generated during that
+	// process.
+	//
+	// This strategy is selected by observing the existence of `bootstrapInPlace`
+	// root key in the install-config.
+	BootstrapInPlaceStrategy BootstrapScalingStrategy = "BootstrapInPlaceStrategy"
+
 	// UnsafeScalingStrategy means scaling will occur without regards to nodes and
 	// any effect on quorum. Use of this strategy isn't officially tested or supported,
 	// but is made available for ad-hoc use.


### PR DESCRIPTION
Currently, the bootstrap in place used with SNO adds an annotation `alpha.installer.openshift.io/etcd-bootstrap` which is intended to be used by the cluster to communicate with the bootstrap etcd instance. But bootstrap in place means that the bootstrap node will never be visible. The result is the cluster never pivots from the bootstrap node endpoint which is not expected. This change fixes that problem by adding the `BootstrapInPlaceStrategy` which omits that annotation.

- [x]  refactor scaling strategies and add BootstrapInPlaceStrategy
- [x] add unit tests