### PR TITLE
pkg/etcdenvvar: set periodical watch progress notification to 5s

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -29,11 +29,12 @@ type envVarContext struct {
 }
 
 var FixedEtcdEnvVars = map[string]string{
-	"ETCD_DATA_DIR":              "/var/lib/etcd",
-	"ETCD_QUOTA_BACKEND_BYTES":   "7516192768", // 7 gig
-	"ETCD_INITIAL_CLUSTER_STATE": "existing",
-	"ETCD_ENABLE_PPROF":          "true",
-	"ETCD_CIPHER_SUITES":         getDefaultCipherSuites(),
+	"ETCD_DATA_DIR":                                    "/var/lib/etcd",
+	"ETCD_QUOTA_BACKEND_BYTES":                         "7516192768", // 7 gig
+	"ETCD_INITIAL_CLUSTER_STATE":                       "existing",
+	"ETCD_ENABLE_PPROF":                                "true",
+	"ETCD_CIPHER_SUITES":                               getDefaultCipherSuites(),
+	"ETCD_EXPERIMENTAL_WATCH_PROGRESS_NOTIFY_INTERVAL": "5s",
 }
 
 type envVarFunc func(envVarContext envVarContext) (map[string]string, error)


### PR DESCRIPTION
While this ENV is currently marked experimental it has large positive performance impacts[1]. Upstream kep[2].

cc @deads2k 

[1] https://github.com/kubernetes/kubernetes/pull/99021/files#diff-53f602f80b466ce021d5d5f8b14894997ccde64ae4d9b207296c3ca49978bdfbR555
[2] https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1904-efficient-watch-resumption