### PR TITLE
Bug 1927942: pkg/etcdenvvar: enable SO_REUSEADDR

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -35,6 +35,7 @@ var FixedEtcdEnvVars = map[string]string{
 	"ETCD_ENABLE_PPROF":                                "true",
 	"ETCD_CIPHER_SUITES":                               getDefaultCipherSuites(),
 	"ETCD_EXPERIMENTAL_WATCH_PROGRESS_NOTIFY_INTERVAL": "5s",
+	"ETCD_SOCKET_REUSE_ADDRESS":                        "true",
 }
 
 type envVarFunc func(envVarContext envVarContext) (map[string]string, error)


### PR DESCRIPTION
This PR adds support for setting socket options `SO_REUSEADDR`[1] to etcd listeners via `ListenConfig`. What we have found is during etcd process restart there can be a considerable time waiting for the port to release by `TIME_WAIT` which for OpenShift is 60 seconds..

```
$ ps aux | grep etcd | wc -l
0

$  ss --numeric -o state time-wait 
tcp    0       0                 10.0.138.12:34642            10.0.138.12:2380   timer:(timewait,50sec,0)                                                       
tcp    0       0                 10.0.138.12:34470            10.0.138.12:2380   timer:(timewait,35sec,0)                                                       
tcp    0       0                 10.0.138.12:34086            10.0.138.12:2380   timer:(timewait,10sec,0)                                                       
tcp    0       0                 10.0.138.12:34232            10.0.138.12:2380   timer:(timewait,20sec,0)                                                       
tcp    0       0                 10.0.138.12:34694            10.0.138.12:2380   timer:(timewait,55sec,0)                                                       
tcp    0       0                 10.0.138.12:34332            10.0.138.12:2380   timer:(timewait,25sec,0)                                                       
tcp    0       0                 10.0.138.12:33966            10.0.138.12:2380   timer:(timewait,845ms,0)                                                       
tcp    0       0                 10.0.138.12:34040            10.0.138.12:2380   timer:(timewait,5.845ms,0)                                                     
tcp    0       0                 10.0.138.12:34184            10.0.138.12:2380   timer:(timewait,15sec,0)                                                       
tcp    0       0                 10.0.138.12:34570            10.0.138.12:2380   timer:(timewait,45sec,0)                                                       
tcp    0       0                 10.0.138.12:34512            10.0.138.12:2380   timer:(timewait,40sec,0)                                                       
tcp    0       0                 10.0.138.12:34398            10.0.138.12:2380   timer:(timewait,30sec,0)  
```
So we can wait for many seconds even after etcd process is long dead for client and peer ports to become available.

```
2021-02-19 13:57:25.117257 C | etcdmain: listen tcp 10.0.138.12:2380: bind: address already in use
```

A similar approach has been taken with the addition of these options in the kube-apiserver[2][3]

[1] https://man7.org/linux/man-pages/man7/socket.7.html
[2] https://github.com/kubernetes/kubernetes/pull/93861
[3] https://github.com/openshift/kubernetes/pull/309

depends on https://github.com/openshift/etcd/pull/70