### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/etcd/ns.yaml
+++ b/bindata/etcd/ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-etcd
   labels:
     openshift.io/run-level: "0"

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: etcd
   namespace: openshift-etcd
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: etcd
     k8s-app: etcd

--- a/manifests/0000_12_etcd-operator_00_namespace.yaml
+++ b/manifests/0000_12_etcd-operator_00_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_12_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_06_deployment.yaml
@@ -19,6 +19,8 @@ spec:
   template:
     metadata:
       name: etcd-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: etcd-operator
     spec:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -416,6 +416,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-etcd
   labels:
     openshift.io/run-level: "0"
@@ -467,6 +468,8 @@ kind: Pod
 metadata:
   name: etcd
   namespace: openshift-etcd
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: etcd
     k8s-app: etcd


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>