### PR TITLE
Bug 1948553: bindata, pkg: Propagate operator log level to etcd itself

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -144,6 +144,7 @@ ${COMPUTED_ENV_VARS}
         # See https://etcd.io/docs/v3.4.0/tuning/ for why we use ionice
         exec ionice -c2 -n0 etcd \
           --logger=zap \
+          --log-level=${VERBOSITY} \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -64,6 +64,7 @@ spec:
         set -x
         exec etcd \
           --logger=zap \
+          --log-level=${VERBOSITY} \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -608,6 +608,7 @@ ${COMPUTED_ENV_VARS}
         # See https://etcd.io/docs/v3.4.0/tuning/ for why we use ionice
         exec ionice -c2 -n0 etcd \
           --logger=zap \
+          --log-level=${VERBOSITY} \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \
@@ -927,6 +928,7 @@ spec:
         set -x
         exec etcd \
           --logger=zap \
+          --log-level=${VERBOSITY} \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -148,18 +148,12 @@ func createTargetConfig(c TargetConfigController, recorder events.Recorder, oper
 	return false, nil
 }
 
-func loglevelToKlog(logLevel operatorv1.LogLevel) string {
+func loglevelToZap(logLevel operatorv1.LogLevel) string {
 	switch logLevel {
-	case operatorv1.Normal:
-		return "2"
-	case operatorv1.Debug:
-		return "4"
-	case operatorv1.Trace:
-		return "6"
-	case operatorv1.TraceAll:
-		return "8"
+	case operatorv1.Debug, operatorv1.Trace, operatorv1.TraceAll:
+		return "debug"
 	default:
-		return "2"
+		return "info"
 	}
 }
 
@@ -179,7 +173,7 @@ func (c *TargetConfigController) getSubstitutionReplacer(operatorSpec *operatorv
 	return strings.NewReplacer(
 		"${IMAGE}", imagePullSpec,
 		"${OPERATOR_IMAGE}", operatorImagePullSpec,
-		"${VERBOSITY}", loglevelToKlog(operatorSpec.LogLevel),
+		"${VERBOSITY}", loglevelToZap(operatorSpec.LogLevel),
 		"${LISTEN_ON_ALL_IPS}", "0.0.0.0", // TODO this needs updating to detect ipv6-ness
 		"${LOCALHOST_IP}", "127.0.0.1", // TODO this needs updating to detect ipv6-ness
 		"${COMPUTED_ENV_VARS}", strings.Join(envVarLines, "\n"), // lacks beauty, but it works


### PR DESCRIPTION
As per @hexfusion suggestion, logLevel was not used anywhere, its intention is for users to set log-level for etcd operand itself. This PR propagates the logLevel from the etcd CR to set the `--log-level` flag.

Opening PR mainly to get feedback on the following:

I didn't change the original Custom Resource definition of logLevel, but I feel like having that be a 1:1 match to the etcd log level would be a better UX. Should I go ahead and change the `operatorSpec.LogLevel` definition? If yes, I could use some pointers, as while I am familiar with library-go, I am not familiar with the way it does the CRDs. 

cc @marun @retroflexer 