### PR TITLE
Bug 1948040: *: enable zap as default logger

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -17,6 +17,7 @@ spec:
       set -euo pipefail
 
       exec etcd \
+        --logger=zap \
         --initial-advertise-peer-urls=https://{{ .EtcdAddress.EscapedBootstrapIP }}:2380 \
         --cert-file=/etc/ssl/etcd/etcd-all-certs/etcd-serving-{{ .Hostname }}.crt \
         --key-file=/etc/ssl/etcd/etcd-all-certs/etcd-serving-{{ .Hostname }}.key \

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -127,12 +127,12 @@ ${COMPUTED_ENV_VARS}
           --data-dir=/var/lib/etcd \
           --target-peer-url-host=${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST} \
           --target-name=NODE_NAME)
-         export ETCD_INITIAL_CLUSTER
+        export ETCD_INITIAL_CLUSTER
 
         # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
-        # so we do the detection in etcd container itsefl.
+        # so we do the detection in etcd container itself.
         echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
-        while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 or sport = 9978 )')" ]; do
+        time while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 or sport = 9978 )')" ]; do
           echo -n "."
           sleep 1
         done
@@ -143,6 +143,7 @@ ${COMPUTED_ENV_VARS}
         set -x
         # See https://etcd.io/docs/v3.4.0/tuning/ for why we use ionice
         exec ionice -c2 -n0 etcd \
+          --logger=zap \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -63,6 +63,7 @@ spec:
 
         set -x
         exec etcd \
+          --logger=zap \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -591,12 +591,12 @@ ${COMPUTED_ENV_VARS}
           --data-dir=/var/lib/etcd \
           --target-peer-url-host=${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST} \
           --target-name=NODE_NAME)
-         export ETCD_INITIAL_CLUSTER
+        export ETCD_INITIAL_CLUSTER
 
         # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
-        # so we do the detection in etcd container itsefl.
+        # so we do the detection in etcd container itself.
         echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
-        while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 or sport = 9978 )')" ]; do
+        time while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 or sport = 9978 )')" ]; do
           echo -n "."
           sleep 1
         done
@@ -607,6 +607,7 @@ ${COMPUTED_ENV_VARS}
         set -x
         # See https://etcd.io/docs/v3.4.0/tuning/ for why we use ionice
         exec ionice -c2 -n0 etcd \
+          --logger=zap \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \
@@ -925,6 +926,7 @@ spec:
 
         set -x
         exec etcd \
+          --logger=zap \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \


### PR DESCRIPTION
`capnslog` will is deprecated`zap` logger will offer much more flexibility. This PR also adds `time` to our while loop during `TIME_WAIT` for a quick summary of this MTTR timing.

```
[WARNING] Deprecated '--logger=capnslog' flag is set; use '--logger=zap' flag instead
```

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>