### PR TITLE
bindata/etcd: Enable gRPC time histograms

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -181,6 +181,7 @@ ${COMPUTED_ENV_VARS}
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379,unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
           --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379,unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
           --listen-peer-urls=https://${LISTEN_ON_ALL_IPS}:2380 \
+          --metrics=extensive \
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     env:
 ${COMPUTED_ENV_VARS}

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -77,6 +77,7 @@ spec:
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
           --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379 \
           --listen-peer-urls=https://${LISTEN_ON_ALL_IPS}:2380 \
+          --metrics=extensive \
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978
     env:
 ${COMPUTED_ENV_VARS}

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -670,6 +670,7 @@ ${COMPUTED_ENV_VARS}
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379,unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
           --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379,unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
           --listen-peer-urls=https://${LISTEN_ON_ALL_IPS}:2380 \
+          --metrics=extensive \
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     env:
 ${COMPUTED_ENV_VARS}
@@ -1047,6 +1048,7 @@ spec:
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
           --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379 \
           --listen-peer-urls=https://${LISTEN_ON_ALL_IPS}:2380 \
+          --metrics=extensive \
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978
     env:
 ${COMPUTED_ENV_VARS}


### PR DESCRIPTION
Wanted to see the latency metrics and noticed we do not have those enabled in OpenShift. This is more aimed at 4.9, opening to check the number of series this adds to cluster Prometheus but also to not forget to enable. :)

This allows us to measure latency distributions of the RPCs. This brings in the following histogram metrics:
* grpc_server_handling_seconds_count
* grpc_server_handling_seconds_sum
* grpc_server_handling_seconds_bucket

/hold