### PR TITLE
Bug 1950934: pkg/etcdenvvar/etcd_env.go: Sort endpoints to prevent rollout

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -3,6 +3,7 @@ package etcdenvvar
 import (
 	"fmt"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/dnshelpers"
@@ -124,6 +125,7 @@ func getEtcdGrpcEndpoints(envVarContext envVarContext) (string, error) {
 		}
 		endpoints = append(endpoints, fmt.Sprintf("https://%s:2379", endpointIP))
 	}
+	sort.Strings(endpoints)
 
 	return strings.Join(endpoints, ","), nil
 }


### PR DESCRIPTION
Make sure endpoints that are returned are sorted to prevent any
unnecessary when nothing changes.

While this does not fix 1948533, I still used it to be valid bugzilla as its where this was caught. Let me know if this is incorrect I can create a separate bugzilla for this.

cc @hexfusion @mfojtik 