### PR TITLE
Rename workload annotations

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: etcd
   namespace: openshift-etcd
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: etcd
     k8s-app: etcd

--- a/manifests/0000_12_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_06_deployment.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       name: etcd-operator
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: etcd-operator
     spec:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -469,7 +469,7 @@ metadata:
   name: etcd
   namespace: openshift-etcd
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: etcd
     k8s-app: etcd


### PR DESCRIPTION
As per openshift/enhancements#739, the workload annotations names are changing.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged