### PR TITLE
Bug 1952266: Don't set operator version before operands update

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -146,8 +146,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	for _, version := range clusterOperator.Status.Versions {
 		versionRecorder.SetVersion(version.Name, version.Version)
 	}
+	// Don't set operator version. library-go will take care of it after setting operands.
 	versionRecorder.SetVersion("raw-internal", status.VersionForOperatorFromEnv())
-	versionRecorder.SetVersion("operator", status.VersionForOperatorFromEnv())
 
 	staticPodControllers, err := staticpod.NewBuilder(operatorClient, kubeClient, kubeInformersForNamespaces).
 		WithEvents(controllerContext.EventRecorder).


### PR DESCRIPTION
Don't set operator version explicitly. library-go will take care of it after updating the operands. 

Setting the operator version ahead of operands will confuse the CVO and the cluster_operator_conditions metrics about what version the etcd component is at until this bug gets fixed.