### PR TITLE
Bug 1952268: Increase inertia duration for the EtcdMembersDegraded condition

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -177,7 +178,14 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorClient,
 		versionRecorder,
 		controllerContext.EventRecorder,
-	)
+	).WithDegradedInertia(status.MustNewInertia(
+		2*time.Minute,
+		status.InertiaCondition{
+			ConditionTypeMatcher: regexp.MustCompile("^(NodeController|EtcdMembers)Degraded$"),
+			Duration:             5 * time.Minute,
+		},
+	).Inertia)
+
 	coreClient := clientset
 
 	etcdCertSignerController := etcdcertsigner.NewEtcdCertSignerController(


### PR DESCRIPTION
It appears rebooting a node and getting it to the point where the kubelet is running static pods can take more than the default 2 minutes. This causes etcd operator to set Degraded=True on healthy machine-config node reboots. 

I am guessing a 5 minute duration is sufficient, but it is the guesswork. I am not sure if there is any slower hardware that would take more than 5 minutes to reboot and restart the static pods.