### PR TITLE
Bug 1946607: bindata/etcd: improve readinessProbe checks by dialing unix socket target

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -156,8 +156,8 @@ ${COMPUTED_ENV_VARS}
           --peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key \
           --peer-trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-peer-client-ca/ca-bundle.crt \
           --peer-client-cert-auth=true \
-          --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
-          --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379 \
+          --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379,unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
+          --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379,unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
           --listen-peer-urls=https://${LISTEN_ON_ALL_IPS}:2380 \
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     env:
@@ -167,8 +167,23 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      tcpSocket:
-        port: 2380
+      exec:
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+
+          # Unix sockets are used for health checks to ensure that the pod is reporting readiness of the etcd process
+          # in this container. While this might seem unnecessary the use of SO_REUSEADDR has made this explicitly
+          # required as the kernel will allow the reuse of a port while in TIME_WAIT. etcd requires socket
+          # path in this format <name>:<port> so port 0 is used only to meet this requirement.
+          unset ETCDCTL_ENDPOINTS
+          /usr/bin/etcdctl \
+            --command-timeout=2s \
+            --dial-timeout=2s \
+            --endpoints=unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
+            endpoint health -w json | grep \"health\":true
       failureThreshold: 3
       initialDelaySeconds: 3
       periodSeconds: 5

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -621,8 +621,8 @@ ${COMPUTED_ENV_VARS}
           --peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key \
           --peer-trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-peer-client-ca/ca-bundle.crt \
           --peer-client-cert-auth=true \
-          --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
-          --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379 \
+          --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379,unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
+          --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379,unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
           --listen-peer-urls=https://${LISTEN_ON_ALL_IPS}:2380 \
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     env:
@@ -632,8 +632,23 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      tcpSocket:
-        port: 2380
+      exec:
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+
+          # Unix sockets are used for health checks to ensure that the pod is reporting readiness of the etcd process
+          # in this container. While this might seem unnecessary the use of SO_REUSEADDR has made this explicitly
+          # required as the kernel will allow the reuse of a port while in TIME_WAIT. etcd requires socket
+          # path in this format <name>:<port> so port 0 is used only to meet this requirement.
+          unset ETCDCTL_ENDPOINTS
+          /usr/bin/etcdctl \
+            --command-timeout=2s \
+            --dial-timeout=2s \
+            --endpoints=unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
+            endpoint health -w json | grep \"health\":true
       failureThreshold: 3
       initialDelaySeconds: 3
       periodSeconds: 5


### PR DESCRIPTION
The current unauthenticated tcpSocket readinessProbe spams the etcd logs and does not properly reflect ready status. In order for etcd to be ready to accept new requests, a quorate health check should return true. Static Pod Installer is smart enough to not install a new static pod until the existing pods are Ready. So we open up a race that could result in temporary quorum loss by not waiting until etcd is actually Ready.

```
2021-03-12 21:35:28.803656 I | embed: rejected connection from "10.0.146.252:36846" (error "EOF", ServerName "")
```

socket path includes `NODE_NODE_ENVVAR_NAME_IP` so that mTLS passes auth. etcd today requires the following format for socket path  `<name>:<port>`. By setting 2s timeouts I believe we should remove the window of opportunity for zombie process as a result of exec probe. tl;dr fail fast

I used port 0 which is a restricted port as per IANA for TCP, but since this is unix socket I figured it would possibly eliminate any assumption that it is TCP. This is open to debate.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>