### PR TITLE
Bug 1958245: etcd/pod: print static pod revision in logs

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -106,6 +106,8 @@ ${COMPUTED_ENV_VARS}
         name: data-dir
     env:
 ${COMPUTED_ENV_VARS}
+      - name: "ETCD_STATIC_POD_REV"
+        value: "REVISION"
   - name: etcd
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
@@ -162,6 +164,8 @@ ${COMPUTED_ENV_VARS}
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     env:
 ${COMPUTED_ENV_VARS}
+      - name: "ETCD_STATIC_POD_REV"
+        value: "REVISION"
     resources:
       requests:
         memory: 600Mi
@@ -210,6 +214,8 @@ ${COMPUTED_ENV_VARS}
           --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-metrics-proxy-serving-ca/ca-bundle.crt
     env:
 ${COMPUTED_ENV_VARS}
+      - name: "ETCD_STATIC_POD_REV"
+        value: "REVISION"
     resources:
       requests:
         memory: 200Mi

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -80,6 +80,8 @@ spec:
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978
     env:
 ${COMPUTED_ENV_VARS}
+      - name: "ETCD_STATIC_POD_REV"
+        value: "REVISION"
     resources:
       requests:
         memory: 600Mi

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -571,6 +571,8 @@ ${COMPUTED_ENV_VARS}
         name: data-dir
     env:
 ${COMPUTED_ENV_VARS}
+      - name: "ETCD_STATIC_POD_REV"
+        value: "REVISION"
   - name: etcd
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
@@ -627,6 +629,8 @@ ${COMPUTED_ENV_VARS}
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     env:
 ${COMPUTED_ENV_VARS}
+      - name: "ETCD_STATIC_POD_REV"
+        value: "REVISION"
     resources:
       requests:
         memory: 600Mi
@@ -675,6 +679,8 @@ ${COMPUTED_ENV_VARS}
           --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-metrics-proxy-serving-ca/ca-bundle.crt
     env:
 ${COMPUTED_ENV_VARS}
+      - name: "ETCD_STATIC_POD_REV"
+        value: "REVISION"
     resources:
       requests:
         memory: 200Mi
@@ -947,6 +953,8 @@ spec:
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978
     env:
 ${COMPUTED_ENV_VARS}
+      - name: "ETCD_STATIC_POD_REV"
+        value: "REVISION"
     resources:
       requests:
         memory: 600Mi


### PR DESCRIPTION
a small change that prints revision in logs. it is generally nice to have this observability when looking at CI etc.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>