### PR TITLE
[wip][testing] pkg/etcdenvvar: enable log rotation for etcd

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -12,6 +12,27 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
+    - name: setup
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      terminationMessagePolicy: FallbackToLogsOnError
+      command:
+        - /bin/sh
+        - -c
+        - |
+          #!/bin/sh
+          echo -n "Fixing etcd log permissions."
+          chmod 0700 /var/log/etcd && touch /var/log/etcd/etcd.log && chmod 0600 /var/log/etcd/*
+
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: 50Mi
+          cpu: 5m
+      volumeMounts:
+        - mountPath: /var/log/etcd
+          name: log-dir
     - name: etcd-ensure-env-vars
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
@@ -204,6 +225,8 @@ ${COMPUTED_ENV_VARS}
         name: cert-dir
       - mountPath: /var/lib/etcd/
         name: data-dir
+      - mountPath: /var/log/etcd/
+        name: log-dir
   - name: etcd-metrics
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
@@ -265,3 +288,6 @@ ${COMPUTED_ENV_VARS}
     - hostPath:
         path: /usr/local/bin
       name: usr-local-bin
+    - hostPath:
+        path: /var/log/etcd
+      name: log-dir

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489
 	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
 	google.golang.org/grpc v1.29.1
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.21.0
 	k8s.io/apiextensions-apiserver v0.21.0
 	k8s.io/apimachinery v0.21.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -442,6 +442,7 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/natefinch/lumberjack.v2 v2.0.0
+## explicit
 gopkg.in/natefinch/lumberjack.v2
 # gopkg.in/yaml.v2 v2.4.0
 gopkg.in/yaml.v2


### PR DESCRIPTION
This PR enables log rotation for etcd logs. This functionality ensures that etcd logs are always persisted without the need of loki. The defaults are based on current audit logs config[1].

[1] https://github.com/openshift/cluster-kube-apiserver-operator/blob/b1010cd0da2702678df7c2a8e06dc17ad6e48853/pkg/operator/v410_00_assets/bindata.go#L298

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>