### PR TITLE
bump(*): vendor update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -13,7 +12,7 @@ require (
 	github.com/openshift/api v0.0.0-20210405165116-47be53705a13
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f
-	github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc
+	github.com/openshift/library-go v0.0.0-20210513103829-aa02c23cb230
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,6 @@ github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
-github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787 h1:AfLWrOEtyI9WI9aaDF0GN/6FQu+rNvl2YUeizB6FYuk=
 github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787/go.mod h1:AlRx4sdoz6EdWGYPMeunQWYf46cKnq7J4iVvLgyb5cY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -416,8 +414,8 @@ github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f h1:MAFVN4yW6pP
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc h1:tywho0nChchtAD4E2YmlX9MWQ3CBoWT49GrTHfM2+ss=
-github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210513103829-aa02c23cb230 h1:Mr0ac4Z0VO8QQ5uFSVXz2x5egyf+UEP3UkcfaM1wwsI=
+github.com/openshift/library-go v0.0.0-20210513103829-aa02c23cb230/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -518,7 +516,6 @@ github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvV
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
-github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 h1:j2hhcujLRHAg872RWAV5yaUrEjHEObwDv3aImCaNLek=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -667,7 +664,6 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/monitoring.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/monitoring.go
@@ -3,23 +3,22 @@ package resourceapply
 import (
 	"context"
 
-	"github.com/imdario/mergo"
-	"k8s.io/klog/v2"
-
+	"github.com/openshift/library-go/pkg/operator/events"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-
-	"github.com/openshift/library-go/pkg/operator/events"
+	"k8s.io/klog/v2"
 )
 
 var serviceMonitorGVR = schema.GroupVersionResource{Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors"}
 
-func ensureServiceMonitorSpec(required, existing *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
-	requiredSpec, _, err := unstructured.NestedMap(required.UnstructuredContent(), "spec")
+func ensureGenericSpec(required, existing *unstructured.Unstructured, mimicDefaultingFn mimicDefaultingFunc, equalityChecker equalityChecker) (*unstructured.Unstructured, bool, error) {
+	requiredCopy := required.DeepCopy()
+	mimicDefaultingFn(requiredCopy)
+	requiredSpec, _, err := unstructured.NestedMap(requiredCopy.UnstructuredContent(), "spec")
 	if err != nil {
 		return nil, false, err
 	}
@@ -28,20 +27,31 @@ func ensureServiceMonitorSpec(required, existing *unstructured.Unstructured) (*u
 		return nil, false, err
 	}
 
-	if err := mergo.Merge(&existingSpec, &requiredSpec); err != nil {
-		return nil, false, err
-	}
-
-	if equality.Semantic.DeepEqual(existingSpec, requiredSpec) {
+	if equalityChecker.DeepEqual(existingSpec, requiredSpec) {
 		return existing, false, nil
 	}
 
 	existingCopy := existing.DeepCopy()
-	if err := unstructured.SetNestedMap(existingCopy.UnstructuredContent(), existingSpec, "spec"); err != nil {
+	if err := unstructured.SetNestedMap(existingCopy.UnstructuredContent(), requiredSpec, "spec"); err != nil {
 		return nil, true, err
 	}
 
 	return existingCopy, true, nil
+}
+
+// mimicDefaultingFunc is used to set fields that are defaulted.  This allows for sparse manifests to apply correctly.
+// For instance, if field .spec.foo is set to 10 if not set, then a function of this type could be used to set
+// the field to 10 to match the comparison.  This is soemtimes (often?) easier than updating the semantic equality.
+// We often see this in places like RBAC and CRD.  Logically it can happen generically too.
+type mimicDefaultingFunc func(obj *unstructured.Unstructured)
+
+func noDefaulting(obj *unstructured.Unstructured) {}
+
+// equalityChecker allows for custom equality comparisons.  This can be used to allow equality checks to skip certain
+// operator managed fields.  This capability allows something like .spec.scale to be specified or changed by a component
+// like HPA.  Use this capability sparingly.  Most places ought to just use `equality.Semantic`
+type equalityChecker interface {
+	DeepEqual(a1, a2 interface{}) bool
 }
 
 // ApplyServiceMonitor applies the Prometheus service monitor.
@@ -64,25 +74,70 @@ func ApplyServiceMonitor(client dynamic.Interface, recorder events.Recorder, req
 
 	existingCopy := existing.DeepCopy()
 
-	updated, endpointsModified, err := ensureServiceMonitorSpec(required, existingCopy)
+	toUpdate, modified, err := ensureGenericSpec(required, existingCopy, noDefaulting, equality.Semantic)
 	if err != nil {
 		return nil, false, err
 	}
 
-	if !endpointsModified {
+	if !modified {
 		return nil, false, nil
 	}
 
 	if klog.V(4).Enabled() {
-		klog.Infof("ServiceMonitor %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, existingCopy))
+		klog.Infof("ServiceMonitor %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, toUpdate))
 	}
 
-	newObj, err := client.Resource(serviceMonitorGVR).Namespace(namespace).Update(context.TODO(), updated, metav1.UpdateOptions{})
+	newObj, err := client.Resource(serviceMonitorGVR).Namespace(namespace).Update(context.TODO(), toUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		recorder.Warningf("ServiceMonitorUpdateFailed", "Failed to update ServiceMonitor.monitoring.coreos.com/v1: %v", err)
 		return nil, true, err
 	}
 
 	recorder.Eventf("ServiceMonitorUpdated", "Updated ServiceMonitor.monitoring.coreos.com/v1 because it changed")
+	return newObj, true, err
+}
+
+var prometheusRuleGVR = schema.GroupVersionResource{Group: "monitoring.coreos.com", Version: "v1", Resource: "prometheusrules"}
+
+// ApplyPrometheusRule applies the PrometheusRule
+func ApplyPrometheusRule(client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+	namespace := required.GetNamespace()
+
+	existing, err := client.Resource(prometheusRuleGVR).Namespace(namespace).Get(context.TODO(), required.GetName(), metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		newObj, createErr := client.Resource(prometheusRuleGVR).Namespace(namespace).Create(context.TODO(), required, metav1.CreateOptions{})
+		if createErr != nil {
+			recorder.Warningf("PrometheusRuleCreateFailed", "Failed to create PrometheusRule.monitoring.coreos.com/v1: %v", createErr)
+			return nil, true, createErr
+		}
+		recorder.Eventf("PrometheusRuleCreated", "Created PrometheusRule.monitoring.coreos.com/v1 because it was missing")
+		return newObj, true, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	existingCopy := existing.DeepCopy()
+
+	toUpdate, modified, err := ensureGenericSpec(required, existingCopy, noDefaulting, equality.Semantic)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if !modified {
+		return nil, false, nil
+	}
+
+	if klog.V(4).Enabled() {
+		klog.Infof("PrometheusRule %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, toUpdate))
+	}
+
+	newObj, err := client.Resource(prometheusRuleGVR).Namespace(namespace).Update(context.TODO(), toUpdate, metav1.UpdateOptions{})
+	if err != nil {
+		recorder.Warningf("PrometheusRuleUpdateFailed", "Failed to update PrometheusRule.monitoring.coreos.com/v1: %v", err)
+		return nil, true, err
+	}
+
+	recorder.Eventf("PrometheusRuleUpdated", "Updated PrometheusRule.monitoring.coreos.com/v1 because it changed")
 	return newObj, true, err
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/unstructured.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/unstructured.go
@@ -12,9 +12,12 @@ import (
 // ApplyKnownUnstructured applies few selected Unstructured types, where it semantic knowledge
 // to merge existing & required objects intelligently. Feel free to add more.
 func ApplyKnownUnstructured(client dynamic.Interface, recorder events.Recorder, obj *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
-	serviceMonitorGK := schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"}
-	if obj.GetObjectKind().GroupVersionKind().GroupKind() == serviceMonitorGK {
+	switch obj.GetObjectKind().GroupVersionKind().GroupKind() {
+	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"}:
 		return ApplyServiceMonitor(client, recorder, obj)
+	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "PrometheusRule"}:
+		return ApplyPrometheusRule(client, recorder, obj)
+
 	}
 
 	return nil, false, fmt.Errorf("unsupported object type: %s", obj.GetKind())

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
@@ -1,9 +1,12 @@
 package resourcemerge
 
 import (
+	"strings"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 // EnsureCustomResourceDefinitionV1Beta1 ensures that the existing matches the required.
@@ -23,9 +26,43 @@ func EnsureCustomResourceDefinitionV1Beta1(modified *bool, existing *apiextensio
 func EnsureCustomResourceDefinitionV1(modified *bool, existing *apiextensionsv1.CustomResourceDefinition, required apiextensionsv1.CustomResourceDefinition) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
+	// we need to match defaults
+	mimicCRDV1Defaulting(&required)
 	// we stomp everything
 	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {
 		*modified = true
 		existing.Spec = required.Spec
+	}
+}
+
+func mimicCRDV1Defaulting(required *apiextensionsv1.CustomResourceDefinition) {
+	crd_SetDefaults_CustomResourceDefinitionSpec(&required.Spec)
+
+	if required.Spec.Conversion != nil &&
+		required.Spec.Conversion.Webhook != nil &&
+		required.Spec.Conversion.Webhook.ClientConfig != nil &&
+		required.Spec.Conversion.Webhook.ClientConfig.Service != nil {
+		crd_SetDefaults_ServiceReference(required.Spec.Conversion.Webhook.ClientConfig.Service)
+	}
+}
+
+// lifted from https://github.com/kubernetes/kubernetes/blob/v1.21.0/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults.go#L42-L61
+func crd_SetDefaults_CustomResourceDefinitionSpec(obj *apiextensionsv1.CustomResourceDefinitionSpec) {
+	if len(obj.Names.Singular) == 0 {
+		obj.Names.Singular = strings.ToLower(obj.Names.Kind)
+	}
+	if len(obj.Names.ListKind) == 0 && len(obj.Names.Kind) > 0 {
+		obj.Names.ListKind = obj.Names.Kind + "List"
+	}
+	if obj.Conversion == nil {
+		obj.Conversion = &apiextensionsv1.CustomResourceConversion{
+			Strategy: apiextensionsv1.NoneConverter,
+		}
+	}
+}
+
+func crd_SetDefaults_ServiceReference(obj *apiextensionsv1.ServiceReference) {
+	if obj.Port == nil {
+		obj.Port = utilpointer.Int32Ptr(443)
 	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
@@ -1,5 +1,7 @@
 package resourcesynccontroller
 
+import "k8s.io/apimachinery/pkg/util/sets"
+
 // ResourceLocation describes coordinates for a resource to be synced
 type ResourceLocation struct {
 	Namespace string `json:"namespace"`
@@ -10,7 +12,16 @@ type ResourceLocation struct {
 	Provider string `json:"provider,omitempty"`
 }
 
-var emptyResourceLocation = ResourceLocation{}
+type syncRuleSource struct {
+	ResourceLocation
+	syncedKeys sets.String // defines the set of keys to sync from source to dest
+}
+
+type syncRules map[ResourceLocation]syncRuleSource
+
+var (
+	emptyResourceLocation = ResourceLocation{}
+)
 
 // ResourceSyncer allows changes to syncing rules by this controller
 type ResourceSyncer interface {

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -97,7 +97,7 @@ func (c RevisionController) createRevisionIfNeeded(recorder events.Recorder, lat
 
 	nextRevision := latestAvailableRevision + 1
 	recorder.Eventf("RevisionTriggered", "new revision %d triggered by %q", nextRevision, reason)
-	if err := c.createNewRevision(recorder, nextRevision); err != nil {
+	if err := c.createNewRevision(recorder, nextRevision, reason); err != nil {
 		cond := operatorv1.OperatorCondition{
 			Type:    "RevisionControllerDegraded",
 			Status:  operatorv1.ConditionTrue,
@@ -191,7 +191,7 @@ func (c RevisionController) isLatestRevisionCurrent(revision int32) (bool, strin
 	return true, ""
 }
 
-func (c RevisionController) createNewRevision(recorder events.Recorder, revision int32) error {
+func (c RevisionController) createNewRevision(recorder events.Recorder, revision int32, reason string) error {
 	// Create a new InProgress status configmap
 	statusConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -201,6 +201,7 @@ func (c RevisionController) createNewRevision(recorder events.Recorder, revision
 		Data: map[string]string{
 			"status":   prune.StatusInProgress,
 			"revision": fmt.Sprintf("%d", revision),
+			"reason":   reason,
 		},
 	}
 	statusConfigMap, _, err := resourceapply.ApplyConfigMap(c.configMapGetter, recorder, statusConfigMap)

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -71,6 +71,13 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			continue
 
 		case apierrors.IsNotFound(err) && cm.Optional:
+			configMapFile := getConfigMapDir(c.destinationDir, cm.Name)
+			if _, err := os.Stat(configMapFile); os.IsNotExist(err) {
+				// if the configmap file does not exist, there is no work to do, so skip making any live check and just return.
+				// if the configmap actually exists in the API, we'll eventually see it on the watch.
+				continue
+			}
+
 			// Check with the live call it is really missing
 			configMap, err = c.configmapGetter.Get(ctx, cm.Name, metav1.GetOptions{})
 			if err == nil {
@@ -84,7 +91,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			}
 
 			// remove missing content
-			if err := os.RemoveAll(getConfigMapDir(c.destinationDir, cm.Name)); err != nil {
+			if err := os.RemoveAll(configMapFile); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed removing file for configmap: %s/%s: %v", c.namespace, cm.Name, err)
 				errors = append(errors, err)
 			}
@@ -168,6 +175,13 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			continue
 
 		case apierrors.IsNotFound(err) && s.Optional:
+			secretFile := getSecretDir(c.destinationDir, s.Name)
+			if _, err := os.Stat(secretFile); os.IsNotExist(err) {
+				// if the secret file does not exist, there is no work to do, so skip making any live check and just return.
+				// if the secret actually exists in the API, we'll eventually see it on the watch.
+				continue
+			}
+
 			// Check with the live call it is really missing
 			secret, err = c.secretGetter.Get(ctx, s.Name, metav1.GetOptions{})
 			if err == nil {
@@ -177,12 +191,6 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			}
 			if !apierrors.IsNotFound(err) {
 				errors = append(errors, err)
-				continue
-			}
-
-			// check if the secret file exists, skip firing events if it does not
-			secretFile := getSecretDir(c.destinationDir, s.Name)
-			if _, err := os.Stat(secretFile); os.IsNotExist(err) {
 				continue
 			}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -348,6 +348,12 @@ func (o *InstallOptions) copyContent(ctx context.Context) error {
 		return err
 	}
 
+	// remove the existing file to ensure kubelet gets "create" event from inotify watchers
+	if err := os.Remove(path.Join(o.PodManifestDir, podFileName)); err == nil {
+		klog.Infof("Removed existing static pod manifest %q ...", path.Join(o.PodManifestDir, podFileName))
+	} else if !os.IsNotExist(err) {
+		return err
+	}
 	klog.Infof("Writing static pod manifest %q ...\n%s", path.Join(o.PodManifestDir, podFileName), finalPodBytes)
 	if err := ioutil.WriteFile(path.Join(o.PodManifestDir, podFileName), []byte(finalPodBytes), 0644); err != nil {
 		return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,8 +25,6 @@ github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/evanphx/json-patch v4.9.0+incompatible
 github.com/evanphx/json-patch
-# github.com/fsnotify/fsnotify v1.4.9
-## explicit
 # github.com/ghodss/yaml v1.0.0
 ## explicit
 github.com/ghodss/yaml
@@ -184,7 +182,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc
+# github.com/openshift/library-go v0.0.0-20210513103829-aa02c23cb230
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
* openshift/library-go@dcdd10a4: add revision reason to status configmaps
* openshift/library-go@c805bbab: add resourceApply for prometheus rule
* openshift/library-go@eadaff0f: stop doing live gets for optional cert syncer files that don't exist on disk yet
* openshift/library-go@c96f1555: resourcesync: don't report modified on both missing target and source
* openshift/library-go@de4d21eb: update CRD apply to understand some fields are defaulted
* openshift/library-go@ed6496bd: provides a precondition checker determines if encryption controllers should synchronise
* openshift/library-go@9daa8a30: add unit tests for the preconditions checker
* openshift/library-go@69691508: wire the preconditions checker to the encryption controllers
* openshift/library-go@cb236f20: apiservercontrollerset: propagate errors that occurred during object/controller construction
* openshift/library-go@f69df685: extends the maximum time the tests will wait for KAS to reach the same revision
* openshift/library-go@dc88912b: fix generic comparison for dynamic resource apply
* openshift/library-go@a5030000: with encryptionWasEnabled
* openshift/library-go@877ab50a: extends the threshold for considering the servers stable
* openshift/library-go@4ba0ccd4: resourcesync: allow syncing only specific CM/secret keys
* openshift/library-go@56fca251: resourceapply-core: add godoc to Sync* functions
* openshift/library-go@ac986232: changes mustSucceedMultipleTimes to sleep before each invocation the given timeout
* openshift/library-go@ddac3998: staticpod: recreate existing pod manifests instead of updating