### PR TITLE
pkg/etcdenvvar: bump ETCD_QUOTA_BACKEND_BYTES to 8GB

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -31,7 +31,7 @@ type envVarContext struct {
 
 var FixedEtcdEnvVars = map[string]string{
 	"ETCD_DATA_DIR":                                    "/var/lib/etcd",
-	"ETCD_QUOTA_BACKEND_BYTES":                         "7516192768", // 7 gig
+	"ETCD_QUOTA_BACKEND_BYTES":                         "8589934592", // 8 GB
 	"ETCD_INITIAL_CLUSTER_STATE":                       "existing",
 	"ETCD_ENABLE_PPROF":                                "true",
 	"ETCD_CIPHER_SUITES":                               getDefaultCipherSuites(),


### PR DESCRIPTION
In the past the hard limit for the backend store was 8GB. This value was chosen because of the MTTR for pulling a large snapshot across the wire could cause disruption with the time it could take to have a new members db to become up to date. In etcd 3.4 that hard limit has been dropped. 

For OCP we set the `NOSPACE` alarm to fire at 7GB allowing admin a buffer between the alarm and hard limit. But since a hard limit is no longer a consideration the PR sets `ETCD_QUOTA_BACKEND_BYTES` to 8GB as it is still the recommended max.

```
2021-05-14 08:39:42.798064 W | etcdserver: backend quota 9589934592 exceeds maximum recommended quota 8589934592
```

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>