### PR TITLE
Bug 1884568: etcd-pod: add liveness probe

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -193,6 +193,26 @@ ${COMPUTED_ENV_VARS}
       periodSeconds: 5
       successThreshold: 1
       timeoutSeconds: 5
+    livenessProbe:
+      exec:
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+
+          # liveness probe uses a serialized get to an non-existant key (liveness) as a condition.
+          unset ETCDCTL_ENDPOINTS
+          /usr/bin/etcdctl \
+            --command-timeout=3s \
+            --dial-timeout=3s \
+            --endpoints=unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
+            --consistency=s \ 
+            get liveness
+      failureThreshold: 3
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 10
     securityContext:
       privileged: true
     volumeMounts:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -658,6 +658,26 @@ ${COMPUTED_ENV_VARS}
       periodSeconds: 5
       successThreshold: 1
       timeoutSeconds: 5
+    livenessProbe:
+      exec:
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+
+          # liveness probe uses a serialized get to an non-existant key (liveness) as a condition.
+          unset ETCDCTL_ENDPOINTS
+          /usr/bin/etcdctl \
+            --command-timeout=3s \
+            --dial-timeout=3s \
+            --endpoints=unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
+            --consistency=s \ 
+            get liveness
+      failureThreshold: 3
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 10
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
etcd should consider a liveness probe, by setting reasonable timeouts we should eliminate disruptive behavior which could result in flapping the service while under pressure.

This PR adds a liveness probe using a serialized get for a key that would not exist as a cheap condition for liveness.