### PR TITLE
Bug 1965535: [release-4.6] Improve cert controller detection and correction of invalid certs

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -3,15 +3,21 @@ package etcdcertsigner
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
@@ -25,6 +31,39 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-etcd-operator/pkg/tlshelpers"
 )
+
+// Annotation key used to associate a cert secret with a node uid. This allows
+// cert regeneration if a node was deleted and added with the same name.
+const nodeUIDAnnotation = "etcd-operator.alpha.openshift.io/cert-secret-node-uid"
+
+// etcdCertConfig defines the configuration required to maintain a cert secret for an etcd member.
+type etcdCertConfig struct {
+	// Name of the secret in namespace openshift-config that contains the CA used to issue the cert
+	caSecretName string
+	// Function that derives the name of the cert secret from the node name
+	secretNameFunc func(nodeName string) string
+	// Function that creates the key material for a new cert
+	newCertFunc func(caCert, caKey []byte, ipAddresses []string) (*bytes.Buffer, *bytes.Buffer, error)
+}
+
+// Define configuration for creating etcd cert secrets.
+var certConfigMap = map[string]etcdCertConfig{
+	"peer": {
+		caSecretName:   "etcd-signer",
+		secretNameFunc: tlshelpers.GetPeerClientSecretNameForNode,
+		newCertFunc:    tlshelpers.CreatePeerCertKey,
+	},
+	"server": {
+		caSecretName:   "etcd-signer",
+		secretNameFunc: tlshelpers.GetServingSecretNameForNode,
+		newCertFunc:    tlshelpers.CreateServerCertKey,
+	},
+	"metric": {
+		caSecretName:   "etcd-metric-signer",
+		secretNameFunc: tlshelpers.GetServingMetricsSecretNameForNode,
+		newCertFunc:    tlshelpers.CreateMetricCertKey,
+	},
+}
 
 type EtcdCertSignerController struct {
 	kubeClient           kubernetes.Interface
@@ -99,8 +138,9 @@ func (c *EtcdCertSignerController) syncAllMasters(recorder events.Recorder) erro
 
 	errs := []error{}
 	for _, node := range nodes {
-		if err := c.createSecretForNode(node, recorder); err != nil {
-			errs = append(errs, err)
+		certErrs := c.ensureCertSecrets(node, recorder)
+		if certErrs != nil {
+			errs = append(errs, certErrs...)
 		}
 	}
 	if len(errs) > 0 {
@@ -178,68 +218,164 @@ func (c *EtcdCertSignerController) syncAllMasters(recorder events.Recorder) erro
 	return utilerrors.NewAggregate(errs)
 }
 
-func (c *EtcdCertSignerController) createSecretForNode(node *corev1.Node, recorder events.Recorder) error {
-	etcdPeerClientCertName := tlshelpers.GetPeerClientSecretNameForNode(node.Name)
-	etcdServingCertName := tlshelpers.GetServingSecretNameForNode(node.Name)
-	metricsServingCertName := tlshelpers.GetServingMetricsSecretNameForNode(node.Name)
-
-	var err error
-	_, err = c.secretLister.Secrets(operatorclient.TargetNamespace).Get(etcdPeerClientCertName)
-	peerClientCertOk := err == nil
-	_, err = c.secretLister.Secrets(operatorclient.TargetNamespace).Get(etcdServingCertName)
-	servingCertOk := err == nil
-	_, err = c.secretLister.Secrets(operatorclient.TargetNamespace).Get(metricsServingCertName)
-	metricsCertOk := err == nil
-
-	// if we have all the certs we want, do nothing.
-	if peerClientCertOk && servingCertOk && metricsCertOk {
-		return nil
+// ensureCertSecret attempts to ensure the existence of secrets containing the
+// etcd cert (cert+key) pairs needed for an etcd member.
+func (c *EtcdCertSignerController) ensureCertSecrets(node *corev1.Node, recorder events.Recorder) []error {
+	ipAddresses, err := dnshelpers.GetInternalIPAddressesForNodeName(node)
+	if err != nil {
+		return []error{err}
 	}
 
-	// get the signers
-	etcdCASecret, err := c.secretLister.Secrets(operatorclient.GlobalUserSpecifiedConfigNamespace).Get("etcd-signer")
-	if err != nil {
-		return err
+	errs := []error{}
+	for _, certConfig := range certConfigMap {
+		err := c.ensureCertSecret(node, ipAddresses, certConfig, recorder)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
 	}
-	etcdMetricCASecret, err := c.secretLister.Secrets(operatorclient.GlobalUserSpecifiedConfigNamespace).Get("etcd-metric-signer")
-	if err != nil {
-		return err
-	}
-
-	nodeInternalIPs, err := dnshelpers.GetInternalIPAddressesForNodeName(node)
-	if err != nil {
-		return err
-	}
-
-	// create the certificates and update them in the API
-	pCert, pKey, err := tlshelpers.CreatePeerCertKey(etcdCASecret.Data["tls.crt"], etcdCASecret.Data["tls.key"], nodeInternalIPs)
-	err = c.createSecret(etcdPeerClientCertName, pCert, pKey, recorder)
-	if err != nil {
-		return err
-	}
-	sCert, sKey, err := tlshelpers.CreateServerCertKey(etcdCASecret.Data["tls.crt"], etcdCASecret.Data["tls.key"], nodeInternalIPs)
-	err = c.createSecret(etcdServingCertName, sCert, sKey, recorder)
-	if err != nil {
-		return err
-	}
-	metricCert, metricKey, err := tlshelpers.CreateMetricCertKey(etcdMetricCASecret.Data["tls.crt"], etcdMetricCASecret.Data["tls.key"], nodeInternalIPs)
-	err = c.createSecret(metricsServingCertName, metricCert, metricKey, recorder)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return errs
 }
 
-func (c *EtcdCertSignerController) createSecret(secretName string, cert *bytes.Buffer, key *bytes.Buffer, recorder events.Recorder) error {
+// ensureCertSecret attempts to ensure the existence of a secret containing an
+// etcd cert (cert+key) pair. The secret will be created if it does not
+// exist. If the secret exists but contains an invalid cert pair, it will be
+// updated with a new cert pair.
+func (c *EtcdCertSignerController) ensureCertSecret(node *corev1.Node, ipAddresses []string, certConfig etcdCertConfig, recorder events.Recorder) error {
+	secretName := certConfig.secretNameFunc(node.Name)
+
+	secret, err := c.secretLister.Secrets(operatorclient.TargetNamespace).Get(secretName)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	storedUID := ""
+	if secret != nil {
+		storedUID := secret.Annotations[nodeUIDAnnotation]
+		invalidMsg, err := checkCertValidity(secret.Data["tls.crt"], secret.Data["tls.key"], ipAddresses, string(node.UID), storedUID)
+		if err != nil {
+			return err
+		}
+		if len(invalidMsg) > 0 {
+			klog.V(4).Infof("TLS cert %s is invalid and will be regenerated: %v", secretName, invalidMsg)
+			// A nil secret will prompt creation of a new keypair
+			secret = nil
+		}
+	}
+
+	cert := []byte{}
+	key := []byte{}
+	if secret != nil {
+		if storedUID == string(node.UID) {
+			// Nothing to do: Cert pair is valid, node uid is current
+			return nil
+		}
+		cert = secret.Data["tls.crt"]
+		key = secret.Data["tls.key"]
+	} else {
+		// Generate a new cert pair. The secret is missing or its contents are invalid.
+		caSecret, err := c.secretLister.Secrets(operatorclient.GlobalUserSpecifiedConfigNamespace).Get(certConfig.caSecretName)
+		if err != nil {
+			return err
+		}
+		certBuffer, keyBuffer, err := certConfig.newCertFunc(caSecret.Data["tls.crt"], caSecret.Data["tls.key"], ipAddresses)
+		if err != nil {
+			return err
+		}
+		cert = certBuffer.Bytes()
+		key = keyBuffer.Bytes()
+	}
+
+	return c.applySecret(secretName, string(node.UID), cert, key, recorder)
+}
+
+func (c *EtcdCertSignerController) applySecret(secretName, nodeUID string, cert, key []byte, recorder events.Recorder) error {
 	//TODO: Update annotations Not Before and Not After for Cert Rotation
-	_, _, err := resourceapply.ApplySecret(c.secretClient, recorder, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: operatorclient.TargetNamespace},
-		Type:       corev1.SecretTypeTLS,
-		Data: map[string][]byte{
-			"tls.crt": cert.Bytes(),
-			"tls.key": key.Bytes(),
-		},
-	})
+	secret := newCertSecret(secretName, nodeUID, cert, key)
+	_, _, err := resourceapply.ApplySecret(c.secretClient, recorder, secret)
 	return err
+}
+
+// newCertSecret ensures consistency of secret creation between the controller
+// and its tests.
+func newCertSecret(secretName, nodeUID string, cert, key []byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: operatorclient.TargetNamespace,
+			Annotations: map[string]string{
+				nodeUIDAnnotation: nodeUID,
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": cert,
+			"tls.key": key,
+		},
+	}
+}
+
+// checkCertValidity validates the provided cert bytes. If the cert needs to be
+// regenerated, a message will be returned indicating why. An empty message
+// indicates a valid cert. An error will be returned if the cert is not valid
+// and should not be regenerated.
+func checkCertValidity(certBytes, keyBytes []byte, ipAddresses []string, nodeUID, storedUID string) (string, error) {
+	// Loading the keypair without error indicates the key material is valid and
+	// the cert and private key are related.
+	keyPair, err := tls.X509KeyPair(certBytes, keyBytes)
+	if err != nil {
+		// Invalid keypair - regen required
+		return fmt.Sprintf("%v", err), nil
+	}
+	leafCert, err := x509.ParseCertificate(keyPair.Certificate[0])
+	if err != nil {
+		// Should never happen once x509KeyPair() succeeds
+		return fmt.Sprintf("%v", err), nil
+	}
+
+	// Check that the cert is valid for the provided ip addresses
+	errs := []error{}
+	for _, ipAddress := range ipAddresses {
+		if err := leafCert.VerifyHostname(ipAddress); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		// When a cluster is upgraded to 4.8 - the first release to annotate
+		// cert secrets with the node UID - previously created secrets will
+		// initially not have a node UID set. Assume that the lack of a stored
+		// node UID indicates that the certs were generated for the current node
+		// so that if the cert is not valid for the node's current ip addresses
+		// it will be flagged as an error.
+		//
+		// TODO(marun) The check for a missing stored uid can be removed in 4.9
+		// since by then all cert secrets will be guaranteed to have a stored
+		// node uid. That would change the conditional from ternary to binary
+		// and allow the use of a boolean indication of node uid change.
+		nodeUIDUnchanged := nodeUID == storedUID || len(storedUID) == 0
+
+		if nodeUIDUnchanged {
+			// This is an error condition. If the cert SAN doesn't include all
+			// of ip's for the node that it was generated for, an out-of-band
+			// etcd cluster membership change may be required. The operator
+			// doesn't currently handle this.
+			return "", utilerrors.NewAggregate(errs)
+		} else {
+			// A different node uid indicates node removal and addition with the
+			// same name. etcd on the node will be a new cluster member and
+			// needs a new certificate.
+			msgs := []string{}
+			for _, err := range errs {
+				msgs = append(msgs, fmt.Sprintf("%v", err))
+			}
+			return strings.Join(msgs, ", "), nil
+		}
+	}
+
+	// TODO(marun) Check that the certificate was issued by the CA
+
+	// TODO(marun) Check that the certificate is not expired or due for replacement
+
+	// Cert is valid
+	return "", nil
 }

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -1,0 +1,254 @@
+package etcdcertsigner
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func TestCheckCertValidity(t *testing.T) {
+	ipAddresses := []string{"127.0.0.1"}
+	differentIpAddresses := []string{"127.0.0.2"}
+
+	nodeUID := "foo-bar"
+	differentNodeUID := "bar-foo"
+
+	expireDays := 100
+
+	caConfig, err := crypto.MakeSelfSignedCAConfig("foo", expireDays)
+	if err != nil {
+		t.Fatalf("Failed to create ca config: %v", err)
+	}
+	ca := &crypto.CA{
+		Config:          caConfig,
+		SerialGenerator: &crypto.RandomSerialGenerator{},
+	}
+
+	testCases := map[string]struct {
+		invalidCertPair  bool
+		certIPAddresses  []string
+		nodeIPAddresses  []string
+		storedNodeUID    string
+		expectedRegenMsg bool
+		expectedErr      bool
+	}{
+		"invalid bytes": {
+			invalidCertPair:  true,
+			expectedRegenMsg: true,
+		},
+		"missing ip address; node uid unchanged": {
+			certIPAddresses: ipAddresses,
+			nodeIPAddresses: differentIpAddresses,
+			storedNodeUID:   nodeUID,
+			expectedErr:     true,
+		},
+		"missing ip address; node uid not stored": {
+			certIPAddresses: ipAddresses,
+			nodeIPAddresses: differentIpAddresses,
+			expectedErr:     true,
+		},
+		"missing ip address; node uid changed": {
+			certIPAddresses:  ipAddresses,
+			nodeIPAddresses:  differentIpAddresses,
+			storedNodeUID:    differentNodeUID,
+			expectedRegenMsg: true,
+		},
+		"valid": {
+			certIPAddresses: ipAddresses,
+			nodeIPAddresses: ipAddresses,
+			storedNodeUID:   nodeUID,
+		},
+	}
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			certBytes := []byte{}
+			keyBytes := []byte{}
+			if !tc.invalidCertPair {
+				// Generate a valid cert for the cert ip addresses
+				certConfig, err := ca.MakeServerCert(sets.NewString(tc.certIPAddresses...), expireDays)
+				if err != nil {
+					t.Fatalf("Error generating cert: %v", err)
+				}
+				certBytes, keyBytes, err = certConfig.GetPEMBytes()
+				if err != nil {
+					t.Fatalf("Error converting cert to bytes: %v", err)
+				}
+			}
+			msg, err := checkCertValidity(certBytes, keyBytes, tc.nodeIPAddresses, nodeUID, tc.storedNodeUID)
+			if tc.expectedRegenMsg && len(msg) == 0 {
+				t.Fatalf("Expected a regen message")
+			}
+			if !tc.expectedRegenMsg && len(msg) > 0 {
+				t.Fatalf("Unexpected regen message: %s", msg)
+			}
+			if tc.expectedErr && err == nil {
+				t.Fatalf("Expected an error")
+			}
+			if !tc.expectedErr && err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestEnsureCertSecret(t *testing.T) {
+	// Any one of the cert configs will be representative
+	certConfig := certConfigMap["peer"]
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-0",
+			UID:  uuid.NewUUID(),
+		},
+	}
+
+	secretName := certConfig.secretNameFunc(node.Name)
+	ipAddresses := []string{"127.0.0.1"}
+	expireDays := 100
+
+	// Create a ca to generate a valid cert from
+	caConfig, err := crypto.MakeSelfSignedCAConfig("foo", expireDays)
+	if err != nil {
+		t.Fatalf("Failed to create ca config: %v", err)
+	}
+	caCertBytes, caKeyBytes, err := caConfig.GetPEMBytes()
+	if err != nil {
+		t.Fatalf("Error converting ca to bytes: %v", err)
+	}
+
+	// Create a ca secret that ensureCertSecret can use to generate a new cert with
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace,
+			Name:      certConfig.caSecretName,
+		},
+		Data: map[string][]byte{
+			"tls.crt": caCertBytes,
+			"tls.key": caKeyBytes,
+		},
+	}
+
+	testCases := map[string]struct {
+		certSecret     *corev1.Secret
+		createExpected bool
+		updateExpected bool
+	}{
+		"missing cert secret is created": {
+			createExpected: true,
+		},
+		"invalid cert secret is regenerated": {
+			certSecret:     newCertSecret(secretName, "", nil, nil),
+			updateExpected: true,
+		},
+		// The test for a valid cert secret is performed after a successful
+		// cert creation to simplify test setup.
+	}
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			objects := []runtime.Object{caSecret}
+			if tc.certSecret != nil {
+				objects = append(objects, tc.certSecret)
+			}
+
+			fakeKubeClient, controller, recorder := setupEnsureCertSecret(t, objects)
+			err := controller.ensureCertSecret(node, ipAddresses, certConfig, recorder)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var updatedSecret *corev1.Secret
+			var createdSecret *corev1.Secret
+			for _, action := range fakeKubeClient.Actions() {
+				if action.Matches("update", "secrets") {
+					updateAction := action.(clientgotesting.UpdateAction)
+					updatedSecret = updateAction.GetObject().(*corev1.Secret)
+					break
+				}
+				if action.Matches("create", "secrets") {
+					createAction := action.(clientgotesting.CreateAction)
+					createdSecret = createAction.GetObject().(*corev1.Secret)
+					break
+				}
+			}
+			if !tc.updateExpected && updatedSecret != nil {
+				t.Fatalf("Secret unexpectedly updated")
+			}
+			if updatedSecret != nil {
+				validateTestSecret(t, "updated", updatedSecret, ipAddresses)
+			}
+			if !tc.createExpected && createdSecret != nil {
+				t.Fatalf("Secret unexpectedly created")
+			}
+			if createdSecret != nil {
+				validateTestSecret(t, "created", createdSecret, ipAddresses)
+
+				// Verify that a cert secret created by ensureCertSecret will
+				// not be updated when immediately round-tripped.
+				objects := []runtime.Object{createdSecret, caSecret}
+				fakeKubeClient, controller, recorder := setupEnsureCertSecret(t, objects)
+				err := controller.ensureCertSecret(node, ipAddresses, certConfig, recorder)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, action := range fakeKubeClient.Actions() {
+					if action.Matches("update", "secrets") {
+						t.Fatal("Valid secret unexpectedly updated")
+					}
+				}
+			}
+		})
+	}
+}
+
+// setupEnsureCertSecret encapsulates test setup for TestEnsureCertSecret for
+// reuse in round-tripping a cert secret created by ensureCertSecret.
+func setupEnsureCertSecret(t *testing.T, objects []runtime.Object) (*fake.Clientset, *EtcdCertSignerController, events.Recorder) {
+	fakeKubeClient := fake.NewSimpleClientset(objects...)
+	recorder := events.NewRecorder(
+		fakeKubeClient.CoreV1().Events(operatorclient.TargetNamespace),
+		"test-ensurecertsecret",
+		&corev1.ObjectReference{},
+	)
+	indexer := cache.NewIndexer(
+		cache.MetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+	for _, obj := range objects {
+		if err := indexer.Add(obj); err != nil {
+			t.Fatal(err)
+		}
+	}
+	controller := &EtcdCertSignerController{
+		secretLister: corev1listers.NewSecretLister(indexer),
+		secretClient: fakeKubeClient.CoreV1(),
+	}
+	return fakeKubeClient, controller, recorder
+}
+
+// validateTestSecret checks that a secret created or updated by
+// ensureCertSecret is valid acording to checkCertValidity.
+func validateTestSecret(t *testing.T, action string, secret *corev1.Secret, ipAddresses []string) {
+	if secret.Data == nil {
+		t.Fatalf("%s secret is empty", action)
+	}
+	storedNodeUID := secret.Annotations[nodeUIDAnnotation]
+	msg, err := checkCertValidity(secret.Data["tls.crt"], secret.Data["tls.key"], ipAddresses, storedNodeUID, storedNodeUID)
+	if len(msg) > 0 {
+		t.Fatalf("%s secret is invalid with message: %s", action, msg)
+	}
+	if err != nil {
+		t.Fatalf("%s secret is invalid with error: %v", action, err)
+	}
+}


### PR DESCRIPTION
This refactor enables regenerating certs for nodes that have been removed and added back with the same name, and simplifies the addition of further checks for cert lineage and expiry.

Manual cherry-pick of https://github.com/openshift/cluster-etcd-operator/pull/540 due to the pick not being clean. The change is limited to the cert signer, and I have manually verified that the this PR updates the cert signer and associated unit tests to match the result of applying 540 to release-4.7. 

/cc @hexfusion  