### PR TITLE
Rotate serving certs when duration less than minimum percent

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -30,9 +30,15 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/tlshelpers"
 )
 
-// Annotation key used to associate a cert secret with a node uid. This allows
-// cert regeneration if a node was deleted and added with the same name.
-const nodeUIDAnnotation = "etcd-operator.alpha.openshift.io/cert-secret-node-uid"
+const (
+	// Annotation key used to associate a cert secret with a node uid. This allows
+	// cert regeneration if a node was deleted and added with the same name.
+	nodeUIDAnnotation = "etcd-operator.alpha.openshift.io/cert-secret-node-uid"
+
+	// The minimum percentage duration of a certificate. If a cert has less than
+	// this percentage of its duration remaining, it will be regenerated.
+	defaultMinDurationPercent = 0.20
+)
 
 // etcdCertConfig defines the configuration required to maintain a cert secret for an etcd member.
 type etcdCertConfig struct {
@@ -233,7 +239,7 @@ func (c *EtcdCertSignerController) ensureCertSecret(secretName, nodeUID string, 
 			return nil, nil, err
 		}
 		if len(invalidMsg) > 0 {
-			klog.V(4).Info("TLS cert %s is invalid and will be regenerated: %v", secretName, invalidMsg)
+			klog.V(4).Infof("TLS cert %s is invalid and will be regenerated: %v", secretName, invalidMsg)
 			// A nil secret will prompt creation of a new keypair
 			secret = nil
 		}
@@ -348,10 +354,22 @@ func checkCertValidity(certBytes, keyBytes []byte, ipAddresses []string, nodeUID
 		}
 	}
 
-	// TODO(marun) Check that the certificate was issued by the CA
+	if ok := lessThanMinimumDuration(leafCert.NotBefore, leafCert.NotAfter, defaultMinDurationPercent); ok {
+		return fmt.Sprintf("less than %d%% duration remaining", int64(defaultMinDurationPercent*100)), nil
+	}
 
-	// TODO(marun) Check that the certificate is not expired or due for replacement
+	// TODO(marun) Check that the certificate was issued by the CA
 
 	// Cert is valid
 	return "", nil
+}
+
+// lessThanMinimumDuration indicates whether the provided cert has less
+// than the provided minimum percentage of its duration remaining.
+func lessThanMinimumDuration(notBefore, notAfter time.Time, minDurationPercent float64) bool {
+	expiry := notAfter
+	duration := expiry.Sub(notBefore)
+	minDuration := time.Duration(float64(duration.Nanoseconds()) * minDurationPercent)
+	replacementTime := expiry.Add(-minDuration)
+	return time.Now().After(replacementTime)
 }

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -2,8 +2,11 @@ package etcdcertsigner
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/x509"
 	"fmt"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,12 +44,13 @@ func TestCheckCertValidity(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		invalidCertPair  bool
-		certIPAddresses  []string
-		nodeIPAddresses  []string
-		storedNodeUID    string
-		expectedRegenMsg bool
-		expectedErr      bool
+		invalidCertPair     bool
+		lessThanMinDuration bool
+		certIPAddresses     []string
+		nodeIPAddresses     []string
+		storedNodeUID       string
+		expectedRegenMsg    bool
+		expectedErr         bool
 	}{
 		"invalid bytes": {
 			invalidCertPair:  true,
@@ -69,6 +73,13 @@ func TestCheckCertValidity(t *testing.T) {
 			storedNodeUID:    differentNodeUID,
 			expectedRegenMsg: true,
 		},
+		"less than minimum duration remaining": {
+			certIPAddresses:     ipAddresses,
+			nodeIPAddresses:     ipAddresses,
+			storedNodeUID:       nodeUID,
+			lessThanMinDuration: true,
+			expectedRegenMsg:    true,
+		},
 		"valid": {
 			certIPAddresses: ipAddresses,
 			nodeIPAddresses: ipAddresses,
@@ -84,6 +95,9 @@ func TestCheckCertValidity(t *testing.T) {
 				certConfig, err := ca.MakeServerCert(sets.NewString(tc.certIPAddresses...), expireDays)
 				if err != nil {
 					t.Fatalf("Error generating cert: %v", err)
+				}
+				if tc.lessThanMinDuration {
+					certConfig = ensureLessThanMinDuration(t, certConfig)
 				}
 				certBytes, keyBytes, err = certConfig.GetPEMBytes()
 				if err != nil {
@@ -334,5 +348,27 @@ func validateTestSecret(t *testing.T, action string, secret *corev1.Secret, ipAd
 	}
 	if err != nil {
 		t.Fatalf("%s secret is invalid with error: %v", action, err)
+	}
+}
+
+func ensureLessThanMinDuration(t *testing.T, caConfig *crypto.TLSCertificateConfig) *crypto.TLSCertificateConfig {
+	caCert := caConfig.Certs[0]
+
+	// Issued 9 hours ago, 1 hour remaining: < 20% duration remaining
+	caCert.NotBefore = time.Now().Add(-9 * time.Hour)
+	caCert.NotAfter = time.Now().Add(time.Hour)
+
+	rawCert, err := x509.CreateCertificate(rand.Reader, caCert, caCert, caCert.PublicKey, caConfig.Key)
+	if err != nil {
+		t.Fatalf("error creating certificate: %v", err)
+	}
+	parsedCerts, err := x509.ParseCertificates(rawCert)
+	if err != nil {
+		t.Fatalf("error parsing certificate: %v", err)
+	}
+
+	return &crypto.TLSCertificateConfig{
+		Certs: []*x509.Certificate{parsedCerts[0]},
+		Key:   caConfig.Key,
 	}
 }


### PR DESCRIPTION
This will ensure against expired serving certs breaking the cluster.

/cc @hexfusion 