### PR TITLE
[release-4.6] Bug 1979585: Validate the status of the etcd snapshot during backup and restore

### DIFF
--- a/bindata/etcd/cluster-backup.sh
+++ b/bindata/etcd/cluster-backup.sh
@@ -101,4 +101,7 @@ fi
 dl_etcdctl
 backup_latest_kube_static_resources "${BACKUP_RESOURCE_LIST[@]}"
 ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot save "${SNAPSHOT_FILE}"
+
+# Check the integrity of the snapshot
+check_snapshot_status "${SNAPSHOT_FILE}"
 echo "snapshot db and kube resources are successfully saved to ${BACKUP_DIR}"

--- a/bindata/etcd/cluster-restore.sh
+++ b/bindata/etcd/cluster-restore.sh
@@ -85,6 +85,10 @@ if [ ! -d "$MANIFEST_STOPPED_DIR" ]; then
   mkdir -p "$MANIFEST_STOPPED_DIR"
 fi
 
+# Download etcdctl and check the snapshot status
+dl_etcdctl
+check_snapshot_status "${SNAPSHOT_FILE}"
+
 # Move static pod manifests out of MANIFEST_DIR
 for POD_FILE_NAME in "${STATIC_POD_LIST[@]}" etcd-pod.yaml; do
   echo "...stopping ${POD_FILE_NAME}"

--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -31,3 +31,11 @@ function exec_etcdctl {
   fi
   crictl exec -it $container_id /bin/sh -c "etcdctl $command"
 }
+
+function check_snapshot_status() {
+  local snap_file="$1"
+  if ! etcdctl snapshot status "${snap_file}" -w json; then
+    echo "Backup integrity verification failed. Backup appears corrupted. Aborting!"
+    return 1
+  fi
+}


### PR DESCRIPTION
manual cherry-pick of https://github.com/openshift/cluster-etcd-operator/pull/617 into release-4.6. This PR omits the refactor with a focus only on "validate the status of etcd snapshot."