### PR TITLE
Replace message with description field

### DIFF
--- a/jsonnet/custom.libsonnet
+++ b/jsonnet/custom.libsonnet
@@ -23,7 +23,7 @@
             alert: 'etcdInsufficientMembers',
             'for': '3m',
             annotations: {
-              message: 'etcd is reporting fewer instances are available than are needed ({{ $value }}). When etcd does not have a majority of instances available the Kubernetes and OpenShift APIs will reject read and write requests and operations that preserve the health of workloads cannot be performed. This can occur when multiple control plane nodes are powered off or are unable to connect to each other via the network. Check that all control plane nodes are powered on and that network connections between each machine are functional.',
+              description: 'etcd is reporting fewer instances are available than are needed ({{ $value }}). When etcd does not have a majority of instances available the Kubernetes and OpenShift APIs will reject read and write requests and operations that preserve the health of workloads cannot be performed. This can occur when multiple control plane nodes are powered off or are unable to connect to each other via the network. Check that all control plane nodes are powered on and that network connections between each machine are functional.',
               summary: 'etcd is reporting that a majority of instances are unavailable.',
             },
             labels: {

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "8f9829cd2dd65479cca9b1497b6e62fdc74df2b6",
-      "sum": "RqOj1ITnyH6jm/6qBtEE+Ob5KTk/nKX1zlhj/SWqARE="
+      "version": "a1fd98c6b0c4c5bc9e36ac45154e6a44d4c31bcb",
+      "sum": "PPTfil9MoAqtyW+hHJuAj3Ap86pB86vIHativ9R5c4I="
     }
   ],
   "legacyImports": false

--- a/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/mixin.libsonnet
+++ b/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/mixin.libsonnet
@@ -130,7 +130,7 @@
               severity: 'critical',
             },
             annotations: {
-              description: 'etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.',
+              description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC requests is {{ $value }}s on etcd instance {{ $labels.instance }}.',
               summary: 'etcd grpc requests are slow',
             },
           },
@@ -189,7 +189,7 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.',
+              description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.',
             },
           },
           {
@@ -217,7 +217,7 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.',
+              description: 'etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.',
             },
           },
           {
@@ -230,7 +230,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes leading to 50% increase in database size over the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.',
+              description: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes leading to 50% increase in database size over the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.',
             },
           },
         ],

--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -40,8 +40,8 @@ spec:
         severity: critical
     - alert: etcdGRPCRequestsSlow
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method
-          }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC requests
+          is {{ $value }}s on etcd instance {{ $labels.instance }}.'
         summary: etcd grpc requests are slow
       expr: |
         histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job=~".*etcd.*", grpc_type="unary"}[5m])) without(grpc_type))
@@ -84,7 +84,7 @@ spec:
         severity: warning
     - alert: etcdHighFsyncDurations
       annotations:
-        message: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations
           are {{ $value }}s on etcd instance {{ $labels.instance }}.'
       expr: |
         histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
@@ -105,9 +105,9 @@ spec:
         severity: warning
     - alert: etcdBackendQuotaLowSpace
       annotations:
-        message: 'etcd cluster "{{ $labels.job }}": database size exceeds the defined
-          quota on etcd instance {{ $labels.instance }}, please defrag or increase
-          the quota as the writes to etcd will be disabled when it is full.'
+        description: 'etcd cluster "{{ $labels.job }}": database size exceeds the
+          defined quota on etcd instance {{ $labels.instance }}, please defrag or
+          increase the quota as the writes to etcd will be disabled when it is full.'
       expr: |
         (etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100 > 95
       for: 10m
@@ -115,7 +115,7 @@ spec:
         severity: critical
     - alert: etcdExcessiveDatabaseGrowth
       annotations:
-        message: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes
+        description: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes
           leading to 50% increase in database size over the past four hours on etcd
           instance {{ $labels.instance }}, please check as it might be disruptive.'
       expr: |
@@ -139,13 +139,13 @@ spec:
         severity: warning
     - alert: etcdInsufficientMembers
       annotations:
-        message: etcd is reporting fewer instances are available than are needed ({{
-          $value }}). When etcd does not have a majority of instances available the
-          Kubernetes and OpenShift APIs will reject read and write requests and operations
-          that preserve the health of workloads cannot be performed. This can occur
-          when multiple control plane nodes are powered off or are unable to connect
-          to each other via the network. Check that all control plane nodes are powered
-          on and that network connections between each machine are functional.
+        description: etcd is reporting fewer instances are available than are needed
+          ({{ $value }}). When etcd does not have a majority of instances available
+          the Kubernetes and OpenShift APIs will reject read and write requests and
+          operations that preserve the health of workloads cannot be performed. This
+          can occur when multiple control plane nodes are powered off or are unable
+          to connect to each other via the network. Check that all control plane nodes
+          are powered on and that network connections between each machine are functional.
         summary: etcd is reporting that a majority of instances are unavailable.
       expr: sum(up{job="etcd"} == bool 1 and etcd_server_has_leader{job="etcd"} ==
         bool 1) without (instance,pod) < ((count(up{job="etcd"}) without (instance,pod)


### PR DESCRIPTION
As per the https://issues.redhat.com/browse/OCPPLAN-6250 epic, message is being removed, so this replaces downstream and upstream alerting definitions with description. 

@hexfusion the only change downstream is the custom.libsonnet, rest you already reviewed upstream.