### PR TITLE
Adjust runbooks url to new path

### DIFF
--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -19,7 +19,7 @@ local excludeRules = std.map(
 local modifiedRules = std.map(function(group) group {
   rules: std.map(function(rule) if 'alert' in rule && !('runbook_url' in rule.annotations) && (rule.labels.severity == 'critical') then rule {
                    annotations+: {
-                     runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/%s.md' % rule.alert,
+                     runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/%s.md' % rule.alert,
                    },
                  } else rule,
                  super.rules),

--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -13,9 +13,8 @@ spec:
     rules:
     - alert: etcdMembersDown
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
-          }}).'
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdMembersDown.md
+        description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value }}).'
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdMembersDown.md
         summary: etcd cluster members are down.
       expr: |
         max without (endpoint) (
@@ -31,9 +30,8 @@ spec:
         severity: critical
     - alert: etcdNoLeader
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
-          }} has no leader.'
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdNoLeader.md
+        description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdNoLeader.md
         summary: etcd cluster has no leader.
       expr: |
         etcd_server_has_leader{job=~".*etcd.*"} == 0
@@ -42,9 +40,8 @@ spec:
         severity: critical
     - alert: etcdGRPCRequestsSlow
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC requests
-          is {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdGRPCRequestsSlow.md
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC requests is {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdGRPCRequestsSlow.md
         summary: etcd grpc requests are slow
       expr: |
         histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job=~".*etcd.*", grpc_type="unary"}[5m])) without(grpc_type))
@@ -54,9 +51,7 @@ spec:
         severity: critical
     - alert: etcdMemberCommunicationSlow
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": member communication with
-          {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance
-          }}.'
+        description: 'etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
         summary: etcd cluster member communication is slow.
       expr: |
         histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~".*etcd.*"}[5m]))
@@ -66,8 +61,7 @@ spec:
         severity: warning
     - alert: etcdHighNumberOfFailedProposals
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures
-          within the last 30 minutes on etcd instance {{ $labels.instance }}.'
+        description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last 30 minutes on etcd instance {{ $labels.instance }}.'
         summary: etcd cluster has high number of proposal failures.
       expr: |
         rate(etcd_server_proposals_failed_total{job=~".*etcd.*"}[15m]) > 5
@@ -76,8 +70,7 @@ spec:
         severity: warning
     - alert: etcdHighFsyncDurations
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations
-          are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
         summary: etcd cluster 99th percentile fsync durations are too high.
       expr: |
         histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
@@ -87,9 +80,8 @@ spec:
         severity: warning
     - alert: etcdHighFsyncDurations
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations
-          are {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdHighFsyncDurations.md
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdHighFsyncDurations.md
       expr: |
         histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
         > 1
@@ -98,8 +90,7 @@ spec:
         severity: critical
     - alert: etcdHighCommitDurations
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit durations
-          {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
         summary: etcd cluster 99th percentile commit durations are too high.
       expr: |
         histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
@@ -109,10 +100,8 @@ spec:
         severity: warning
     - alert: etcdBackendQuotaLowSpace
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": database size exceeds the
-          defined quota on etcd instance {{ $labels.instance }}, please defrag or
-          increase the quota as the writes to etcd will be disabled when it is full.'
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdBackendQuotaLowSpace.md
+        description: 'etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdBackendQuotaLowSpace.md
       expr: |
         (etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100 > 95
       for: 10m
@@ -120,9 +109,7 @@ spec:
         severity: critical
     - alert: etcdExcessiveDatabaseGrowth
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes
-          leading to 50% increase in database size over the past four hours on etcd
-          instance {{ $labels.instance }}, please check as it might be disruptive.'
+        description: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes leading to 50% increase in database size over the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
       expr: |
         increase(((etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100)[240m:1m]) > 50
       for: 10m
@@ -132,10 +119,7 @@ spec:
     rules:
     - alert: etcdHighNumberOfLeaderChanges
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": {{ $value }} leader changes
-          within the last 15 minutes. Frequent elections may be a sign of insufficient
-          resources, high network latency, or disruptions by other components and
-          should be investigated.'
+        description: 'etcd cluster "{{ $labels.job }}": {{ $value }} leader changes within the last 15 minutes. Frequent elections may be a sign of insufficient resources, high network latency, or disruptions by other components and should be investigated.'
         summary: etcd cluster has high number of leader changes.
       expr: |
         increase((max without (instance) (etcd_server_leader_changes_seen_total{job=~".*etcd.*"}) or 0*absent(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}))[15m:1m]) >= 5
@@ -144,18 +128,10 @@ spec:
         severity: warning
     - alert: etcdInsufficientMembers
       annotations:
-        description: etcd is reporting fewer instances are available than are needed
-          ({{ $value }}). When etcd does not have a majority of instances available
-          the Kubernetes and OpenShift APIs will reject read and write requests and
-          operations that preserve the health of workloads cannot be performed. This
-          can occur when multiple control plane nodes are powered off or are unable
-          to connect to each other via the network. Check that all control plane nodes
-          are powered on and that network connections between each machine are functional.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdInsufficientMembers.md
+        description: etcd is reporting fewer instances are available than are needed ({{ $value }}). When etcd does not have a majority of instances available the Kubernetes and OpenShift APIs will reject read and write requests and operations that preserve the health of workloads cannot be performed. This can occur when multiple control plane nodes are powered off or are unable to connect to each other via the network. Check that all control plane nodes are powered on and that network connections between each machine are functional.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdInsufficientMembers.md
         summary: etcd is reporting that a majority of instances are unavailable.
-      expr: sum(up{job="etcd"} == bool 1 and etcd_server_has_leader{job="etcd"} ==
-        bool 1) without (instance,pod) < ((count(up{job="etcd"}) without (instance,pod)
-        + 1) / 2)
+      expr: sum(up{job="etcd"} == bool 1 and etcd_server_has_leader{job="etcd"} == bool 1) without (instance,pod) < ((count(up{job="etcd"}) without (instance,pod) + 1) / 2)
       for: 3m
       labels:
         severity: critical


### PR DESCRIPTION
The base path for runbooks in github.com/openshift/runbooks has been adjusted, this adjusts the path in `runbooks_url` accordingly