### PR TITLE
Bug 1988491: bindata/etcd/quorumguard-deployment: simplify health true matching

### DIFF
--- a/bindata/etcd/quorumguard-deployment.yaml
+++ b/bindata/etcd/quorumguard-deployment.yaml
@@ -78,7 +78,7 @@ spec:
                   declare -r cacert="/var/run/configmaps/etcd-ca/ca-bundle.crt"
                   export NSS_SDB_USE_CACHE=no
                   [[ -z $cert || -z $key ]] && exit 1
-                  curl --max-time 2 --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
+                  curl --max-time 2 --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '"health":"true"'
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 3

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -910,7 +910,7 @@ spec:
                   declare -r cacert="/var/run/configmaps/etcd-ca/ca-bundle.crt"
                   export NSS_SDB_USE_CACHE=no
                   [[ -z $cert || -z $key ]] && exit 1
-                  curl --max-time 2 --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
+                  curl --max-time 2 --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '"health":"true"'
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 3


### PR DESCRIPTION
etcd 3.5 health now responds with additional json key "reason" this breaks health checks for quorum guard. This is all very brittle and should be replaced with golang at minimum etcdctl for reasonable error handling. 

was
```
{"health":"true"}
```

now
```
{"health":"true","reason":""}
```