### PR TITLE
Revert "Bug 1701154: Enable etcdHighNumberOfFailedGRPCRequests alerts"

### DIFF
--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -6,7 +6,7 @@ local promRules = if std.objectHasAll(etcdMixin, 'prometheusRules') then etcdMix
 
 // Exclude rules that are either OpenShift specific or do not work for OpenShift.
 // List should be ordered!
-local excludedAlerts = ['etcdHighNumberOfLeaderChanges', 'etcdInsufficientMembers'];
+local excludedAlerts = ['etcdHighNumberOfFailedGRPCRequests', 'etcdHighNumberOfLeaderChanges', 'etcdInsufficientMembers'];
 local excludeRules = std.map(
   function(group) group {
     rules: std.filter(

--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -38,35 +38,6 @@ spec:
       for: 1m
       labels:
         severity: critical
-    - alert: etcdHighNumberOfFailedGRPCRequests
-      annotations:
-        description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
-          for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance
-          }}.'
-        summary: etcd cluster has high number of failed grpc requests.
-      expr: |
-        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[5m])) without (grpc_type, grpc_code)
-          /
-        sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) without (grpc_type, grpc_code)
-          > 1
-      for: 10m
-      labels:
-        severity: warning
-    - alert: etcdHighNumberOfFailedGRPCRequests
-      annotations:
-        description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
-          for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance
-          }}.'
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdHighNumberOfFailedGRPCRequests.md
-        summary: etcd cluster has high number of failed grpc requests.
-      expr: |
-        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[5m])) without (grpc_type, grpc_code)
-          /
-        sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) without (grpc_type, grpc_code)
-          > 5
-      for: 5m
-      labels:
-        severity: critical
     - alert: etcdGRPCRequestsSlow
       annotations:
         description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC requests is {{ $value }}s on etcd instance {{ $labels.instance }}.'


### PR DESCRIPTION
Reverts openshift/cluster-etcd-operator#626

This is almost-permafailing [4.9's metal-ipi blocking job][1]:

![Screenshot 2021-08-03 11 33 53](https://user-images.githubusercontent.com/209920/128045385-2cfc700e-9e14-4153-9156-1da149e7f70d.png)

[1]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.9-blocking#periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi