### PR TITLE
Bug 1980465: pkg/etcdenvvar: warn on apply duration over 200ms

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -33,6 +33,7 @@ var FixedEtcdEnvVars = map[string]string{
 	"ETCD_ENABLE_PPROF":                                "true",
 	"ETCD_EXPERIMENTAL_WATCH_PROGRESS_NOTIFY_INTERVAL": "5s",
 	"ETCD_SOCKET_REUSE_ADDRESS":                        "true",
+	"ETCD_EXPERIMENTAL_WARNING_APPLY_DURATION":         "200ms",
 }
 
 type envVarFunc func(envVarContext envVarContext) (map[string]string, error)


### PR DESCRIPTION
Lets not scare folks with logs? Performance issues should be debugged with metrics. Logs are useful but 100ms threshold is quite common in a production cluster and does not necessarily conclude a performance issue. Moving this threshold to 200ms makes the log more of a useful potential signal.
