### PR TITLE
Bug 1957498: Revert "Revert "Bug 1957498: Update policy.v1beta1 to v1 as it is deprecated in v1.21""

### DIFF
--- a/lib/resourceapply/policyv1.go
+++ b/lib/resourceapply/policyv1.go
@@ -3,15 +3,15 @@ package resourceapply
 import (
 	"context"
 	"github.com/openshift/cluster-etcd-operator/lib/resourcemerge"
-	"k8s.io/api/policy/v1beta1"
+	"k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	policyv1beta1 "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
+	policyv1 "k8s.io/client-go/kubernetes/typed/policy/v1"
 	"k8s.io/utils/pointer"
 )
 
 // ApplyPodDisruptionBudgets applies the required deployment to the cluster.
-func ApplyPodDisruptionBudgets(ctx context.Context, client policyv1beta1.PodDisruptionBudgetsGetter, required *v1beta1.PodDisruptionBudget) (*v1beta1.PodDisruptionBudget, bool, error) {
+func ApplyPodDisruptionBudgets(ctx context.Context, client policyv1.PodDisruptionBudgetsGetter, required *v1.PodDisruptionBudget) (*v1.PodDisruptionBudget, bool, error) {
 	existing, err := client.PodDisruptionBudgets(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.PodDisruptionBudgets(required.Namespace).Create(ctx, required, metav1.CreateOptions{})

--- a/lib/resourcemerge/policyv1.go
+++ b/lib/resourcemerge/policyv1.go
@@ -1,13 +1,13 @@
 package resourcemerge
 
 import (
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // EnsurePodDisruptionBudgets ensures that the existing matches the required.
 // modified is set to true when existing had to be updated with required.
-func EnsurePodDisruptionBudgets(modified *bool, existing *v1beta1.PodDisruptionBudget, required v1beta1.PodDisruptionBudget) {
+func EnsurePodDisruptionBudgets(modified *bool, existing *policyv1.PodDisruptionBudget, required policyv1.PodDisruptionBudget) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
 	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {

--- a/pkg/operator/quorumguardcontroller/quorumguardcontroller_test.go
+++ b/pkg/operator/quorumguardcontroller/quorumguardcontroller_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	fakecore "k8s.io/client-go/kubernetes/fake"
@@ -30,7 +30,7 @@ controlPlane:
   name: master
   replicas: 3`}}
 
-	changedPDB := &policyv1beta1.PodDisruptionBudget{}
+	changedPDB := &policyv1.PodDisruptionBudget{}
 	*changedPDB = *pdb
 	changedPDB.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-changed": EtcdGuardDeploymentName}}
 	deployment := resourceread.ReadDeploymentV1OrDie(etcd_assets.MustAsset("etcd/quorumguard-deployment.yaml"))


### PR DESCRIPTION
Reverts openshift/cluster-etcd-operator#592

4.8 by default has v1 enabled so upgrades from 4.8 -> 4.9 should be smooth