### PR TITLE
Bug 1994707: pkg/etcdcli: provide clear error on status check for unstarted etcd member

### DIFF
--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -281,6 +281,12 @@ func (g *etcdClientGetter) Status(ctx context.Context, member *etcdserverpb.Memb
 	if err != nil {
 		return nil, err
 	}
+
+	// PeerURL is a manditory field, but ClientURL is populated at runtime.
+	if len(member.ClientURLs) == 0 {
+		return nil, fmt.Errorf("etcd member unstarted, status check failed, review operator logs for scaling problems: %s", member.PeerURLs[0])
+	}
+
 	return cli.Status(ctx, member.ClientURLs[0])
 }
 


### PR DESCRIPTION
An RPC to StatusRequest has a dependency on the member being running for dial. This PR handles this failure case and provides context to possible scaling issues.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>