### PR TITLE
Bug 1997207: Pass context into clientv3.Config to use same context

### DIFF
--- a/pkg/cmd/monitor/monitor.go
+++ b/pkg/cmd/monitor/monitor.go
@@ -205,7 +205,7 @@ func (o *monitorOpts) newMonitor(ctx context.Context, lg *zap.Logger, singleTarg
 	// Create single target checks one check per target
 	for _, target := range targets {
 		// one client per target to eliminate lock racing
-		client, err := newETCD3Client(tlsInfo, targets)
+		client, err := newETCD3Client(ctx, tlsInfo, targets)
 		if err != nil {
 			return nil, err
 		}
@@ -219,7 +219,7 @@ func (o *monitorOpts) newMonitor(ctx context.Context, lg *zap.Logger, singleTarg
 	}
 
 	if len(targets) > 1 {
-		client, err := newETCD3Client(tlsInfo, targets)
+		client, err := newETCD3Client(ctx, tlsInfo, targets)
 		if err != nil {
 			return nil, err
 		}
@@ -262,7 +262,7 @@ func WithSingleTargetHealthCheck(checks ...health.CheckFunc) []health.CheckFunc 
 	return checks
 }
 
-func newETCD3Client(tlsInfo transport.TLSInfo, endpoints []string) (*clientv3.Client, error) {
+func newETCD3Client(ctx context.Context, tlsInfo transport.TLSInfo, endpoints []string) (*clientv3.Client, error) {
 
 	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
@@ -279,6 +279,7 @@ func newETCD3Client(tlsInfo transport.TLSInfo, endpoints []string) (*clientv3.Cl
 		DialKeepAliveTimeout: keepaliveTimeout,
 		Endpoints:            endpoints,
 		TLS:                  tlsConfig,
+		Context:              ctx,
 	}
 
 	return clientv3.New(*cfg)


### PR DESCRIPTION
grpc health check does not use context in here https://github.com/openshift/cluster-etcd-operator/blob/ab70a6487419774dabd514824e20f639e8a555bd/pkg/cmd/monitor/health/health.go#L108. Primary reason of this is context value is nil in here https://github.com/openshift/cluster-etcd-operator/blob/ab70a6487419774dabd514824e20f639e8a555bd/vendor/go.etcd.io/etcd/client/v3/client.go#L293. Thereby, cancellations or any other context based operations have no effect on this function.

This PR passes ctx to stick same context also for grpc health check dials.