### PR TITLE
Bug 1994986: test/e2e/etcdctl_test.go: Skip check perf test as we disabled it

### DIFF
--- a/test/e2e/etcdctl_test.go
+++ b/test/e2e/etcdctl_test.go
@@ -30,7 +30,7 @@ func TestEtcdctlCommands(t *testing.T) {
 	}{
 		{"etcdctl alarm disarm", false, "", ""},
 		{"etcdctl alarm list", false, "", ""},
-		{"etcdctl check perf", false, "", ""},
+		{"etcdctl check perf", true, "OpenShift disabled command", ""},
 		{"etcdctl compaction 0", false, "", "Error: etcdserver: mvcc: required revision has been compacted"},
 		{"etcdctl defrag", false, "", ""},
 		{"etcdctl elect myelection", false, "", "no proposal argument but -l not set"},


### PR DESCRIPTION
See https://github.com/openshift/etcd/pull/94 for background.

/hold