### PR TITLE
Bug 1956879: pkg/operator/metriccontroller: read etcd-operator SA token rather than using prometheus

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -161,7 +161,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		return err
 	}
 
-	fsyncMetricController := metriccontroller.NewFSyncController(operatorClient, configClient.ConfigV1(), kubeClient.CoreV1(), controllerContext.EventRecorder)
+	fsyncMetricController := metriccontroller.NewFSyncController(configClient.ConfigV1(), controllerContext.EventRecorder)
 
 	statusController := status.NewClusterOperatorStatusController(
 		"etcd",


### PR DESCRIPTION
Currently, etcd-operator extracts the openshift-monitoring/prometheus-k8s service account token
to use it as a bearer token to execute requests against the prometheus API (via thanos).

Two issues were found:

1. The service account token extraction does not filter tokens annoted with
"kubernetes.io/created-by: openshift.io/create-dockercfg-secrets".

This causes randomly the wrong service account token to be picked up.

2. It impersonates requests against the prometheus API using the prometheus SA token
rather than using it owns.

This fixes it by reading the service account token directly from the pod file system.

/cc @lilic @hexfusion 