### PR TITLE
Bug 1997347: pkg/cmd/verify: bug fixes and improvements

### DIFF
--- a/bindata/etcd/cluster-backup-pod.yaml
+++ b/bindata/etcd/cluster-backup-pod.yaml
@@ -20,6 +20,10 @@ spec:
       volumeMounts:
         - mountPath: /etc/kubernetes/cluster-backup
           name: etc-kubernetes-cluster-backup
+        - mountPath: /var/run/secrets/etcd-client
+          name: etcd-client
+        - mountPath: /var/run/configmaps/etcd-ca
+          name: etcd-ca
   containers:
   - name: cluster-backup
     imagePullPolicy: IfNotPresent
@@ -73,4 +77,9 @@ spec:
     - hostPath:
         path: /etc/kubernetes/static-pod-resources/etcd-certs
       name: cert-dir
-
+    - name: etcd-client
+      secret:
+        secretName: etcd-client
+    - name: etcd-ca
+      configMap:
+        name: etcd-ca-bundle

--- a/cmd/cluster-etcd-operator/main.go
+++ b/cmd/cluster-etcd-operator/main.go
@@ -65,7 +65,7 @@ func NewSSCSCommand() *cobra.Command {
 	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))
 	cmd.AddCommand(waitforceo.NewWaitForCeoCommand(os.Stderr))
 	cmd.AddCommand(monitor.NewMonitorCommand(os.Stderr))
-	cmd.AddCommand(verify.NewVerifyCommand())
+	cmd.AddCommand(verify.NewVerifyCommand(os.Stderr))
 
 	return cmd
 }

--- a/pkg/cmd/verify/backupstorage.go
+++ b/pkg/cmd/verify/backupstorage.go
@@ -58,6 +58,7 @@ func NewVerifyBackupStorage(errOut io.Writer) *cobra.Command {
 			must := func(fn func(ctx context.Context) error) {
 				if err := fn(context.Background()); err != nil {
 					fmt.Fprint(verifyBackupStorage.errOut, err.Error())
+					os.Exit(1)
 				}
 			}
 			must(verifyBackupStorage.Run)

--- a/pkg/cmd/verify/backupstorage.go
+++ b/pkg/cmd/verify/backupstorage.go
@@ -227,7 +227,7 @@ func getPathAvailableSpaceBytes(path string) (int64, error) {
 		return 0, fmt.Errorf("filesystem status: %w", err)
 	}
 
-	available := int64(stat.Bavail) * stat.Bsize
+	available := int64(stat.Bavail) * int64(stat.Bsize)
 	if available == 0 {
 		return 0, fmt.Errorf("filesystem status: no available bytes")
 	}

--- a/pkg/cmd/verify/backupstorage.go
+++ b/pkg/cmd/verify/backupstorage.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	defaultEndpoint       = "https://127.0.0.1:2370"
-	defaultBackupPath     = "/var/lib/cluster-backup"
+	defaultEndpoint       = "https://localhost:2379"
+	defaultBackupPath     = "/etc/kubernetes/cluster-backup"
 	defaultCertFilePath   = "/var/run/secrets/etcd-client/tls.crt"
 	defaultKeyFilePath    = "/var/run/secrets/etcd-client/tls.key"
 	defaultCaCertFilePath = "/var/run/configmaps/etcd-ca/ca-bundle.crt"

--- a/pkg/cmd/verify/verify.go
+++ b/pkg/cmd/verify/verify.go
@@ -7,17 +7,16 @@ import (
 )
 
 type verifyStorageOpts struct {
-	errOut     io.Writer
-	kubeconfig string
+	errOut io.Writer
 }
 
 // NewVerifyCommand checks to verify preconditions and exit 0 on success.
-func NewVerifyCommand() *cobra.Command {
+func NewVerifyCommand(errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "performs checks to verify preconditions and exit 0 on success",
 		Run:   func(cmd *cobra.Command, args []string) {},
 	}
-	cmd.AddCommand(NewVerifyBackupStorage())
+	cmd.AddCommand(NewVerifyBackupStorage(errOut))
 	return cmd
 }

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -89,6 +89,10 @@ spec:
       volumeMounts:
         - mountPath: /etc/kubernetes/cluster-backup
           name: etc-kubernetes-cluster-backup
+        - mountPath: /var/run/secrets/etcd-client
+          name: etcd-client
+        - mountPath: /var/run/configmaps/etcd-ca
+          name: etcd-ca
   containers:
   - name: cluster-backup
     imagePullPolicy: IfNotPresent
@@ -142,7 +146,12 @@ spec:
     - hostPath:
         path: /etc/kubernetes/static-pod-resources/etcd-certs
       name: cert-dir
-
+    - name: etcd-client
+      secret:
+        secretName: etcd-client
+    - name: etcd-ca
+      configMap:
+        name: etcd-ca-bundle
 `)
 
 func etcdClusterBackupPodYamlBytes() ([]byte, error) {


### PR DESCRIPTION
This PR addresses a few bugs that were missed in the original PR. The fact that logging was muted and the initcontainer was exiting 0 on failure masked the problems which did end up with a successful backup but the disk checks were not properly being performed. This also adds a fix for s390x compile errors carried from #656 thanks again @yselkowitz
