### PR TITLE
Bug 2006975: Suppress noisy logs and improve client errors

### DIFF
--- a/pkg/cmd/backuprestore/backuprestore.go
+++ b/pkg/cmd/backuprestore/backuprestore.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"io"
-	"k8s.io/klog/v2"
 	"os"
 	"os/signal"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
 )
 
 type backupOptions struct {

--- a/pkg/cmd/backuprestore/backuputils.go
+++ b/pkg/cmd/backuprestore/backuputils.go
@@ -2,9 +2,10 @@ package backuprestore
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"path/filepath"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 //This backup mimics the functionality of cluster-backup.sh

--- a/pkg/cmd/backuprestore/etcdclientutils.go
+++ b/pkg/cmd/backuprestore/etcdclientutils.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"time"
 
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
 	"k8s.io/klog/v2"
 )
 
 func getEtcdClient(endpoints []string) (*clientv3.Client, error) {
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr))
 	dialOptions := []grpc.DialOption{
 		grpc.WithBlock(), // block until the underlying connection is up
 	}

--- a/pkg/cmd/verify/backupstorage.go
+++ b/pkg/cmd/verify/backupstorage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -17,6 +18,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -157,6 +159,7 @@ func (v *verifyBackupStorage) isStorageAdequate(ctx context.Context) (bool, erro
 }
 
 func newETCD3Client(ctx context.Context, tlsInfo transport.TLSInfo) (*clientv3.Client, error) {
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr))
 	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -3,8 +3,10 @@ package etcdcli
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -15,9 +17,12 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -133,10 +138,12 @@ func (g *etcdClientGetter) getEtcdClient() (*clientv3.Client, error) {
 }
 
 func getEtcdClientWithClientOpts(endpoints []string, opts ...ClientOption) (*clientv3.Client, error) {
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr))
 	clientOpts, err := newClientOpts(opts...)
 	if err != nil {
 		return nil, err
 	}
+
 	dialOptions := []grpc.DialOption{
 		grpc.WithBlock(), // block until the underlying connection is up
 	}

--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -158,11 +158,20 @@ func getEtcdClientWithClientOpts(endpoints []string, opts ...ClientOption) (*cli
 		return nil, err
 	}
 
+	// Our logs are noisy
+	lcfg := logutil.DefaultZapLoggerConfig
+	lcfg.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
+	l, err := lcfg.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed building client logger: %w", err)
+	}
+
 	cfg := &clientv3.Config{
 		DialOptions: dialOptions,
 		Endpoints:   endpoints,
 		DialTimeout: clientOpts.dialTimeout,
 		TLS:         tlsConfig,
+		Logger:      l,
 	}
 
 	cli, err := clientv3.New(*cfg)

--- a/pkg/etcdcli/helpers.go
+++ b/pkg/etcdcli/helpers.go
@@ -39,14 +39,14 @@ func (f *fakeEtcdClient) MemberAdd(peerURL string) error {
 	panic("implement me")
 }
 
-func (f *fakeEtcdClient) MemberList() ([]*etcdserverpb.Member, error) {
+func (f *fakeEtcdClient) MemberList(ctx context.Context) ([]*etcdserverpb.Member, error) {
 	return f.members, nil
 }
 
 func (f *fakeEtcdClient) MemberRemove(member string) error {
 	panic("implement me")
 }
-func (f *fakeEtcdClient) MemberHealth() (memberHealth, error) {
+func (f *fakeEtcdClient) MemberHealth(ctx context.Context) (memberHealth, error) {
 	var healthy, unhealthy int
 	var memberHealth memberHealth
 	for _, member := range f.members {

--- a/pkg/etcdcli/interfaces.go
+++ b/pkg/etcdcli/interfaces.go
@@ -43,7 +43,7 @@ type MemberAdder interface {
 }
 
 type MemberHealth interface {
-	MemberHealth() (memberHealth, error)
+	MemberHealth(ctx context.Context) (memberHealth, error)
 }
 type IsMemberHealthy interface {
 	IsMemberHealthy(member *etcdserverpb.Member) (bool, error)
@@ -53,7 +53,7 @@ type MemberRemover interface {
 }
 
 type MemberLister interface {
-	MemberList() ([]*etcdserverpb.Member, error)
+	MemberList(ctx context.Context) ([]*etcdserverpb.Member, error)
 }
 
 type HealthyMemberLister interface {

--- a/pkg/operator/defragcontroller/defragcontroller.go
+++ b/pkg/operator/defragcontroller/defragcontroller.go
@@ -102,13 +102,13 @@ func (c *DefragController) checkDefrag(ctx context.Context, recorder events.Reco
 		recorder.Warning("DefragControllerUpdatingStatus", updateErr.Error())
 	}
 
-	etcdMembers, err := c.etcdClient.MemberList()
+	etcdMembers, err := c.etcdClient.MemberList(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Do not defrag if any of the cluster members are unhealthy
-	memberHealth, err := c.etcdClient.MemberHealth()
+	memberHealth, err := c.etcdClient.MemberHealth(ctx)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (c *DefragController) checkDefrag(ctx context.Context, recorder events.Reco
 				waitDuration,
 				timeoutDuration,
 				func() (bool, error) {
-					memberHealth, err := c.etcdClient.MemberHealth()
+					memberHealth, err := c.etcdClient.MemberHealth(ctx)
 					if err != nil {
 						klog.Warningf("failed checking member health: %v", err)
 						return false, nil

--- a/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
+++ b/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
@@ -60,7 +60,10 @@ func (c *EtcdMembersController) sync(ctx context.Context, syncCtx factory.SyncCo
 }
 
 func (c *EtcdMembersController) reportEtcdMembers(recorder events.Recorder) error {
-	memberHealth, err := c.etcdClient.MemberHealth()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	memberHealth, err := c.etcdClient.MemberHealth(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Suppress noisy logs like context cancelled or context deadline exceeded as they are confusing to users.

