### PR TITLE
pkg/operator: disable upgrade backup controller

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -28,7 +28,6 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/scriptcontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/targetconfigcontroller"
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/upgradebackupcontroller"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -248,19 +247,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 	)
 
-	upgradeBackupController := upgradebackupcontroller.NewUpgradeBackupController(
-		operatorClient,
-		configClient.ConfigV1(),
-		kubeClient,
-		etcdClient,
-		kubeInformersForNamespaces,
-		configInformers.Config().V1().ClusterVersions(),
-		configInformers.Config().V1().ClusterOperators(),
-		controllerContext.EventRecorder,
-		os.Getenv("IMAGE"),
-		os.Getenv("OPERATOR_IMAGE"),
-	)
-
 	unsupportedConfigOverridesController := unsupportedconfigoverridescontroller.NewUnsupportedConfigOverridesController(
 		operatorClient,
 		controllerContext.EventRecorder,
@@ -296,7 +282,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	go scriptController.Run(ctx, 1)
 	go quorumGuardController.Run(ctx, 1)
 	go defragController.Run(ctx, 1)
-	go upgradeBackupController.Run(ctx, 1)
 
 	go envVarController.Run(1, ctx.Done())
 	go staticPodControllers.Start(ctx)

--- a/pkg/operator/upgradebackupcontroller/upgradebackupcontroller.go
+++ b/pkg/operator/upgradebackupcontroller/upgradebackupcontroller.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// NOTE: This controller DISABLED in 4.10+ and can be removed at any time.
+
 // UpgradeBackupController responds to an upgrade request to 4.9 by attempting
 // to ensure the cluster is backed up. The CVO is expected to wait on a ceo
 // condition indicating successful backup before responding to the upgrade


### PR DESCRIPTION
This controller was added specifically for 4.8 -> 4.9 upgrades. This PR diable the controller in 4.10 while we consider the fate of the code moving forward.

cc @lilic @hasbro17 