### PR TITLE
Bug 2013661: pkg: Go degraded if disk metrics are above threshold

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -162,7 +162,10 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		return err
 	}
 
-	fsyncMetricController := metriccontroller.NewFSyncController(configClient.ConfigV1(), controllerContext.EventRecorder)
+	fsyncMetricController := metriccontroller.NewFSyncController(
+		configClient.ConfigV1(),
+		operatorClient,
+		controllerContext.EventRecorder)
 
 	statusController := status.NewClusterOperatorStatusController(
 		"etcd",


### PR DESCRIPTION
Backport of https://github.com/openshift/cluster-etcd-operator/pull/687.

Adding another commit to this as waiting for the adjust query PR to be merged first, will rebase then again when https://github.com/openshift/cluster-etcd-operator/pull/686 is merged.

/hold

We want to be merged only when it soaks up in 4.10 and we see that it goes degraded correctly.

cc @hasbro17 @hexfusion 