### PR TITLE
Exclude all metal env from etcdHighNumberOfFailedGRPCRequests

### DIFF
--- a/jsonnet/custom.libsonnet
+++ b/jsonnet/custom.libsonnet
@@ -10,7 +10,7 @@
               100 * sum(rate(grpc_server_handled_total{job="etcd", grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[5m])) without (grpc_type, grpc_code)
                 /
               sum(rate(grpc_server_handled_total{job="etcd"}[5m])) without (grpc_type, grpc_code)
-                > 2 and on ()(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal"} == bool 1))
+                > 2 and on ()(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal|None|oVirt"} == bool 1))
             |||,
             'for': '10m',
             labels: {
@@ -27,7 +27,7 @@
               100 * sum(rate(grpc_server_handled_total{job="etcd", grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[5m])) without (grpc_type, grpc_code)
                 /
               sum(rate(grpc_server_handled_total{job="etcd"}[5m])) without (grpc_type, grpc_code)
-                > 5 and on ()(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal"} == bool 1))
+                > 5 and on ()(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal|None|oVirt"} == bool 1))
             |||,
             'for': '10m',
             labels: {

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "519f62b269cbc5f0438587cdcd9e3d4653c6515b",
-      "sum": "IF9N4i2Zgl4vm3ZHe3MDptcqLswNESKy9NMz9av8Im0="
+      "version": "38a7d79810bd273bd078bf0931480b743afee003",
+      "sum": "drRRtMPhvpUZ8v7Weqz7Cg2pwDA2cSb6X1pjBPoCx1w="
     }
   ],
   "legacyImports": false

--- a/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/mixin.libsonnet
+++ b/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/mixin.libsonnet
@@ -132,7 +132,7 @@
               severity: 'critical',
             },
             annotations: {
-              description: 'etcd cluster "{{ $labels.%s }}": 99th percentile of gRPC requests is {{ $value }}s on etcd instance {{ $labels.instance }}.' % $._config.clusterLabel,
+              description: 'etcd cluster "{{ $labels.%s }}": 99th percentile of gRPC requests is {{ $value }}s on etcd instance {{ $labels.instance }} for {{ $labels.grpc_method }} method.' % $._config.clusterLabel,
               summary: 'etcd grpc requests are slow',
             },
           },
@@ -1381,7 +1381,7 @@
               value: 'Prometheus',
             },
             hide: 0,
-            label: null,
+            label: 'Data Source',
             name: 'datasource',
             options: [],
             query: 'prometheus',

--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -13,8 +13,7 @@ spec:
     rules:
     - alert: etcdMembersDown
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
-          }}).'
+        description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value }}).'
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdMembersDown.md
         summary: etcd cluster members are down.
       expr: |
@@ -31,8 +30,7 @@ spec:
         severity: critical
     - alert: etcdNoLeader
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
-          }} has no leader.'
+        description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdNoLeader.md
         summary: etcd cluster has no leader.
       expr: |
@@ -42,8 +40,7 @@ spec:
         severity: critical
     - alert: etcdGRPCRequestsSlow
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC requests
-          is {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC requests is {{ $value }}s on etcd instance {{ $labels.instance }} for {{ $labels.grpc_method }} method.'
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdGRPCRequestsSlow.md
         summary: etcd grpc requests are slow
       expr: |
@@ -54,9 +51,7 @@ spec:
         severity: critical
     - alert: etcdMemberCommunicationSlow
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": member communication with
-          {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance
-          }}.'
+        description: 'etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
         summary: etcd cluster member communication is slow.
       expr: |
         histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~".*etcd.*"}[5m]))
@@ -66,8 +61,7 @@ spec:
         severity: warning
     - alert: etcdHighNumberOfFailedProposals
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures
-          within the last 30 minutes on etcd instance {{ $labels.instance }}.'
+        description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last 30 minutes on etcd instance {{ $labels.instance }}.'
         summary: etcd cluster has high number of proposal failures.
       expr: |
         rate(etcd_server_proposals_failed_total{job=~".*etcd.*"}[15m]) > 5
@@ -76,8 +70,7 @@ spec:
         severity: warning
     - alert: etcdHighFsyncDurations
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations
-          are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
         summary: etcd cluster 99th percentile fsync durations are too high.
       expr: |
         histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
@@ -87,8 +80,7 @@ spec:
         severity: warning
     - alert: etcdHighFsyncDurations
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations
-          are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdHighFsyncDurations.md
       expr: |
         histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
@@ -98,8 +90,7 @@ spec:
         severity: critical
     - alert: etcdHighCommitDurations
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit durations
-          {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
         summary: etcd cluster 99th percentile commit durations are too high.
       expr: |
         histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
@@ -109,9 +100,7 @@ spec:
         severity: warning
     - alert: etcdBackendQuotaLowSpace
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": database size exceeds the
-          defined quota on etcd instance {{ $labels.instance }}, please defrag or
-          increase the quota as the writes to etcd will be disabled when it is full.'
+        description: 'etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdBackendQuotaLowSpace.md
       expr: |
         (etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100 > 95
@@ -120,9 +109,7 @@ spec:
         severity: critical
     - alert: etcdExcessiveDatabaseGrowth
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes
-          leading to 50% increase in database size over the past four hours on etcd
-          instance {{ $labels.instance }}, please check as it might be disruptive.'
+        description: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes leading to 50% increase in database size over the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
       expr: |
         increase(((etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100)[240m:1m]) > 50
       for: 10m
@@ -138,7 +125,7 @@ spec:
         100 * sum(rate(grpc_server_handled_total{job="etcd", grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[5m])) without (grpc_type, grpc_code)
           /
         sum(rate(grpc_server_handled_total{job="etcd"}[5m])) without (grpc_type, grpc_code)
-          > 2 and on ()(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal"} == bool 1))
+          > 2 and on ()(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal|None|oVirt"} == bool 1))
       for: 10m
       labels:
         severity: warning
@@ -151,16 +138,13 @@ spec:
         100 * sum(rate(grpc_server_handled_total{job="etcd", grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[5m])) without (grpc_type, grpc_code)
           /
         sum(rate(grpc_server_handled_total{job="etcd"}[5m])) without (grpc_type, grpc_code)
-          > 5 and on ()(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal"} == bool 1))
+          > 5 and on ()(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal|None|oVirt"} == bool 1))
       for: 10m
       labels:
         severity: critical
     - alert: etcdHighNumberOfLeaderChanges
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": {{ $value }} leader changes
-          within the last 15 minutes. Frequent elections may be a sign of insufficient
-          resources, high network latency, or disruptions by other components and
-          should be investigated.'
+        description: 'etcd cluster "{{ $labels.job }}": {{ $value }} leader changes within the last 15 minutes. Frequent elections may be a sign of insufficient resources, high network latency, or disruptions by other components and should be investigated.'
         summary: etcd cluster has high number of leader changes.
       expr: |
         increase((max without (instance) (etcd_server_leader_changes_seen_total{job=~".*etcd.*"}) or 0*absent(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}))[15m:1m]) >= 5
@@ -169,18 +153,10 @@ spec:
         severity: warning
     - alert: etcdInsufficientMembers
       annotations:
-        description: etcd is reporting fewer instances are available than are needed
-          ({{ $value }}). When etcd does not have a majority of instances available
-          the Kubernetes and OpenShift APIs will reject read and write requests and
-          operations that preserve the health of workloads cannot be performed. This
-          can occur when multiple control plane nodes are powered off or are unable
-          to connect to each other via the network. Check that all control plane nodes
-          are powered on and that network connections between each machine are functional.
+        description: etcd is reporting fewer instances are available than are needed ({{ $value }}). When etcd does not have a majority of instances available the Kubernetes and OpenShift APIs will reject read and write requests and operations that preserve the health of workloads cannot be performed. This can occur when multiple control plane nodes are powered off or are unable to connect to each other via the network. Check that all control plane nodes are powered on and that network connections between each machine are functional.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdInsufficientMembers.md
         summary: etcd is reporting that a majority of instances are unavailable.
-      expr: sum(up{job="etcd"} == bool 1 and etcd_server_has_leader{job="etcd"} ==
-        bool 1) without (instance,pod) < ((count(up{job="etcd"}) without (instance,pod)
-        + 1) / 2)
+      expr: sum(up{job="etcd"} == bool 1 and etcd_server_has_leader{job="etcd"} == bool 1) without (instance,pod) < ((count(up{job="etcd"}) without (instance,pod) + 1) / 2)
       for: 3m
       labels:
         severity: critical


### PR DESCRIPTION
This is due to slower startup which makes etcd unavailable longer compared to other platforms or env.

@hexfusion please take a look, thanks!

I will do either a follow-up ticket or PR to have an alert for metal env that takes this bootstrap into account, but this enables CI jobs to pass while still having alerts fire correctly for other env.