### PR TITLE
pkg/operator/etcdendpointscontroller: use etcd membership to populate endpoints

### DIFF
--- a/pkg/dnshelpers/util.go
+++ b/pkg/dnshelpers/util.go
@@ -3,6 +3,7 @@ package dnshelpers
 import (
 	"fmt"
 	"net"
+	"net/url"
 
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -129,4 +130,18 @@ func GetInternalIPAddressesForNodeName(node *corev1.Node) ([]string, error) {
 	}
 
 	return addresses, nil
+}
+
+// GetIPFromAddress takes a client or peer address and returns the IP address (unescaped if IPv6).
+func GetIPFromAddress(address string) (string, error) {
+	u, err := url.Parse(address)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse address: %s: %w", address, err)
+	}
+	host, _, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		return "", fmt.Errorf("failed to split host port: %s: %w", u.Host, err)
+	}
+
+	return host, nil
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -306,6 +306,7 @@ var RevisionConfigMaps = []revision.RevisionResource{
 	{Name: "etcd-peer-client-ca"},
 	{Name: "etcd-metrics-proxy-serving-ca"},
 	{Name: "etcd-metrics-proxy-client-ca"},
+	{Name: "etcd-endpoints"},
 }
 
 // RevisionSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.


### PR DESCRIPTION
This PR is a step towards the goal of providing more flexibility in way we communicate etcd membership to the apiserver on a revision level. First of all, we are going to now version the etcd-endpoints configmap. Membership change precludes a new revision and we want to use the etcd-endpoints data to be able to understand this during the revision and as a historical reference.

The second part moves the population of endpoints to actual etcd membership `MemberList` vs blindly using all control-plane nodes. This will prove future flexibility as OpenShift begins to overcome future scaling challenges.

The third part of this change adjusts the key used in the configmap. Today we base64 encode the IP address, while this does generate a unique key per endpoint the data is not useful. We now use the etcd member id as the key. This is an important designation because an IP address (node) can over time have many members. An example of this would be disaster recovery.

example of versioned configmap taken from CI
```
        {
            "apiVersion": "v1",
            "data": {
                "5a4b27de7cb53cad": "10.0.190.46",
                "77564ad437dae32e": "10.0.253.233",
                "ac137595322cc148": "10.0.138.56"
            },
            "kind": "ConfigMap",
            "metadata": {
                "annotations": {
                    "alpha.installer.openshift.io/etcd-bootstrap": "10.0.33.149"
                },
                "creationTimestamp": "2021-11-12T15:30:19Z",
                "name": "etcd-endpoints-5",
                "namespace": "openshift-etcd",
                "ownerReferences": [
                    {
                        "apiVersion": "v1",
                        "kind": "ConfigMap",
                        "name": "revision-status-5",
                        "uid": "118b6a3c-c67c-4f90-ba73-73c38f9a1ed6"
                    }
                ],
                "resourceVersion": "11277",
                "uid": "23d091c2-954c-44eb-bdf2-2a0b776a24da"
            }
        },
 ```


 A noticeable change is that etcd goes from 3 revisions to 6 during install. But because these happen fairly quickly the net revisions per node is still max(3)
 