### PR TITLE
pkg/operator/quorumguardcontroller: add pod affinity

### DIFF
--- a/bindata/etcd/quorumguard-deployment.yaml
+++ b/bindata/etcd/quorumguard-deployment.yaml
@@ -21,6 +21,15 @@ spec:
     spec:
       hostNetwork: true
       affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values:
+                      - "etcd"
+              topologyKey: kubernetes.io/hostname
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -963,6 +963,15 @@ spec:
     spec:
       hostNetwork: true
       affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values:
+                      - "etcd"
+              topologyKey: kubernetes.io/hostname
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/pkg/operator/quorumguardcontroller/quorumguardcontroller.go
+++ b/pkg/operator/quorumguardcontroller/quorumguardcontroller.go
@@ -172,7 +172,7 @@ func (c *QuorumGuardController) ensureEtcdGuardDeployment(ctx context.Context, r
 	// use image from release payload
 	c.etcdQuorumGuard.Spec.Template.Spec.Containers[0].Image = c.cliImagePullSpec
 
-	// if restart occurred, we will apply etcd guard deployment but if it is the same, nothing will happened
+	// if restart occurred, we will apply etcd guard deployment but if it is the same, nothing will happen
 	actual, modified, err := resourceapply.ApplyDeploymentv1(ctx, c.kubeClient.AppsV1(), c.etcdQuorumGuard)
 	if err != nil {
 		klog.Errorf("failed to verify/apply %s, error %w", EtcdGuardDeploymentName, err)

--- a/pkg/operator/quorumguardcontroller/quorumguardcontroller_test.go
+++ b/pkg/operator/quorumguardcontroller/quorumguardcontroller_test.go
@@ -103,7 +103,7 @@ controlPlane:
 			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 2, wantErr: false, expectedReplicaCount: 3,
 		},
 		{
-			name: "test ensureEtcdGuard - nonHAmod",
+			name: "test ensureEtcdGuard - non HA mode",
 			fields: fields{
 				client: fakecore.NewSimpleClientset(),
 				infraObj: &configv1.Infrastructure{
@@ -117,7 +117,7 @@ controlPlane:
 			expectedHATopology: configv1.SingleReplicaTopologyMode, expectedEvents: 0, wantErr: false, expectedReplicaCount: 0,
 		},
 		{
-			name: "test ensureEtcdGuard - ha mod not set, nothing exists",
+			name: "test ensureEtcdGuard - HA mode not set, nothing exists",
 			fields: fields{
 				client: fakecore.NewSimpleClientset(&clusterConfigFullHA),
 				infraObj: &configv1.Infrastructure{

--- a/test/e2e/etcquorumguard_test.go
+++ b/test/e2e/etcquorumguard_test.go
@@ -146,8 +146,8 @@ func makeAllNodesSchedulable(cs *framework.ClientSet) error {
 	return getMasterNodes(cs)
 }
 
-func evictEtcdQuotaGuardPodsFromNode(cs *framework.ClientSet, node string) error {
-	pods, err := getEtcdQuotaGuardPodsOnNode(cs, node)
+func evictEtcdQuorumGuardPodsFromNode(cs *framework.ClientSet, node string) error {
+	pods, err := getEtcdQuorumGuardPodsOnNode(cs, node)
 	if err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func makeOneNodeUnschedulableAndEvict(cs *framework.ClientSet) error {
 				break
 			}
 			nodes[node] = true
-			err = evictEtcdQuotaGuardPodsFromNode(cs, node)
+			err = evictEtcdQuorumGuardPodsFromNode(cs, node)
 			break
 		}
 	}
@@ -256,7 +256,7 @@ func getMasterNodes(cs *framework.ClientSet) error {
 	return nil
 }
 
-func getEtcdQuotaGuardPodsOnNode(cs *framework.ClientSet, node string) ([]corev1.Pod, error) {
+func getEtcdQuorumGuardPodsOnNode(cs *framework.ClientSet, node string) ([]corev1.Pod, error) {
 	_, err := getNode(cs, node)
 	var answer []corev1.Pod
 	if err != nil {


### PR DESCRIPTION
This PR add pod affinity for the quorum-guard pod matching k8s-app etcd. This gives us more flexibility in the future to ensure quorum-guard is scheduled to nodes where etcd static-pod has been installed.

This also will reduce the amount of time during install where quorum-guard reports health check failures while etcd is rolling out during install.