### PR TITLE
pkg/etcdenvvar: set max learners based on desired control plane replicas

### DIFF
--- a/pkg/cmd/render/env_test.go
+++ b/pkg/cmd/render/env_test.go
@@ -1,22 +1,127 @@
 package render
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ghodss/yaml"
+)
+
+var (
+	installConfigSNO = `
+    apiVersion: v1
+    baseDomain: test.com
+    compute:
+    - architecture: amd64
+      name: worker
+      replicas: 3
+    controlPlane:
+      name: master
+      replicas: 1
+`
+	installConfigHA = `
+    apiVersion: v1
+    baseDomain: test.com
+    compute:
+    - architecture: amd64
+      name: worker
+      replicas: 3
+    controlPlane:
+      name: master
+      replicas: 3
+`
+)
 
 func TestEtcdEnv(t *testing.T) {
-	for _, test := range []struct {
-		platform, arch, wantKey, wantValue string
+	tests := []struct {
+		name          string
+		platform      string
+		arch          string
+		wantKey       string
+		wantValue     string
+		installConfig string
 	}{
-		{"AWS", "amd64", "ETCD_HEARTBEAT_INTERVAL", "100"},
-		{"AWS", "amd64", "ETCD_ELECTION_TIMEOUT", "1000"},
-		{"Azure", "ppc64le", "ETCD_HEARTBEAT_INTERVAL", "500"},
-		{"Azure", "amd64", "ETCD_ELECTION_TIMEOUT", "2500"},
-		{"None", "ppc64le", "ETCD_HEARTBEAT_INTERVAL", "100"},
-		{"Azure", "s390x", "ETCD_UNSUPPORTED_ARCH", "s390x"},
-		{"None", "arm64", "ETCD_UNSUPPORTED_ARCH", "arm64"},
-	} {
-		env, _ := getEtcdEnv(test.platform, test.arch)
-		if env[test.wantKey] != test.wantValue {
-			t.Errorf("getEtcdEnv(%q, %q) =  want %q = %q got %q = %q", test.platform, test.arch, test.wantKey, test.wantValue, test.wantKey, env[test.wantKey])
-		}
+		{
+			name:          "AWS HA etcd heartbeat interval",
+			platform:      "AWS",
+			arch:          "amd64",
+			wantKey:       "ETCD_HEARTBEAT_INTERVAL",
+			installConfig: installConfigHA,
+			wantValue:     "100",
+		},
+		{
+			name:          "None SNO etcd election timeout",
+			platform:      "None",
+			arch:          "ppc64le",
+			wantKey:       "ETCD_HEARTBEAT_INTERVAL",
+			installConfig: installConfigSNO,
+			wantValue:     "100",
+		},
+		{
+			name:          "Azure HA etcd heartbeat interval",
+			platform:      "Azure",
+			arch:          "amd64",
+			wantKey:       "ETCD_HEARTBEAT_INTERVAL",
+			installConfig: installConfigHA,
+			wantValue:     "500",
+		},
+		{
+			name:          "Azure HA etcd election timeout",
+			platform:      "Azure",
+			arch:          "amd64",
+			wantKey:       "ETCD_ELECTION_TIMEOUT",
+			installConfig: installConfigHA,
+			wantValue:     "2500",
+		},
+		{
+			name:          "None HA s390x",
+			platform:      "None",
+			arch:          "s390x",
+			wantKey:       "ETCD_UNSUPPORTED_ARCH",
+			installConfig: installConfigHA,
+			wantValue:     "s390x",
+		},
+		{
+			name:          "None SNO arm64",
+			platform:      "None",
+			arch:          "arm64",
+			wantKey:       "ETCD_UNSUPPORTED_ARCH",
+			installConfig: installConfigSNO,
+			wantValue:     "arm64",
+		},
+		{
+			name:          "GCP SNO max learners",
+			platform:      "GCP",
+			arch:          "arm64",
+			wantKey:       "ETCD_EXPERIMENTAL_MAX_LEARNERS",
+			installConfig: installConfigSNO,
+			wantValue:     "1",
+		},
+		{
+			name:          "None HA max learners",
+			platform:      "None",
+			arch:          "arm64",
+			wantKey:       "ETCD_EXPERIMENTAL_MAX_LEARNERS",
+			installConfig: installConfigHA,
+			wantValue:     "3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var installConfig map[string]interface{}
+			installConfigJson, _ := yaml.YAMLToJSON([]byte(tt.installConfig))
+			err := json.Unmarshal(installConfigJson, &installConfig)
+			if err != nil {
+				t.Errorf("failed to unmarshal install config json %w", err)
+			}
+			data := &envVarData{tt.platform, tt.arch, installConfig}
+			env, err := getEtcdEnv(data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if env[tt.wantKey] != tt.wantValue {
+				t.Errorf("getEtcdEnv(%q, %q) =  want %q = %q got %q = %q", tt.platform, tt.arch, tt.wantKey, tt.wantValue, tt.wantKey, env[tt.wantKey])
+			}
+		})
 	}
 }

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -182,6 +182,9 @@ type TemplateData struct {
 
 	// EtcdEndpointConfigmapData is an optional data field used by etcd-endpoints configmap.
 	EtcdEndpointConfigmapData string
+
+	// MaxLearners is the maximum number of learner members that can be part of the cluster membership.
+	MaxLearners int
 }
 
 type StaticFile struct {
@@ -257,7 +260,7 @@ func newTemplateData(opts *renderOpts) (*TemplateData, error) {
 		return nil, err
 	}
 
-	if err := templateData.setComputedEnvVars(templateData.Platform); err != nil {
+	if err := templateData.setComputedEnvVars(templateData.Platform, installConfig); err != nil {
 		return nil, err
 	}
 
@@ -559,8 +562,9 @@ func (t *TemplateData) setSingleStackIPv6(serviceCIDR []string) error {
 	return nil
 }
 
-func (t *TemplateData) setComputedEnvVars(platform string) error {
-	envVarMap, err := getEtcdEnv(platform, runtime.GOARCH)
+func (t *TemplateData) setComputedEnvVars(platform string, installConfig map[string]interface{}) error {
+	envVarData := &envVarData{platform: platform, arch: runtime.GOARCH, installConfig: installConfig}
+	envVarMap, err := getEtcdEnv(envVarData)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -5,4 +5,5 @@ const (
 	GlobalMachineSpecifiedConfigNamespace = "openshift-config-managed"
 	OperatorNamespace                     = "openshift-etcd-operator"
 	TargetNamespace                       = "openshift-etcd"
+	KubeSystemNamespace                   = "kube-system"
 )

--- a/pkg/operator/quorumguardcontroller/quorumguardcontroller_test.go
+++ b/pkg/operator/quorumguardcontroller/quorumguardcontroller_test.go
@@ -6,6 +6,8 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcd_assets"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	corev1 "k8s.io/api/core/v1"
@@ -13,17 +15,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	fakecore "k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/pointer"
-
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcd_assets"
 )
 
 func TestQuorumGuardController_ensureEtcdGuard(t *testing.T) {
-	clusterConfigFullHA := corev1.ConfigMap{TypeMeta: metav1.TypeMeta{},
+	clusterConfigFullHA := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterConfigName,
-			Namespace: clusterConfigNamespace,
+			Namespace: operatorclient.TargetNamespace,
 		}, Data: map[string]string{clusterConfigKey: `apiVersion: v1
 controlPlane:
   hyperthreading: Enabled
@@ -37,8 +39,7 @@ controlPlane:
 	changedDeployment := resourceread.ReadDeploymentV1OrDie(etcd_assets.MustAsset("etcd/quorumguard-deployment.yaml"))
 	changedDeployment.Spec.Replicas = pointer.Int32Ptr(1)
 
-	fakeInfraIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	haInfra := &configv1.Infrastructure{
+	haInfra := configv1.Infrastructure{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: infrastructureClusterName,
@@ -48,8 +49,9 @@ controlPlane:
 	}
 
 	type fields struct {
-		client   kubernetes.Interface
-		infraObj *configv1.Infrastructure
+		client           kubernetes.Interface
+		infraObj         configv1.Infrastructure
+		clusterConfigObj corev1.ConfigMap
 	}
 	tests := []struct {
 		name                 string
@@ -62,51 +64,81 @@ controlPlane:
 		{
 			name: "test ensureEtcdGuard - deployment exists but pdb not",
 			fields: fields{
-				client:   fakecore.NewSimpleClientset(deployment, &clusterConfigFullHA),
-				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 2, wantErr: false, expectedReplicaCount: 3,
+				client:           fakecore.NewSimpleClientset(deployment),
+				infraObj:         haInfra,
+				clusterConfigObj: clusterConfigFullHA,
+			},
+
+			expectedHATopology:   configv1.HighlyAvailableTopologyMode,
+			expectedEvents:       2,
+			wantErr:              false,
+			expectedReplicaCount: 3,
 		},
 		{
 			name: "test ensureEtcdGuard - deployment and pdb exists",
 			fields: fields{
-				client:   fakecore.NewSimpleClientset(deployment, pdb, &clusterConfigFullHA),
-				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 1, wantErr: false, expectedReplicaCount: 3,
+				client:           fakecore.NewSimpleClientset(deployment, pdb),
+				infraObj:         haInfra,
+				clusterConfigObj: clusterConfigFullHA,
+			},
+			expectedHATopology:   configv1.HighlyAvailableTopologyMode,
+			expectedEvents:       1,
+			wantErr:              false,
+			expectedReplicaCount: 3,
 		},
 		{
 			name: "test ensureEtcdGuard - deployment not exists but pdb exists",
 			fields: fields{
-				client:   fakecore.NewSimpleClientset(&clusterConfigFullHA, pdb),
-				infraObj: haInfra,
+				client:           fakecore.NewSimpleClientset(pdb),
+				infraObj:         haInfra,
+				clusterConfigObj: clusterConfigFullHA,
 			},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 1, wantErr: false, expectedReplicaCount: 3,
+			expectedHATopology:   configv1.HighlyAvailableTopologyMode,
+			expectedEvents:       1,
+			wantErr:              false,
+			expectedReplicaCount: 3,
 		},
 		{
 			name: "test ensureEtcdGuard - deployment was changed and pdb exists",
 			fields: fields{
-				client:   fakecore.NewSimpleClientset(changedDeployment, pdb, &clusterConfigFullHA),
-				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 1, wantErr: false, expectedReplicaCount: 3,
+				client:           fakecore.NewSimpleClientset(changedDeployment, pdb),
+				infraObj:         haInfra,
+				clusterConfigObj: clusterConfigFullHA,
+			},
+			expectedHATopology:   configv1.HighlyAvailableTopologyMode,
+			expectedEvents:       1,
+			wantErr:              false,
+			expectedReplicaCount: 3,
 		},
 		{
 			name: "test ensureEtcdGuard - deployment exists and pdb was changed",
 			fields: fields{
-				client:   fakecore.NewSimpleClientset(deployment, changedPDB, &clusterConfigFullHA),
-				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 2, wantErr: false, expectedReplicaCount: 3,
+				client:           fakecore.NewSimpleClientset(deployment, changedPDB),
+				infraObj:         haInfra,
+				clusterConfigObj: clusterConfigFullHA,
+			},
+			expectedHATopology:   configv1.HighlyAvailableTopologyMode,
+			expectedEvents:       2,
+			wantErr:              false,
+			expectedReplicaCount: 3,
 		},
 		{
 			name: "test ensureEtcdGuard - deployment and pdb were changed",
 			fields: fields{
-				client:   fakecore.NewSimpleClientset(changedDeployment, changedPDB, &clusterConfigFullHA),
-				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 2, wantErr: false, expectedReplicaCount: 3,
+				client:           fakecore.NewSimpleClientset(changedDeployment, changedPDB),
+				infraObj:         haInfra,
+				clusterConfigObj: clusterConfigFullHA,
+			},
+			expectedHATopology:   configv1.HighlyAvailableTopologyMode,
+			expectedEvents:       2,
+			wantErr:              false,
+			expectedReplicaCount: 3,
 		},
 		{
 			name: "test ensureEtcdGuard - non HA mode",
 			fields: fields{
 				client: fakecore.NewSimpleClientset(),
-				infraObj: &configv1.Infrastructure{
+				infraObj: configv1.Infrastructure{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: infrastructureClusterName,
@@ -114,68 +146,94 @@ controlPlane:
 					Status: configv1.InfrastructureStatus{
 						ControlPlaneTopology: configv1.SingleReplicaTopologyMode},
 				}},
-			expectedHATopology: configv1.SingleReplicaTopologyMode, expectedEvents: 0, wantErr: false, expectedReplicaCount: 0,
+			expectedHATopology:   configv1.SingleReplicaTopologyMode,
+			expectedEvents:       0,
+			wantErr:              false,
+			expectedReplicaCount: 0,
 		},
 		{
 			name: "test ensureEtcdGuard - HA mode not set, nothing exists",
 			fields: fields{
-				client: fakecore.NewSimpleClientset(&clusterConfigFullHA),
-				infraObj: &configv1.Infrastructure{
+				client: fakecore.NewSimpleClientset(),
+				infraObj: configv1.Infrastructure{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: infrastructureClusterName,
 					},
 					Status: configv1.InfrastructureStatus{}}},
-			expectedHATopology: "", expectedEvents: 0, wantErr: true, expectedReplicaCount: 0,
+			expectedHATopology:   "",
+			expectedEvents:       0,
+			wantErr:              true,
+			expectedReplicaCount: 0,
 		},
 		{
 			name: "test ensureEtcdGuard - 5 replicas and nothing exists",
 			fields: fields{
-				client: fakecore.NewSimpleClientset(&corev1.ConfigMap{TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      clusterConfigName,
-						Namespace: clusterConfigNamespace,
-					}, Data: map[string]string{clusterConfigKey: `apiVersion: v1
-controlPlane:
- hyperthreading: Enabled
- name: master
- replicas: 5`}}),
-				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 2, wantErr: false, expectedReplicaCount: 5,
-		},
-		{
-			name: "test ensureEtcdGuard - get clusterConfig not exists",
-			fields: fields{
 				client:   fakecore.NewSimpleClientset(),
-				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 0, wantErr: true,
-		},
-		{
-			name: "test ensureEtcdGuard - get replicas count key not found",
-			fields: fields{
-				client: fakecore.NewSimpleClientset(&corev1.ConfigMap{TypeMeta: metav1.TypeMeta{},
+				infraObj: haInfra,
+				clusterConfigObj: corev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      clusterConfigName,
 						Namespace: operatorclient.TargetNamespace,
 					}, Data: map[string]string{clusterConfigKey: `apiVersion: v1
 controlPlane:
  hyperthreading: Enabled
- name: master`}}),
-				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 0, wantErr: true,
+ name: master
+ replicas: 5`}},
+			},
+			expectedHATopology:   configv1.HighlyAvailableTopologyMode,
+			expectedEvents:       2,
+			wantErr:              false,
+			expectedReplicaCount: 5,
+		},
+		{
+			name: "test ensureEtcdGuard - get clusterConfig not exists",
+			fields: fields{
+				client:   fakecore.NewSimpleClientset(),
+				infraObj: haInfra,
+			},
+			expectedHATopology: configv1.HighlyAvailableTopologyMode,
+			expectedEvents:     0,
+			wantErr:            true,
+		},
+		{
+			name: "test ensureEtcdGuard - get replicas count key not found",
+			fields: fields{
+				client:   fakecore.NewSimpleClientset(),
+				infraObj: haInfra,
+				clusterConfigObj: corev1.ConfigMap{TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      clusterConfigName,
+						Namespace: operatorclient.TargetNamespace,
+					}, Data: map[string]string{clusterConfigKey: `apiVersion: v1
+controlPlane:
+ hyperthreading: Enabled
+ name: master`}},
+			},
+			expectedHATopology: configv1.HighlyAvailableTopologyMode,
+			expectedEvents:     0,
+			wantErr:            true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := events.NewInMemoryRecorder("test")
 
-			if err := fakeInfraIndexer.Add(tt.fields.infraObj); err != nil {
+			fakeInfraIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			if err := fakeInfraIndexer.Add(&tt.fields.infraObj); err != nil {
+				t.Fatal(err)
+			}
+
+			fakeConfigMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			if err := fakeConfigMapIndexer.Add(&tt.fields.clusterConfigObj); err != nil {
 				t.Fatal(err)
 			}
 
 			c := &QuorumGuardController{
 				kubeClient:           tt.fields.client,
 				infrastructureLister: configv1listers.NewInfrastructureLister(fakeInfraIndexer),
+				configMapLister:      corev1listers.NewConfigMapLister(fakeConfigMapIndexer),
 			}
 			err := c.ensureEtcdGuard(context.TODO(), recorder)
 			if (err != nil) != tt.wantErr {

--- a/pkg/operator/quorumguardcontroller/quorumguardcontroller_test.go
+++ b/pkg/operator/quorumguardcontroller/quorumguardcontroller_test.go
@@ -156,7 +156,7 @@ controlPlane:
 				client: fakecore.NewSimpleClientset(&corev1.ConfigMap{TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      clusterConfigName,
-						Namespace: clusterConfigNamespace,
+						Namespace: operatorclient.TargetNamespace,
 					}, Data: map[string]string{clusterConfigKey: `apiVersion: v1
 controlPlane:
  hyperthreading: Enabled

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -76,6 +76,12 @@ func NewResourceSyncController(
 	); err != nil {
 		return nil, err
 	}
+	if err := resourceSyncController.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "cluster-config-v1"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.KubeSystemNamespace, Name: "cluster-config-v1"},
+	); err != nil {
+		return nil, err
+	}
 
 	return resourceSyncController, nil
 }


### PR DESCRIPTION
This PR enables max learners to equal the desired control-plane replicas. For example, a typical HA IPI cluster would have max learners 3 while SNO would allow max learners 1 (default). Additionally, the kube-system/cluster-config-v1 configmap is now synced to openshift-etcd namespace. This simplifies access to the resource and allows the use of a single namespace informer.