### PR TITLE
pkg/operator/quorumguardcontroller: set pod affinity for topology mode HA only

### DIFF
--- a/bindata/etcd/quorumguard-deployment.yaml
+++ b/bindata/etcd/quorumguard-deployment.yaml
@@ -20,16 +20,7 @@ spec:
         k8s-app: etcd-quorum-guard
     spec:
       hostNetwork: true
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: k8s-app
-                    operator: In
-                    values:
-                      - "etcd"
-              topologyKey: kubernetes.io/hostname
+      affinity: # podAffinity is managed/defined by quorum-guard controller
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -962,16 +962,7 @@ spec:
         k8s-app: etcd-quorum-guard
     spec:
       hostNetwork: true
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: k8s-app
-                    operator: In
-                    values:
-                      - "etcd"
-              topologyKey: kubernetes.io/hostname
+      affinity: # podAffinity is managed/defined by quorum-guard controller
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/pkg/operator/quorumguardcontroller/quorumguardcontroller_test.go
+++ b/pkg/operator/quorumguardcontroller/quorumguardcontroller_test.go
@@ -64,14 +64,14 @@ controlPlane:
 			fields: fields{
 				client:   fakecore.NewSimpleClientset(deployment, &clusterConfigFullHA),
 				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 1, wantErr: false, expectedReplicaCount: 3,
+			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 2, wantErr: false, expectedReplicaCount: 3,
 		},
 		{
 			name: "test ensureEtcdGuard - deployment and pdb exists",
 			fields: fields{
 				client:   fakecore.NewSimpleClientset(deployment, pdb, &clusterConfigFullHA),
 				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 0, wantErr: false, expectedReplicaCount: 3,
+			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 1, wantErr: false, expectedReplicaCount: 3,
 		},
 		{
 			name: "test ensureEtcdGuard - deployment not exists but pdb exists",
@@ -93,7 +93,7 @@ controlPlane:
 			fields: fields{
 				client:   fakecore.NewSimpleClientset(deployment, changedPDB, &clusterConfigFullHA),
 				infraObj: haInfra},
-			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 1, wantErr: false, expectedReplicaCount: 3,
+			expectedHATopology: configv1.HighlyAvailableTopologyMode, expectedEvents: 2, wantErr: false, expectedReplicaCount: 3,
 		},
 		{
 			name: "test ensureEtcdGuard - deployment and pdb were changed",


### PR DESCRIPTION
#706 introduced a change that affects SNO install workflow, the pod affinity is expected to assist cluster-etcd-operator during vertical scaling which precludes HA topology. This PR gates pod affinity for quorum-guard to HA mode explicitly.

