### PR TITLE
pkg/cmd/monitor: handle error on failed monitor

### DIFF
--- a/pkg/cmd/monitor/monitor.go
+++ b/pkg/cmd/monitor/monitor.go
@@ -170,6 +170,11 @@ func (o *monitorOpts) Run(ctx context.Context) error {
 			// health.WithNodeICMP(),
 		),
 	)
+	if err != nil {
+		errMsg := "failed to create new health monitor"
+		lg.Error(errMsg, zap.Error(err))
+		return fmt.Errorf("%s: %v", errMsg, err)
+	}
 
 	lg.Info("health monitor is starting",
 		zap.String("pod", o.podName),


### PR DESCRIPTION
If the etcd client fails or `newMonitor` for any other reason has an error it is not handled at all which can result in panic. This PR resolves the error handling and adds a test case.