### PR TITLE
pkg/operator/defragcontroller: ensure defrag controller is disabled for non HA tolopogy

### DIFF
--- a/pkg/operator/defragcontroller/defragcontroller_test.go
+++ b/pkg/operator/defragcontroller/defragcontroller_test.go
@@ -123,7 +123,7 @@ func TestNewDefragController(t *testing.T) {
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			integration.BeforeTest(t)
+			integration.BeforeTestExternal(t)
 			// use integration etcd to create etcd members and status
 			testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: scenario.clusterSize})
 			defer testServer.Terminate(t)


### PR DESCRIPTION
Due to an unfortunate series of events we have missed the fact that defrag is not properly disabled for non HA clusters. Because integration tests were using `BeforeTest` vs `BeforeTestExternal` it actually skipped the test... This PR resolves the test failure as well as properly gates the controller against non HA usage...

```
=== RUN   TestNewDefragController
--- PASS: TestNewDefragController (0.26s)
=== RUN   TestNewDefragController/defrag_success
    leak.go:102: Found leaked goroutined BEFORE test appears to have leaked :
        k8s.io/klog/v2.(*loggingT).flushDaemon(0x0)
        	/home/remote/sbatsche/projects/openshift/cluster-etcd-operator/vendor/k8s.io/klog/v2/klog.go:1169 +0x6a
        created by k8s.io/klog/v2.init.0
        	/home/remote/sbatsche/projects/openshift/cluster-etcd-operator/vendor/k8s.io/klog/v2/klog.go:420 +0xfb
    --- SKIP: TestNewDefragController/defrag_success (0.05s)
    ```