### PR TITLE
[release-4.9] pkg/operator/resourcesynccontroller: sync cluster-config-v1 to openshift-etcd

### DIFF
--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -5,4 +5,5 @@ const (
 	GlobalMachineSpecifiedConfigNamespace = "openshift-config-managed"
 	OperatorNamespace                     = "openshift-etcd-operator"
 	TargetNamespace                       = "openshift-etcd"
+	KubeSystemNamespace                   = "kube-system"
 )

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -76,6 +76,12 @@ func NewResourceSyncController(
 	); err != nil {
 		return nil, err
 	}
+	if err := resourceSyncController.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "cluster-config-v1"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.KubeSystemNamespace, Name: "cluster-config-v1"},
+	); err != nil {
+		return nil, err
+	}
 
 	return resourceSyncController, nil
 }


### PR DESCRIPTION
#708 added resource sync of kube-system cluster-config-v1 configmap. This PR brings that resource back to 4.9. Although the resource is not directly used in 4.9 is will make upgrades smoother into 4.10 as the operator will not have to wait for it to be created.

/hold for #708 
Signed-off-by: Sam Batschelet <sbatsche@redhat.com>