### PR TITLE
operator: remove etcd-endpoints from revisioned configmaps

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -306,7 +306,6 @@ var RevisionConfigMaps = []revision.RevisionResource{
 	{Name: "etcd-peer-client-ca"},
 	{Name: "etcd-metrics-proxy-serving-ca"},
 	{Name: "etcd-metrics-proxy-client-ca"},
-	{Name: "etcd-endpoints"},
 }
 
 // RevisionSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.


### PR DESCRIPTION
While this had the best of intentions the inevitable result is creating 2 revisions for each change to the resource as we also must update the pod.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>