### PR TITLE
Bug 2039344: Do not include ipv6 node address in cert

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -80,6 +80,24 @@ func TestCheckCertValidity(t *testing.T) {
 			lessThanMinDuration: true,
 			expectedRegenMsg:    true,
 		},
+		"dual-stack": {
+			certIPAddresses:  ipAddresses,
+			nodeIPAddresses:  append(ipAddresses, "2345:0425:2CA1:0000:0000:0567:5673:23b5"),
+			storedNodeUID:    nodeUID,
+			expectedRegenMsg: false,
+		},
+		"single stack ipv6 invalid": {
+			certIPAddresses: ipAddresses,
+			nodeIPAddresses: []string{"2345:0425:2CA1:0000:0000:0567:5673:23b5"},
+			storedNodeUID:   nodeUID,
+			expectedErr:     true,
+		},
+		"single stack ipv6 valid": {
+			certIPAddresses: []string{"2345:0425:2CA1:0000:0000:0567:5673:23b5"},
+			nodeIPAddresses: []string{"2345:0425:2CA1:0000:0000:0567:5673:23b5"},
+			storedNodeUID:   nodeUID,
+			expectedErr:     false,
+		},
 		"valid": {
 			certIPAddresses: ipAddresses,
 			nodeIPAddresses: ipAddresses,


### PR DESCRIPTION
If dual-stack is enabled in cluster, this will cause the etcd not go
degraded, but instead the IPv6 address of Node will be skipped in the
check.