### PR TITLE
envvar: detect empty etcd endpoints slice

### DIFF
--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -321,6 +321,9 @@ func getEtcdEndpoints(configmapLister corev1listers.ConfigMapLister, skipBootstr
 		}
 		etcdURLs = append(etcdURLs, fmt.Sprintf("https://%s:2379", ip))
 	}
+	if len(etcdURLs) == 0 {
+		return "", fmt.Errorf("no etcd endpoints found in %s/%s configmap", operatorclient.TargetNamespace, etcdEndpointName)
+	}
 	sort.Strings(etcdURLs)
 
 	return strings.Join(etcdURLs, ","), nil


### PR DESCRIPTION
Running etcd member with empty `ETCDCTL_ENDPOINTS` env var results in:

```
Err: connection error: desc = "transport: Error while dialing dial tcp: missing address"
```

and eventually, the init container panics and etcd member pod go into crash loop.

If we can detect the empty endpoints, either because configmap it uses is broken or other reason, we should prevent creating etcd member pods that are guaranteed to fail to run. 