### PR TITLE
an e2e test for checking scaling up and down by one master node

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// TODO: Remove this once scale down is implemented
+	// TODO: Remove this function once the scaling tests are moved to their own job
 	reorderTestExecutionOrder(m)
 	os.Exit(m.Run())
 }
@@ -17,8 +17,6 @@ func TestMain(m *testing.M) {
 // reorderTestExecutionOrder a hack to place the vertical scaling test at the end of execution chain
 // Some test like TestEtcdQuorumGuard assume exactly 3 master cluster. Since the scaling test add new machine(s) and
 // we don't have a function to scale them down we need to run the new test after existing ones.
-//
-// This function should be removed once scaling down is implemented
 func reorderTestExecutionOrder(m *testing.M) {
 	pointerVal := reflect.ValueOf(m)
 	val := reflect.Indirect(pointerVal)
@@ -29,6 +27,6 @@ func reorderTestExecutionOrder(m *testing.M) {
 	tests := *realPtrToTests
 
 	sort.Slice(tests, func(i, j int) bool {
-		return tests[i].Name != "TestScalingUpSingleNode"
+		return tests[i].Name != "TestScalingUpAndDownSingleNode"
 	})
 }


### PR DESCRIPTION
builds on https://github.com/openshift/cluster-etcd-operator/pull/732, requires https://github.com/openshift/cluster-etcd-operator/pull/737, promotes the previous test to `TestScalingUpAndDownSingleNode` which tests basic vertical scaling scenario.

This scenario starts by adding a new master machine to the cluster, next it validates the size of etcd cluster and makes sure the new member is healthy.
The test ends by removing the newly added machine and validating the size of the cluster and asserting the member was removed from the etcd cluster by contacting MemberList API.

a sample output from the test:
```
    vertical_scaling_test.go:148: checking if there are any excessive machines in the cluster (created by a previous test), expected cluster size is 3, found 3 machines
    vertical_scaling_test.go:174: Waiting up to 5m0s for the cluster to reach the expected member count of 3
    vertical_scaling_test.go:201: cluster have reached the expected number of 3 members, the members are: [ip-10-0-146-123.ec2.internal ip-10-0-129-236.ec2.internal ip-10-0-165-196.ec2.internal]
    vertical_scaling_test.go:93: Created a new master machine/node "polfrikdzdjw-qllkn-master-0-clone"
    vertical_scaling_test.go:100: Waiting up to 5m0s for "polfrikdzdjw-qllkn-master-0-clone" machine to be in the Running state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Provisioning" state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Provisioning" state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Provisioned" state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Provisioned" state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Provisioned" state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Provisioned" state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Provisioned" state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Provisioned" state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Provisioned" state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Provisioned" state
    vertical_scaling_test.go:108: "polfrikdzdjw-qllkn-master-0-clone" machine is in "Running" state
    vertical_scaling_test.go:174: Waiting up to 5m0s for the cluster to reach the expected member count of 4
    vertical_scaling_test.go:197: unexpected number of etcd members, expected exactly 4, got: 3, current members are: [ip-10-0-146-123.ec2.internal ip-10-0-129-236.ec2.internal ip-10-0-165-196.ec2.internal]
    vertical_scaling_test.go:197: unexpected number of etcd members, expected exactly 4, got: 3, current members are: [ip-10-0-146-123.ec2.internal ip-10-0-129-236.ec2.internal ip-10-0-165-196.ec2.internal]
    vertical_scaling_test.go:197: unexpected number of etcd members, expected exactly 4, got: 3, current members are: [ip-10-0-146-123.ec2.internal ip-10-0-129-236.ec2.internal ip-10-0-165-196.ec2.internal]
    vertical_scaling_test.go:201: cluster have reached the expected number of 4 members, the members are: [ip-10-0-146-123.ec2.internal ip-10-0-129-236.ec2.internal ip-10-0-133-115.ec2.internal ip-10-0-165-196.ec2.internal]
    vertical_scaling_test.go:241: successfully evaluated health condition of "ip-10-0-133-115.ec2.internal" member
    vertical_scaling_test.go:62: successfully removed (scheduled removal) the machine "polfrikdzdjw-qllkn-master-0-clone" from the cluster
    vertical_scaling_test.go:174: Waiting up to 5m0s for the cluster to reach the expected member count of 3
{"level":"warn","ts":"2022-02-04T11:58:00.305+0100","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0004fbc00/#initially=[https://127.0.0.1:62803]","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = latest balancer error: last connection error: connection error: desc = \"transport: authentication handshake failed: EOF\""}
    vertical_scaling_test.go:188: failed to get the member list, will retry, err: context deadline exceeded
    vertical_scaling_test.go:179: failed to get etcd client, will retry, err: failed to scan port forward std out
    vertical_scaling_test.go:179: failed to get etcd client, will retry, err: failed to scan port forward std out
    vertical_scaling_test.go:179: failed to get etcd client, will retry, err: failed to scan port forward std out
    vertical_scaling_test.go:179: failed to get etcd client, will retry, err: failed to scan port forward std out
    vertical_scaling_test.go:179: failed to get etcd client, will retry, err: failed to scan port forward std out
    vertical_scaling_test.go:179: failed to get etcd client, will retry, err: failed to scan port forward std out
    vertical_scaling_test.go:179: failed to get etcd client, will retry, err: failed to scan port forward std out
    vertical_scaling_test.go:378: failed on waiting for the cluster to reach the expected member count of 3, err timed out waiting for the condition, retrying after 40 seconds, round: 1
    vertical_scaling_test.go:174: Waiting up to 5m0s for the cluster to reach the expected member count of 3
    vertical_scaling_test.go:201: cluster have reached the expected number of 3 members, the members are: [ip-10-0-146-123.ec2.internal ip-10-0-129-236.ec2.internal ip-10-0-165-196.ec2.internal]
```