### PR TITLE
changes the signature of the MemberRemove method to accept a memberID (uint64) not a Name (string)

### DIFF
--- a/pkg/etcdcli/helpers.go
+++ b/pkg/etcdcli/helpers.go
@@ -43,7 +43,7 @@ func (f *fakeEtcdClient) MemberList(ctx context.Context) ([]*etcdserverpb.Member
 	return f.members, nil
 }
 
-func (f *fakeEtcdClient) MemberRemove(ctx context.Context, member string) error {
+func (f *fakeEtcdClient) MemberRemove(ctx context.Context, memberID uint64) error {
 	panic("implement me")
 }
 func (f *fakeEtcdClient) MemberHealth(ctx context.Context) (memberHealth, error) {

--- a/pkg/etcdcli/interfaces.go
+++ b/pkg/etcdcli/interfaces.go
@@ -49,7 +49,7 @@ type IsMemberHealthy interface {
 	IsMemberHealthy(ctx context.Context, member *etcdserverpb.Member) (bool, error)
 }
 type MemberRemover interface {
-	MemberRemove(ctx context.Context, member string) error
+	MemberRemove(ctx context.Context, memberID uint64) error
 }
 
 type MemberLister interface {


### PR DESCRIPTION
previously the method required contacting with the etcd cluster to get the current list of members just to find an ID of the member that matches the given name.

however, all current callers (i.e. the bootstrapteardown, member removal controllers) of this method already have an ID of the member they want to remove.

in addition to that, it is easier to deal with an ID instead of a Name because the latter might be sometimes empty (i.e. member hasn't been started) which leads to awkward error handling in the operator.