### PR TITLE
Bug 2052270: pkg/operator/metriccontroller/fsync_controller: Fix "treshold" -> "thresholds" typos

### DIFF
--- a/pkg/operator/metriccontroller/fsync_controller.go
+++ b/pkg/operator/metriccontroller/fsync_controller.go
@@ -124,13 +124,13 @@ func (c *FSyncController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    "FSyncControllerDegraded",
 			Status:  operatorv1.ConditionTrue,
-			Reason:  "etcd disk metrics exceeded known tresholds",
-			Message: fmt.Sprintf("etcd disk metrics exceeded known tresholds: %s", degradedMsg),
+			Reason:  "etcd disk metrics exceeded known thresholds",
+			Message: fmt.Sprintf("etcd disk metrics exceeded known thresholds: %s", degradedMsg),
 		}))
 		if updateErr != nil {
 			syncCtx.Recorder().Warning("FSyncControllerErrorUpdatingStatus", updateErr.Error())
 		}
-		return fmt.Errorf("etcd disk metrics exceeded known tresholds")
+		return fmt.Errorf("etcd disk metrics exceeded known thresholds")
 	}
 
 	return nil


### PR DESCRIPTION
These slipped in when the threshold guard landed in 0d4883ed77 (#687).