### PR TITLE
Bug 2057644: Fix FSyncController degraded latch

### DIFF
--- a/pkg/operator/metriccontroller/fsync_controller.go
+++ b/pkg/operator/metriccontroller/fsync_controller.go
@@ -67,7 +67,13 @@ func (c *FSyncController) sync(ctx context.Context, syncCtx factory.SyncContext)
 	leaderChanges := vector[0].Value
 	// Do nothing if there are no significant leader changes.
 	if leaderChanges < 2.0 {
-		return nil
+		_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient,
+			v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+				Type:   "FSyncControllerDegraded",
+				Status: operatorv1.ConditionFalse,
+				Reason: "AsExpected",
+			}))
+		return updateErr
 	}
 
 	klog.V(4).Infof("Etcd leader changes increase in last 5m: %s", leaderChanges)
@@ -133,5 +139,12 @@ func (c *FSyncController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		return fmt.Errorf("etcd disk metrics exceeded known tresholds")
 	}
 
-	return nil
+	_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient,
+		v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+			Type:   "FSyncControllerDegraded",
+			Status: operatorv1.ConditionFalse,
+			Reason: "AsExpected",
+		}))
+
+	return updateErr
 }


### PR DESCRIPTION
When there's a spike in leader elections and disk metrics, etcd can go degraded and never leave it even if the spike recedes and the cluster is ok.

https://bugzilla.redhat.com/show_bug.cgi?id=2057644