### PR TITLE
Bug 2053596: Increase IBMCloud VPC heartbeat timeout to 500ms and leader election timeout to 2500ms

### DIFF
--- a/pkg/cmd/render/env.go
+++ b/pkg/cmd/render/env.go
@@ -71,7 +71,7 @@ func getHeartbeatInterval(e *envVarData) (map[string]string, error) {
 	case configv1.IBMCloudPlatformType:
 		switch configv1.IBMCloudProviderType(e.platformData) {
 		case configv1.IBMCloudProviderTypeVPC:
-			heartbeat = "2000"
+			heartbeat = "500"
 		}
 	}
 
@@ -89,7 +89,7 @@ func getElectionTimeout(e *envVarData) (map[string]string, error) {
 	case configv1.IBMCloudPlatformType:
 		switch configv1.IBMCloudProviderType(e.platformData) {
 		case configv1.IBMCloudProviderTypeVPC:
-			timeout = "10000"
+			timeout = "2500"
 		}
 	}
 

--- a/pkg/cmd/render/env.go
+++ b/pkg/cmd/render/env.go
@@ -89,7 +89,7 @@ func getElectionTimeout(e *envVarData) (map[string]string, error) {
 	case configv1.IBMCloudPlatformType:
 		switch configv1.IBMCloudProviderType(e.platformData) {
 		case configv1.IBMCloudProviderTypeVPC:
-			timeout = "4000"
+			timeout = "10000"
 		}
 	}
 

--- a/pkg/cmd/render/env.go
+++ b/pkg/cmd/render/env.go
@@ -63,13 +63,16 @@ func getEtcdName(_ *envVarData) (map[string]string, error) {
 }
 
 func getHeartbeatInterval(e *envVarData) (map[string]string, error) {
-	var heartbeat string
+	heartbeat := "100"
 
 	switch configv1.PlatformType(e.platform) {
 	case configv1.AzurePlatformType:
 		heartbeat = "500"
-	default:
-		heartbeat = "100"
+	case configv1.IBMCloudPlatformType:
+		switch configv1.IBMCloudProviderType(e.platformData) {
+		case configv1.IBMCloudProviderTypeVPC:
+			heartbeat = "2000"
+		}
 	}
 
 	return map[string]string{
@@ -86,7 +89,7 @@ func getElectionTimeout(e *envVarData) (map[string]string, error) {
 	case configv1.IBMCloudPlatformType:
 		switch configv1.IBMCloudProviderType(e.platformData) {
 		case configv1.IBMCloudProviderTypeVPC:
-			timeout = "2000"
+			timeout = "4000"
 		}
 	}
 

--- a/pkg/cmd/render/env_test.go
+++ b/pkg/cmd/render/env_test.go
@@ -113,7 +113,7 @@ func TestEtcdEnv(t *testing.T) {
 			arch:          "amd64",
 			wantKey:       "ETCD_ELECTION_TIMEOUT",
 			installConfig: installConfigHA,
-			wantValue:     "2000",
+			wantValue:     "2500",
 		},
 		{
 			name:          "IBMCloud non-VPC etcd election timeout",
@@ -123,6 +123,24 @@ func TestEtcdEnv(t *testing.T) {
 			wantKey:       "ETCD_ELECTION_TIMEOUT",
 			installConfig: installConfigHA,
 			wantValue:     "1000",
+		},
+		{
+			name:          "IBMCloud VPC heartbeat interval",
+			platform:      "IBMCloud",
+			platformData:  "VPC",
+			arch:          "amd64",
+			wantKey:       "ETCD_HEARTBEAT_INTERVAL",
+			installConfig: installConfigHA,
+			wantValue:     "500",
+		},
+		{
+			name:          "IBMCloud non-VPC heartbeat interval",
+			platform:      "IBMCloud",
+			platformData:  "Classic",
+			arch:          "amd64",
+			wantKey:       "ETCD_HEARTBEAT_INTERVAL",
+			installConfig: installConfigHA,
+			wantValue:     "100",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
+	v1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -202,6 +203,10 @@ func getHeartbeatInterval(envVarContext envVarContext) (map[string]string, error
 		switch {
 		case status.Azure != nil:
 			heartbeat = "500"
+		case status.IBMCloud != nil:
+			if infrastructure.Status.PlatformStatus.IBMCloud.ProviderType == v1.IBMCloudProviderTypeVPC {
+				heartbeat = "500"
+			}
 		}
 	}
 
@@ -222,6 +227,10 @@ func getElectionTimeout(envVarContext envVarContext) (map[string]string, error) 
 		switch {
 		case status.Azure != nil:
 			timeout = "2500"
+		case status.IBMCloud != nil:
+			if infrastructure.Status.PlatformStatus.IBMCloud.ProviderType == v1.IBMCloudProviderTypeVPC {
+				timeout = "2500"
+			}
 		}
 	}
 


### PR DESCRIPTION
Work in progress fix for: https://bugzilla.redhat.com/show_bug.cgi?id=2055833