### PR TITLE
Bug 2027744: Change PodDisruptionBudget policy to minavailable

### DIFF
--- a/pkg/operator/quorumguardcontroller/quorumguardcontroller.go
+++ b/pkg/operator/quorumguardcontroller/quorumguardcontroller.go
@@ -50,8 +50,8 @@ var pdb = &policyv1.PodDisruptionBudget{
 		Namespace: operatorclient.TargetNamespace,
 	},
 	Spec: policyv1.PodDisruptionBudgetSpec{
-		MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: int32(1)},
-		Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": EtcdGuardDeploymentName}},
+		MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: int32(2)},
+		Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": EtcdGuardDeploymentName}},
 	},
 }
 


### PR DESCRIPTION
Change PodDistruptionBudget policy to MinAvailable instead of MaxUnavailable.

The quorum guard purpose is to keep minimum of two etcd pods running to guarantee quorum in the cluster. 

The assumption is that usually there are 3 master nodes, and therefore we can not allow more than one node down. If the cluster master was more than this, the condition still applies unnecessarily. 

Changing the policy to MinAvailable of two has the same expected result

fixes BZ [2027744](https://bugzilla.redhat.com/show_bug.cgi?id=2027744)