### PR TITLE
Bug 2071114: manifests/0000_90_etcd-operator_03_prometheusrule: Add etcdDivergentRevisions

### DIFF
--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -184,3 +184,26 @@ spec:
       for: 3m
       labels:
         severity: critical
+    - alert: etcdDivergentRevisions
+      annotations:
+        description: etcd is reporting divergent member revisions, with a pod
+          {{ $labels.pod }} on instance {{ $labels.instance }} trailing
+          {{ $value }} compacted revisions behind pod {{ $labels.max_pod }} on
+          instance {{ $labels.max_instance }}. Members may be stuck or, in
+          extreme circumstances, split brained.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdDivergentRevisions.md
+        summary: etcd is reporting divergent member revisions.
+      expr: |
+        -etcd_debugging_mvcc_compact_revision{job=~".*etcd.*"}
+          + on (job, namespace) group_left (max_instance, max_pod)
+        label_replace(
+          label_replace(
+            topk by (job,namespace) (1, etcd_debugging_mvcc_compact_revision{job=~".*etcd.*"}),
+            "max_instance", "$1", "instance", "(.*)"
+          ),
+          "max_pod", "$1", "pod", "(.*)"
+        )
+          > 0
+      for: 10m
+      labels:
+        severity: critical


### PR DESCRIPTION
Proximal trigger is the etcd 3.5.(<=2) split-brain issue ([upstream announcement][1], etcd-io/etcd#13766, [rhbz#2068601][3]). 
  But having this alert in place to look out for future issues seems useful, even once that gets fixed.  This alert supports 139ca20fc0 (#770), but:

* The initial corruption check keeps the corrupted member from coming up, preventing split-braining.  The alert just lets you know if something bad is happening; it doesn't block anything.
* The current initial corruption [check seems to ignore large divergence][4].  This alert will complain about any divergence, regardless of size.
* Adding a new alert PrometheusRule to existing clusters is an easier mitigating patch than adjusting the etcd-launching configuration.

[1]: https://etcd.io/docs/v3.5/op-guide/data_corruption/
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=2068601
[4]: https://github.com/etcd-io/etcd/issues/13766#issuecomment-1083033017