### PR TITLE
no pending on etcdHighNumberOfLeaderChanges 1st 1h

### DIFF
--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -163,7 +163,11 @@ spec:
           should be investigated.'
         summary: etcd cluster has high number of leader changes.
       expr: |
-        increase((max without (instance) (etcd_server_leader_changes_seen_total{job=~".*etcd.*"}) or 0*absent(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}))[15m:1m]) >= 5
+         (increase((max without (instance) (etcd_server_leader_changes_seen_total{job=~".*etcd.*"})
+         or
+           0*absent(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}))[15m:1m]) >= 5)
+         and
+           on () time() - cluster_version{type="initial"} > 3600
       for: 5m
       labels:
         severity: warning


### PR DESCRIPTION
during initial cluster roll-out there is enough churn that etcd
leadership will change and these alerts would result. This can
result of normal cluster installation and the alerts could cause
false concern of some problem.

this is happening more frquently in CI with OVN as the CNI,
especially in the GCP cloud (for whatever reason) and results
in extra failures in CI.

This should wait for an hour after "cluster_version" goes
initial and should provide enough time before the alert would
be much more meaningful if it came.

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>