### PR TITLE
Bug 2074544 : Fix ipv6 regression in clustermembercontroller

### DIFF
--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -3,6 +3,7 @@ package clustermembercontroller
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -111,7 +112,7 @@ func (c *ClusterMemberController) reconcileMembers(ctx context.Context, recorder
 	}
 
 	recorder.Eventf("FoundPodToScale", "found pod to add to etcd membership: %v", podToAdd.Name)
-	err = c.etcdClient.MemberAdd(ctx, fmt.Sprintf("https://%s:2380", etcdHost))
+	err = c.etcdClient.MemberAdd(ctx, fmt.Sprintf("https://%s", net.JoinHostPort(etcdHost, "2380")))
 	if err != nil {
 		return fmt.Errorf("could not add member :%w", err)
 	}
@@ -200,5 +201,6 @@ func (c *ClusterMemberController) getEtcdPeerHostToScale(podToAdd *corev1.Pod) (
 		return "", err
 	}
 
-	return dnshelpers.GetEscapedPreferredInternalIPAddressForNodeName(network, node)
+	ip, _, err := dnshelpers.GetPreferredInternalIPAddressForNodeName(network, node)
+	return ip, err
 }

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -261,7 +261,7 @@ func (c *clusterMemberRemovalController) getNodeForMember(memberInternalIP strin
 	}
 
 	for _, masterNode := range masterNodes {
-		internalNodeIP, err := dnshelpers.GetEscapedPreferredInternalIPAddressForNodeName(network, masterNode)
+		internalNodeIP, _, err := dnshelpers.GetPreferredInternalIPAddressForNodeName(network, masterNode)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get internal IP for node: %w", err)
 		}

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
@@ -173,15 +173,37 @@ func TestClusterMemberRemovalController(t *testing.T) {
 		initialObjectsForMachineLister   []runtime.Object
 		initialEtcdMemberList            []*etcdserverpb.Member
 		validateFn                       func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient)
+		serviceNetwork                   string
 	}{
 		// scenario 1
 		{
 			name:                             "happy path: an etcd member has a corresponding machine and node resources",
+			serviceNetwork:                   "172.30.0.0/16",
 			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
 			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
 			initialObjectsForNodeLister:      []runtime.Object{wellKnownMasterNode()},
 			initialObjectsForMachineLister:   []runtime.Object{wellKnownMasterMachine()},
 			initialEtcdMemberList:            wellKnownEtcdMemberList(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 1 {
+					t.Errorf("expected exactly one etcd member, got %v", memberList)
+				}
+			},
+		},
+
+		// scenario 1 (ipv6)
+		{
+			name:                             "happy path (ipv6): an etcd member has a corresponding machine and node resources",
+			serviceNetwork:                   "fd02::/112",
+			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMapIpv6()},
+			initialObjectsForNodeLister:      []runtime.Object{wellKnownMasterNodeIpv6()},
+			initialObjectsForMachineLister:   []runtime.Object{wellKnownMasterMachineIpv6()},
+			initialEtcdMemberList:            wellKnownEtcdMemberListIpv6(),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {
@@ -196,6 +218,7 @@ func TestClusterMemberRemovalController(t *testing.T) {
 		// scenario 2
 		{
 			name:                             "an etcd member doesn't have a corresponding machine nor node resource and it is removed",
+			serviceNetwork:                   "172.30.0.0/16",
 			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
 			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
 			initialEtcdMemberList:            wellKnownEtcdMemberList(),
@@ -210,9 +233,28 @@ func TestClusterMemberRemovalController(t *testing.T) {
 			},
 		},
 
+		// scenario 2 (ipv6)
+		{
+			name:                             "(ipv6) an etcd member doesn't have a corresponding machine nor node resource and it is removed",
+			serviceNetwork:                   "fd02::/112",
+			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMapIpv6()},
+			initialEtcdMemberList:            wellKnownEtcdMemberListIpv6(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 0 {
+					t.Errorf("expected an empty member list, got %v", memberList)
+				}
+			},
+		},
+
 		// scenario 3
 		{
 			name:                             "an etcd member with only a corresponding machine resource is not removed",
+			serviceNetwork:                   "172.30.0.0/16",
 			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
 			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
 			initialObjectsForMachineLister:   []runtime.Object{wellKnownMasterMachine()},
@@ -228,13 +270,52 @@ func TestClusterMemberRemovalController(t *testing.T) {
 			},
 		},
 
+		// scenario 3 (ipv6)
+		{
+			name:                             "(ipv6) an etcd member with only a corresponding machine resource is not removed",
+			serviceNetwork:                   "fd02::/112",
+			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMapIpv6()},
+			initialObjectsForMachineLister:   []runtime.Object{wellKnownMasterMachineIpv6()},
+			initialEtcdMemberList:            wellKnownEtcdMemberListIpv6(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 1 {
+					t.Errorf("expected exactly one etcd member, got %v", memberList)
+				}
+			},
+		},
+
 		// scenario 4
 		{
 			name:                             "an etcd member with only a corresponding node resource is not removed",
+			serviceNetwork:                   "172.30.0.0/16",
 			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
 			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
 			initialObjectsForNodeLister:      []runtime.Object{wellKnownMasterNode()},
 			initialEtcdMemberList:            wellKnownEtcdMemberList(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 1 {
+					t.Errorf("expected exactly one etcd member, got %v", memberList)
+				}
+			},
+		},
+
+		// scenario 4 (ipv6)
+		{
+			name:                             "(ipv6) an etcd member with only a corresponding node resource is not removed",
+			serviceNetwork:                   "fd02::/112",
+			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMapIpv6()},
+			initialObjectsForNodeLister:      []runtime.Object{wellKnownMasterNodeIpv6()},
+			initialEtcdMemberList:            wellKnownEtcdMemberListIpv6(),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {
@@ -270,7 +351,7 @@ func TestClusterMemberRemovalController(t *testing.T) {
 			}
 
 			networkIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-			networkIndexer.Add(&configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Spec: configv1.NetworkSpec{ServiceNetwork: []string{"172.30.0.0/16"}}})
+			networkIndexer.Add(&configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Spec: configv1.NetworkSpec{ServiceNetwork: []string{scenario.serviceNetwork}}})
 			networkLister := configv1listers.NewNetworkLister(networkIndexer)
 
 			machineIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
@@ -320,6 +401,15 @@ func wellKnownEtcdEndpointsConfigMap() *corev1.ConfigMap {
 	}
 }
 
+func wellKnownEtcdEndpointsConfigMapIpv6() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "etcd-endpoints", Namespace: "openshift-etcd"},
+		Data: map[string]string{
+			"m-0": "fd2e:6f44:5dd8:c956::16",
+		},
+	}
+}
+
 func wellKnownEtcdMemberList() []*etcdserverpb.Member {
 	return []*etcdserverpb.Member{
 		{
@@ -340,6 +430,16 @@ func wellKnownEtcdMemberList() []*etcdserverpb.Member {
 	}
 }
 
+func wellKnownEtcdMemberListIpv6() []*etcdserverpb.Member {
+	return []*etcdserverpb.Member{
+		{
+			Name:     "m-0",
+			ID:       8,
+			PeerURLs: []string{"https://[fd2e:6f44:5dd8:c956::16]:1234"},
+		},
+	}
+}
+
 func wellKnownMasterNode() *corev1.Node {
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "m-0", Labels: map[string]string{"node-role.kubernetes.io/master": ""}},
@@ -352,6 +452,18 @@ func wellKnownMasterNode() *corev1.Node {
 	}
 }
 
+func wellKnownMasterNodeIpv6() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "m-0", Labels: map[string]string{"node-role.kubernetes.io/master": ""}},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "fd2e:6f44:5dd8:c956::16",
+			},
+		}},
+	}
+}
+
 func wellKnownMasterMachine() *machinev1beta1.Machine {
 	return &machinev1beta1.Machine{
 		ObjectMeta: metav1.ObjectMeta{Name: "m-0", Labels: map[string]string{"machine.openshift.io/cluster-api-machine-role": "master"}},
@@ -359,6 +471,18 @@ func wellKnownMasterMachine() *machinev1beta1.Machine {
 			{
 				Type:    corev1.NodeInternalIP,
 				Address: "10.0.139.78",
+			},
+		}},
+	}
+}
+
+func wellKnownMasterMachineIpv6() *machinev1beta1.Machine {
+	return &machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "m-0", Labels: map[string]string{"machine.openshift.io/cluster-api-machine-role": "master"}},
+		Status: machinev1beta1.MachineStatus{Addresses: []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "fd2e:6f44:5dd8:c956::16",
 			},
 		}},
 	}


### PR DESCRIPTION
Since #780 ipv6 deployments are broken with an error like:

ClusterMemberControllerDegraded: unable to find machine for member: [fd2e:6f44:5dd8:c956::16]

Machine/Node IPs don't include the port, therefore are unquoted, so
ceohelpers.IndexMachinesByNodeInternalIP gives a map with keys that
do not include brackets.

It seems getEtcdPeerHostToScale can return the unquoted IP which
should reolve this issue, then we can re-add the brackets for the call to `etcdClient.MemberAdd` - I added a test to verify this.