### PR TITLE
temporarily disables check for machine for the member controller as it fails on ipv6

### DIFF
--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -104,11 +104,13 @@ func (c *ClusterMemberController) reconcileMembers(ctx context.Context, recorder
 		return fmt.Errorf("could not get etcd peer host :%w", err)
 	}
 
-	if machineForHostPendingDeletion, err := c.isMachinePendingDeletionFor(etcdHost); err != nil {
-		return err
-	} else if machineForHostPendingDeletion {
-		return nil
-	}
+	// TODO (polynomial) this fails on ipv6
+	/*
+		if machineForHostPendingDeletion, err := c.isMachinePendingDeletionFor(etcdHost); err != nil {
+			return err
+		} else if machineForHostPendingDeletion {
+			return nil
+		}*/
 
 	recorder.Eventf("FoundPodToScale", "found pod to add to etcd membership: %v", podToAdd.Name)
 	err = c.etcdClient.MemberAdd(ctx, fmt.Sprintf("https://%s:2380", etcdHost))

--- a/pkg/operator/clustermembercontroller/clustermembercontroller_test.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller_test.go
@@ -2,7 +2,6 @@ package clustermembercontroller
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -316,7 +315,8 @@ func TestReconcileMembers(t *testing.T) {
 				}
 			},
 		},
-		{
+		// TODO (polynomial) this fails on ipv6
+		/*{
 			name:                     "member not added, machine pending deletion",
 			isFunctionalMachineAPIFn: alwaysTrueIsFunctionalMachineAPIFn,
 			initialObjectsForMachineLister: func() []runtime.Object {
@@ -357,7 +357,7 @@ func TestReconcileMembers(t *testing.T) {
 					t.Errorf("expected exactly 0 members, got %v", len(memberList))
 				}
 			},
-		},
+		},*/
 		{
 			name:                     "member is added, pod not ready, machine pending deletion, machine api off",
 			isFunctionalMachineAPIFn: func() (bool, error) { return false, nil },
@@ -400,44 +400,47 @@ func TestReconcileMembers(t *testing.T) {
 				}
 			},
 		},
-		{
-			name:                        "member not added, machine not found",
-			isFunctionalMachineAPIFn:    alwaysTrueIsFunctionalMachineAPIFn,
-			initialObjectsForNodeLister: []runtime.Object{wellKnownMasterNode()},
-			initialObjectsForPodLister: []runtime.Object{
-				&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "etcd-a",
-						Namespace: "openshift-etcd",
-						Labels:    labels.Set{"app": "etcd"},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "m-0",
-					},
-					Status: corev1.PodStatus{
-						Phase: "Running",
-						ContainerStatuses: []corev1.ContainerStatus{
-							{
-								Name:  "etcd",
-								Ready: false,
-								State: corev1.ContainerState{
-									Running: &corev1.ContainerStateRunning{},
+
+		// TODO (polynomial) this fails on ipv6
+		/*
+			{
+				name:                        "member not added, machine not found",
+				isFunctionalMachineAPIFn:    alwaysTrueIsFunctionalMachineAPIFn,
+				initialObjectsForNodeLister: []runtime.Object{wellKnownMasterNode()},
+				initialObjectsForPodLister: []runtime.Object{
+					&corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "etcd-a",
+							Namespace: "openshift-etcd",
+							Labels:    labels.Set{"app": "etcd"},
+						},
+						Spec: corev1.PodSpec{
+							NodeName: "m-0",
+						},
+						Status: corev1.PodStatus{
+							Phase: "Running",
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:  "etcd",
+									Ready: false,
+									State: corev1.ContainerState{
+										Running: &corev1.ContainerStateRunning{},
+									},
 								},
 							},
 						},
-					},
-				}},
-			expectedError: fmt.Errorf("unable to find machine for member: 10.0.139.78"),
-			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
-				memberList, err := fakeEtcdClient.MemberList(context.TODO())
-				if err != nil {
-					t.Fatal(err)
-				}
-				if len(memberList) != 0 {
-					t.Errorf("expected exactly 0 members, got %v", len(memberList))
-				}
-			},
-		},
+					}},
+				expectedError: fmt.Errorf("unable to find machine for member: 10.0.139.78"),
+				validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+					memberList, err := fakeEtcdClient.MemberList(context.TODO())
+					if err != nil {
+						t.Fatal(err)
+					}
+					if len(memberList) != 0 {
+						t.Errorf("expected exactly 0 members, got %v", len(memberList))
+					}
+				},
+			},*/
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {


### PR DESCRIPTION
as an alternative for https://github.com/openshift/cluster-etcd-operator/pull/786 so that we don't have to revert multiple PRs