### PR TITLE
ClusterMemberController adds members whose machines are not pending deletion

### DIFF
--- a/pkg/etcdcli/helpers.go
+++ b/pkg/etcdcli/helpers.go
@@ -36,7 +36,14 @@ func (f *fakeEtcdClient) Status(ctx context.Context, target string) (*clientv3.S
 }
 
 func (f *fakeEtcdClient) MemberAdd(ctx context.Context, peerURL string) error {
-	panic("implement me")
+	memberCount := len(f.members)
+	m := &etcdserverpb.Member{
+		Name:     fmt.Sprintf("m-%d", memberCount+1),
+		ID:       uint64(memberCount + 1),
+		PeerURLs: []string{peerURL},
+	}
+	f.members = append(f.members, m)
+	return nil
 }
 
 func (f *fakeEtcdClient) MemberList(ctx context.Context) ([]*etcdserverpb.Member, error) {

--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -12,17 +12,19 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	machinelistersv1beta1 "github.com/openshift/client-go/machine/listers/machine/v1beta1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/dnshelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 )
 
@@ -35,52 +37,46 @@ type ClusterMemberController struct {
 	podLister      corev1listers.PodLister
 	nodeLister     corev1listers.NodeLister
 	networkLister  configv1listers.NetworkLister
+	// machineAPIChecker determines if the precondition for this controller is met,
+	// this controller can be run only on a cluster that exposes a functional Machine API
+	machineAPIChecker ceohelpers.MachineAPIChecker
+
+	masterMachineLister   machinelistersv1beta1.MachineLister
+	masterMachineSelector labels.Selector
 }
 
 func NewClusterMemberController(
 	operatorClient v1helpers.OperatorClient,
+	machineAPIChecker ceohelpers.MachineAPIChecker,
 	kubeInformers v1helpers.KubeInformersForNamespaces,
 	networkInformer configv1informers.NetworkInformer,
+	masterMachineInformer cache.SharedIndexInformer,
+	masterMachineSelector labels.Selector,
 	etcdClient etcdcli.EtcdClient,
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &ClusterMemberController{
-		operatorClient: operatorClient,
-		etcdClient:     etcdClient,
-		podLister:      kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().Pods().Lister(),
-		nodeLister:     kubeInformers.InformersFor("").Core().V1().Nodes().Lister(),
-		networkLister:  networkInformer.Lister(),
+		operatorClient:        operatorClient,
+		machineAPIChecker:     machineAPIChecker,
+		etcdClient:            etcdClient,
+		podLister:             kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().Pods().Lister(),
+		nodeLister:            kubeInformers.InformersFor("").Core().V1().Nodes().Lister(),
+		networkLister:         networkInformer.Lister(),
+		masterMachineLister:   machinelistersv1beta1.NewMachineLister(masterMachineInformer.GetIndexer()),
+		masterMachineSelector: masterMachineSelector,
 	}
-	return factory.New().ResyncEvery(time.Minute).WithInformers(
-		kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().Pods().Informer(),
-		kubeInformers.InformersFor("").Core().V1().Nodes().Informer(),
-		networkInformer.Informer(),
-		operatorClient.Informer(),
-	).WithSync(c.sync).ResyncEvery(time.Minute).ToController("ClusterMemberController", eventRecorder.WithComponentSuffix("cluster-member-controller"))
+	return factory.New().ResyncEvery(time.Minute).
+		WithBareInformers(networkInformer.Informer()).
+		WithInformers(
+			kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().Pods().Informer(),
+			kubeInformers.InformersFor("").Core().V1().Nodes().Informer(),
+			operatorClient.Informer(),
+			masterMachineInformer,
+		).WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ResyncEvery(time.Minute).ToController("ClusterMemberController", eventRecorder.WithComponentSuffix("cluster-member-controller"))
 }
 
 func (c *ClusterMemberController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	err := c.reconcileMembers(ctx, syncCtx.Recorder())
-	if err != nil {
-		_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-			Type:    "ClusterMemberControllerDegraded",
-			Status:  operatorv1.ConditionTrue,
-			Reason:  "Error",
-			Message: err.Error(),
-		}))
-		if updateErr != nil {
-			syncCtx.Recorder().Warning("ClusterMemberControllerUpdatingStatus", updateErr.Error())
-		}
-		return err
-	}
-
-	_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient,
-		v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-			Type:   "ClusterMemberControllerDegraded",
-			Status: operatorv1.ConditionFalse,
-			Reason: "AsExpected",
-		}))
-	return updateErr
+	return c.reconcileMembers(ctx, syncCtx.Recorder())
 }
 
 func (c *ClusterMemberController) reconcileMembers(ctx context.Context, recorder events.Recorder) error {
@@ -101,19 +97,52 @@ func (c *ClusterMemberController) reconcileMembers(ctx context.Context, recorder
 	case podToAdd == nil:
 		// no more work left to do
 		return nil
-	default:
-		recorder.Eventf("FoundPodToScale", "found pod to add to etcd membership: %v", podToAdd.Name)
 	}
 
 	etcdHost, err := c.getEtcdPeerHostToScale(podToAdd)
 	if err != nil {
 		return fmt.Errorf("could not get etcd peer host :%w", err)
 	}
+
+	if machineForHostPendingDeletion, err := c.isMachinePendingDeletionFor(etcdHost); err != nil {
+		return err
+	} else if machineForHostPendingDeletion {
+		return nil
+	}
+
+	recorder.Eventf("FoundPodToScale", "found pod to add to etcd membership: %v", podToAdd.Name)
 	err = c.etcdClient.MemberAdd(ctx, fmt.Sprintf("https://%s:2380", etcdHost))
 	if err != nil {
 		return fmt.Errorf("could not add member :%w", err)
 	}
 	return nil
+}
+
+func (c *ClusterMemberController) isMachinePendingDeletionFor(etcdHost string) (bool, error) {
+	if isFunctional, err := c.machineAPIChecker.IsFunctional(); err != nil {
+		return false, err
+	} else if !isFunctional {
+		// always return false when the machine API is off
+		// otherwise we won't be able to add any member
+		return false, nil
+	}
+
+	masterMachines, err := c.masterMachineLister.List(c.masterMachineSelector)
+	if err != nil {
+		return false, err
+	}
+
+	// one we have functional machine API, get the corresponding machine and check DeletionTimestamp
+	switch machineForEtcdHost, hasMachine := ceohelpers.IndexMachinesByNodeInternalIP(masterMachines)[etcdHost]; {
+	case hasMachine && machineForEtcdHost.DeletionTimestamp != nil:
+		klog.V(2).Infof("member: %v has a machine that is pending deletion: %v", etcdHost, machineForEtcdHost.Name)
+		return true, nil
+	case !hasMachine:
+		return false, fmt.Errorf("unable to find machine for member: %v", etcdHost)
+	default:
+		// we've found a machine and it is not pending deletion
+		return false, nil
+	}
 }
 
 func (c *ClusterMemberController) getEtcdPodToAddToMembership(ctx context.Context) (*corev1.Pod, error) {

--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -3,6 +3,7 @@ package clustermembercontroller
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -111,7 +112,7 @@ func (c *ClusterMemberController) reconcileMembers(ctx context.Context, recorder
 	}
 
 	recorder.Eventf("FoundPodToScale", "found pod to add to etcd membership: %v", podToAdd.Name)
-	err = c.etcdClient.MemberAdd(ctx, fmt.Sprintf("https://%s:2380", etcdHost))
+	err = c.etcdClient.MemberAdd(ctx, fmt.Sprintf("https://%s", net.JoinHostPort(etcdHost, "2380")))
 	if err != nil {
 		return fmt.Errorf("could not add member :%w", err)
 	}
@@ -200,5 +201,6 @@ func (c *ClusterMemberController) getEtcdPeerHostToScale(podToAdd *corev1.Pod) (
 		return "", err
 	}
 
-	return dnshelpers.GetEscapedPreferredInternalIPAddressForNodeName(network, node)
+	ip, _, err := dnshelpers.GetPreferredInternalIPAddressForNodeName(network, node)
+	return ip, err
 }

--- a/pkg/operator/clustermembercontroller/clustermembercontroller_test.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller_test.go
@@ -2,6 +2,7 @@ package clustermembercontroller
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -9,11 +10,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	machinelistersv1beta1 "github.com/openshift/client-go/machine/listers/machine/v1beta1"
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
+	"github.com/openshift/library-go/pkg/operator/events"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 type fakePodLister struct {
@@ -253,4 +262,271 @@ func TestClusterMemberController_getEtcdPodToAddToMembership(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileMembers(t *testing.T) {
+	alwaysTrueIsFunctionalMachineAPIFn := func() (bool, error) { return true, nil }
+
+	scenarios := []struct {
+		name                           string
+		isFunctionalMachineAPIFn       func() (bool, error)
+		initialEtcdMemberList          []*etcdserverpb.Member
+		initialObjectsForMachineLister []runtime.Object
+		initialObjectsForPodLister     []runtime.Object
+		initialObjectsForNodeLister    []runtime.Object
+		podLister                      corev1lister.PodLister
+		expectedError                  error
+		validateFn                     func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient)
+	}{
+		{
+			name:                           "member is added, pod not ready, machine not pending deletion",
+			isFunctionalMachineAPIFn:       alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForMachineLister: []runtime.Object{wellKnownMasterMachine()},
+			initialObjectsForNodeLister:    []runtime.Object{wellKnownMasterNode()},
+			initialObjectsForPodLister: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "etcd-a",
+						Namespace: "openshift-etcd",
+						Labels:    labels.Set{"app": "etcd"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "m-0",
+					},
+					Status: corev1.PodStatus{
+						Phase: "Running",
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "etcd",
+								Ready: false,
+								State: corev1.ContainerState{
+									Running: &corev1.ContainerStateRunning{},
+								},
+							},
+						},
+					},
+				}},
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 1 {
+					t.Errorf("expected exactly 1 members, got %v", len(memberList))
+				}
+			},
+		},
+		{
+			name:                     "member not added, machine pending deletion",
+			isFunctionalMachineAPIFn: alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForMachineLister: func() []runtime.Object {
+				machine := wellKnownMasterMachine()
+				machine.DeletionTimestamp = &metav1.Time{}
+				return []runtime.Object{machine}
+			}(),
+			initialObjectsForNodeLister: []runtime.Object{wellKnownMasterNode()},
+			initialObjectsForPodLister: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "etcd-a",
+						Namespace: "openshift-etcd",
+						Labels:    labels.Set{"app": "etcd"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "m-0",
+					},
+					Status: corev1.PodStatus{
+						Phase: "Running",
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "etcd",
+								Ready: false,
+								State: corev1.ContainerState{
+									Running: &corev1.ContainerStateRunning{},
+								},
+							},
+						},
+					},
+				}},
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 0 {
+					t.Errorf("expected exactly 0 members, got %v", len(memberList))
+				}
+			},
+		},
+		{
+			name:                     "member is added, pod not ready, machine pending deletion, machine api off",
+			isFunctionalMachineAPIFn: func() (bool, error) { return false, nil },
+			initialObjectsForMachineLister: func() []runtime.Object {
+				machine := wellKnownMasterMachine()
+				machine.DeletionTimestamp = &metav1.Time{}
+				return []runtime.Object{machine}
+			}(),
+			initialObjectsForNodeLister: []runtime.Object{wellKnownMasterNode()},
+			initialObjectsForPodLister: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "etcd-a",
+						Namespace: "openshift-etcd",
+						Labels:    labels.Set{"app": "etcd"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "m-0",
+					},
+					Status: corev1.PodStatus{
+						Phase: "Running",
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "etcd",
+								Ready: false,
+								State: corev1.ContainerState{
+									Running: &corev1.ContainerStateRunning{},
+								},
+							},
+						},
+					},
+				}},
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 1 {
+					t.Errorf("expected exactly 1 members, got %v", len(memberList))
+				}
+			},
+		},
+		{
+			name:                        "member not added, machine not found",
+			isFunctionalMachineAPIFn:    alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForNodeLister: []runtime.Object{wellKnownMasterNode()},
+			initialObjectsForPodLister: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "etcd-a",
+						Namespace: "openshift-etcd",
+						Labels:    labels.Set{"app": "etcd"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "m-0",
+					},
+					Status: corev1.PodStatus{
+						Phase: "Running",
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "etcd",
+								Ready: false,
+								State: corev1.ContainerState{
+									Running: &corev1.ContainerStateRunning{},
+								},
+							},
+						},
+					},
+				}},
+			expectedError: fmt.Errorf("unable to find machine for member: 10.0.139.78"),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 0 {
+					t.Errorf("expected exactly 0 members, got %v", len(memberList))
+				}
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			eventRecorder := events.NewRecorder(fake.NewSimpleClientset().CoreV1().Events("operator"), "test-cluster-member-controller", &corev1.ObjectReference{})
+			fakeMachineAPIChecker := &fakeMachineAPI{isMachineAPIFunctional: scenario.isFunctionalMachineAPIFn}
+
+			machineIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, initialObj := range scenario.initialObjectsForMachineLister {
+				machineIndexer.Add(initialObj)
+			}
+			machineLister := machinelistersv1beta1.NewMachineLister(machineIndexer)
+			machineSelector, err := labels.Parse("machine.openshift.io/cluster-api-machine-role=master")
+			if err != nil {
+				t.Fatal(err)
+			}
+			networkIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			networkIndexer.Add(&configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Spec: configv1.NetworkSpec{ServiceNetwork: []string{"172.30.0.0/16"}}})
+			networkLister := configv1listers.NewNetworkLister(networkIndexer)
+			nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, initialObj := range scenario.initialObjectsForNodeLister {
+				nodeIndexer.Add(initialObj)
+			}
+			nodeLister := corev1listers.NewNodeLister(nodeIndexer)
+
+			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(scenario.initialEtcdMemberList)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// act
+			target := ClusterMemberController{
+				etcdClient:            fakeEtcdClient,
+				podLister:             &fakePodLister{fake.NewSimpleClientset(scenario.initialObjectsForPodLister...), "openshift-etcd"},
+				machineAPIChecker:     fakeMachineAPIChecker,
+				masterMachineLister:   machineLister,
+				masterMachineSelector: machineSelector,
+				networkLister:         networkLister,
+				nodeLister:            nodeLister,
+			}
+			err = target.reconcileMembers(context.TODO(), eventRecorder)
+			if err == nil && scenario.expectedError != nil {
+				t.Fatal("expected to get an error from sync() method")
+			}
+			if err != nil && scenario.expectedError == nil {
+				t.Fatal(err)
+			}
+			if err != nil && scenario.expectedError != nil && err.Error() != scenario.expectedError.Error() {
+				t.Fatalf("unexpected error returned = %v, expected = %v", err, scenario.expectedError)
+			}
+			if scenario.validateFn != nil {
+				scenario.validateFn(t, fakeEtcdClient)
+			}
+		})
+	}
+}
+
+func wellKnownMasterMachine() *machinev1beta1.Machine {
+	return machineFor("m-0", "10.0.139.78")
+}
+
+func machineFor(name, internalIP string) *machinev1beta1.Machine {
+	return &machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{"machine.openshift.io/cluster-api-machine-role": "master"}},
+		Status: machinev1beta1.MachineStatus{Addresses: []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: internalIP,
+			},
+		}},
+	}
+}
+
+func wellKnownMasterNode() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "m-0", Labels: map[string]string{"node-role.kubernetes.io/master": ""}},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "10.0.139.78",
+			},
+		}},
+	}
+}
+
+type fakeMachineAPI struct {
+	isMachineAPIFunctional func() (bool, error)
+}
+
+func (dm *fakeMachineAPI) IsFunctional() (bool, error) {
+	return dm.isMachineAPIFunctional()
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -290,10 +290,15 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		kubeInformersForNamespaces,
 	)
 
+	machineAPI := ceohelpers.NewMachineAPI(masterMachineInformer, machinelistersv1beta1.NewMachineLister(masterMachineInformer.GetIndexer()), masterMachineLabelSelector)
+
 	clusterMemberController := clustermembercontroller.NewClusterMemberController(
 		operatorClient,
+		machineAPI,
 		kubeInformersForNamespaces,
 		configInformers.Config().V1().Networks(),
+		masterMachineInformer,
+		masterMachineLabelSelector,
 		etcdClient,
 		controllerContext.EventRecorder,
 	)


### PR DESCRIPTION
This PR brings back https://github.com/openshift/cluster-etcd-operator/pull/780, pulls https://github.com/openshift/cluster-etcd-operator/pull/785 and updates `IndexMachinesByNodeInternalIP` to collect all `InternalIPs` assigned to a machine.