### PR TITLE
adds attemptToRemoveLearningMember to the cluster member removal controller 

### DIFF
--- a/pkg/operator/ceohelpers/common.go
+++ b/pkg/operator/ceohelpers/common.go
@@ -110,13 +110,17 @@ func HasMachineDeletionHook(machine *machinev1beta1.Machine) bool {
 	return false
 }
 
+// IndexMachinesByNodeInternalIP maps machines to IPs
+//
+// Note that a machine can have multiple internal IPs
 func IndexMachinesByNodeInternalIP(machines []*machinev1beta1.Machine) map[string]*machinev1beta1.Machine {
 	index := map[string]*machinev1beta1.Machine{}
 	for _, machine := range machines {
 		for _, addr := range machine.Status.Addresses {
 			if addr.Type == corev1.NodeInternalIP {
 				index[addr.Address] = machine
-				break
+				// do not stop on first match
+				// machines can have multiple network interfaces
 			}
 		}
 	}

--- a/pkg/operator/ceohelpers/common.go
+++ b/pkg/operator/ceohelpers/common.go
@@ -5,14 +5,14 @@ import (
 	"net"
 	"net/url"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/ghodss/yaml"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // MachineDeletionHookName holds a name of the Machine Deletion Hook
@@ -110,9 +110,22 @@ func HasMachineDeletionHook(machine *machinev1beta1.Machine) bool {
 	return false
 }
 
+func IndexMachinesByNodeInternalIP(machines []*machinev1beta1.Machine) map[string]*machinev1beta1.Machine {
+	index := map[string]*machinev1beta1.Machine{}
+	for _, machine := range machines {
+		for _, addr := range machine.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				index[addr.Address] = machine
+				break
+			}
+		}
+	}
+	return index
+}
+
 func memberToURL(member *etcdserverpb.Member) (string, error) {
 	if len(member.PeerURLs) == 0 {
-		return "", fmt.Errorf("unable to extract member's URL address, it has an empty PeerURLs field, member: %v", spew.Sdump(member))
+		return "", fmt.Errorf("unable to extract member's URL address, it has an empty PeerURLs field, member name: %v, id: %v", member.Name, member.ID)
 	}
 	return member.PeerURLs[0], nil
 }

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -261,7 +261,7 @@ func (c *clusterMemberRemovalController) getNodeForMember(memberInternalIP strin
 	}
 
 	for _, masterNode := range masterNodes {
-		internalNodeIP, err := dnshelpers.GetEscapedPreferredInternalIPAddressForNodeName(network, masterNode)
+		internalNodeIP, _, err := dnshelpers.GetPreferredInternalIPAddressForNodeName(network, masterNode)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get internal IP for node: %w", err)
 		}

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -20,6 +20,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -88,7 +90,15 @@ func (c *clusterMemberRemovalController) sync(ctx context.Context, _ factory.Syn
 		return nil
 	}
 
-	return c.removeMemberWithoutMachine(ctx)
+	var errs []error
+	if err := c.removeMemberWithoutMachine(ctx); err != nil {
+		errs = append(errs, err)
+	}
+	if err := c.attemptToRemoveLearningMember(ctx); err != nil {
+		errs = append(errs, err)
+	}
+	return kerrors.NewAggregate(errs)
+
 }
 
 func (c *clusterMemberRemovalController) removeMemberWithoutMachine(ctx context.Context) error {
@@ -152,6 +162,62 @@ func (c *clusterMemberRemovalController) removeMemberWithoutMachine(ctx context.
 		}
 	}
 	return nil
+}
+
+// attemptToRemoveLearningMember attempts to remove a learning member pending deletion regardless of whether a replacement member has been found
+func (c *clusterMemberRemovalController) attemptToRemoveLearningMember(ctx context.Context) error {
+	currentVotingMemberIPListSet, err := c.votingMemberIPListSet()
+	if err != nil {
+		return err
+	}
+	memberMachines, err := c.currentMemberMachines()
+	if err != nil {
+		return err
+	}
+	var learningMachines []*machinev1beta1.Machine
+	for memberMachineIP, memberMachine := range ceohelpers.IndexMachinesByNodeInternalIP(memberMachines) {
+		if !currentVotingMemberIPListSet.Has(memberMachineIP) {
+			learningMachines = append(learningMachines, memberMachine)
+		}
+	}
+
+	learnerMachinesPendingDeletion := ceohelpers.FilterMachinesPendingDeletion(learningMachines)
+	if len(learnerMachinesPendingDeletion) == 0 {
+		return nil
+	}
+
+	// based on the data in the cache it looks like we have something to do
+	// get the live members, to observe the current state and the member IDs
+	members, err := c.etcdClient.MemberList(ctx)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, learnerMachinePendingDeletion := range learnerMachinesPendingDeletion {
+		for _, member := range members {
+			if !member.IsLearner {
+				// ignore voting members
+				continue
+			}
+			learnerIP, err := ceohelpers.MemberToNodeInternalIP(member)
+			if err != nil {
+				memberLocator := fmt.Sprintf("[ name: %v, id: %v ]", member.Name, member.ID)
+				errs = append(errs, fmt.Errorf("failed to get an IP for member: %v, err: %v", memberLocator, err))
+				continue
+			}
+			if hasInternalIP(learnerMachinePendingDeletion, learnerIP) {
+				memberLocator := fmt.Sprintf("[ url: %v, name: %v, id: %v ]", learnerIP, member.Name, member.ID)
+				if err := c.etcdClient.MemberRemove(ctx, member.ID); err != nil {
+					errs = append(errs, fmt.Errorf("failed to remove learning member: %v, err: %v", memberLocator, err))
+					continue
+				}
+				klog.V(2).Infof("successfully removed learning member: %v from the cluster", memberLocator)
+			}
+		}
+	}
+
+	return kerrors.NewAggregate(errs)
 }
 
 func (c *clusterMemberRemovalController) getMachineForMember(memberInternalIP string) (*machinev1beta1.Machine, error) {
@@ -226,4 +292,35 @@ func (c *clusterMemberRemovalController) findMachineByNodeInternalIP(nodeInterna
 		}
 	}
 	return nil, nil
+}
+
+func (c *clusterMemberRemovalController) votingMemberIPListSet() (sets.String, error) {
+	etcdEndpointsConfigMap, err := c.configMapListerForTargetNamespace.Get("etcd-endpoints")
+	if err != nil {
+		return sets.NewString(), err // should not happen
+	}
+	currentVotingMemberIPListSet := sets.NewString()
+	for _, votingMemberIP := range etcdEndpointsConfigMap.Data {
+		currentVotingMemberIPListSet.Insert(votingMemberIP)
+	}
+
+	return currentVotingMemberIPListSet, nil
+}
+
+// currentMemberMachines returns machines with the deletion hooks from the lister
+func (c *clusterMemberRemovalController) currentMemberMachines() ([]*machinev1beta1.Machine, error) {
+	masterMachines, err := c.masterMachineLister.List(c.masterMachineSelector)
+	if err != nil {
+		return nil, err
+	}
+	return ceohelpers.FilterMachinesWithMachineDeletionHook(masterMachines), nil
+}
+
+func hasInternalIP(machine *machinev1beta1.Machine, memberInternalIP string) bool {
+	for _, addr := range machine.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP && addr.Address == memberInternalIP {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
@@ -173,15 +173,37 @@ func TestClusterMemberRemovalController(t *testing.T) {
 		initialObjectsForMachineLister   []runtime.Object
 		initialEtcdMemberList            []*etcdserverpb.Member
 		validateFn                       func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient)
+		serviceNetwork                   string
 	}{
 		// scenario 1
 		{
 			name:                             "happy path: an etcd member has a corresponding machine and node resources",
+			serviceNetwork:                   "172.30.0.0/16",
 			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
 			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
 			initialObjectsForNodeLister:      []runtime.Object{wellKnownMasterNode()},
 			initialObjectsForMachineLister:   []runtime.Object{wellKnownMasterMachine()},
 			initialEtcdMemberList:            wellKnownEtcdMemberList(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 1 {
+					t.Errorf("expected exactly one etcd member, got %v", memberList)
+				}
+			},
+		},
+
+		// scenario 1 (ipv6)
+		{
+			name:                             "happy path (ipv6): an etcd member has a corresponding machine and node resources",
+			serviceNetwork:                   "fd02::/112",
+			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMapIpv6()},
+			initialObjectsForNodeLister:      []runtime.Object{wellKnownMasterNodeIpv6()},
+			initialObjectsForMachineLister:   []runtime.Object{wellKnownMasterMachineIpv6()},
+			initialEtcdMemberList:            wellKnownEtcdMemberListIpv6(),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {
@@ -196,6 +218,7 @@ func TestClusterMemberRemovalController(t *testing.T) {
 		// scenario 2
 		{
 			name:                             "an etcd member doesn't have a corresponding machine nor node resource and it is removed",
+			serviceNetwork:                   "172.30.0.0/16",
 			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
 			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
 			initialEtcdMemberList:            wellKnownEtcdMemberList(),
@@ -210,9 +233,28 @@ func TestClusterMemberRemovalController(t *testing.T) {
 			},
 		},
 
+		// scenario 2 (ipv6)
+		{
+			name:                             "(ipv6) an etcd member doesn't have a corresponding machine nor node resource and it is removed",
+			serviceNetwork:                   "fd02::/112",
+			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMapIpv6()},
+			initialEtcdMemberList:            wellKnownEtcdMemberListIpv6(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 0 {
+					t.Errorf("expected an empty member list, got %v", memberList)
+				}
+			},
+		},
+
 		// scenario 3
 		{
 			name:                             "an etcd member with only a corresponding machine resource is not removed",
+			serviceNetwork:                   "172.30.0.0/16",
 			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
 			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
 			initialObjectsForMachineLister:   []runtime.Object{wellKnownMasterMachine()},
@@ -228,13 +270,52 @@ func TestClusterMemberRemovalController(t *testing.T) {
 			},
 		},
 
+		// scenario 3 (ipv6)
+		{
+			name:                             "(ipv6) an etcd member with only a corresponding machine resource is not removed",
+			serviceNetwork:                   "fd02::/112",
+			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMapIpv6()},
+			initialObjectsForMachineLister:   []runtime.Object{wellKnownMasterMachineIpv6()},
+			initialEtcdMemberList:            wellKnownEtcdMemberListIpv6(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 1 {
+					t.Errorf("expected exactly one etcd member, got %v", memberList)
+				}
+			},
+		},
+
 		// scenario 4
 		{
 			name:                             "an etcd member with only a corresponding node resource is not removed",
+			serviceNetwork:                   "172.30.0.0/16",
 			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
 			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
 			initialObjectsForNodeLister:      []runtime.Object{wellKnownMasterNode()},
 			initialEtcdMemberList:            wellKnownEtcdMemberList(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 1 {
+					t.Errorf("expected exactly one etcd member, got %v", memberList)
+				}
+			},
+		},
+
+		// scenario 4 (ipv6)
+		{
+			name:                             "(ipv6) an etcd member with only a corresponding node resource is not removed",
+			serviceNetwork:                   "fd02::/112",
+			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMapIpv6()},
+			initialObjectsForNodeLister:      []runtime.Object{wellKnownMasterNodeIpv6()},
+			initialEtcdMemberList:            wellKnownEtcdMemberListIpv6(),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {
@@ -270,7 +351,7 @@ func TestClusterMemberRemovalController(t *testing.T) {
 			}
 
 			networkIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-			networkIndexer.Add(&configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Spec: configv1.NetworkSpec{ServiceNetwork: []string{"172.30.0.0/16"}}})
+			networkIndexer.Add(&configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Spec: configv1.NetworkSpec{ServiceNetwork: []string{scenario.serviceNetwork}}})
 			networkLister := configv1listers.NewNetworkLister(networkIndexer)
 
 			machineIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
@@ -320,6 +401,15 @@ func wellKnownEtcdEndpointsConfigMap() *corev1.ConfigMap {
 	}
 }
 
+func wellKnownEtcdEndpointsConfigMapIpv6() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "etcd-endpoints", Namespace: "openshift-etcd"},
+		Data: map[string]string{
+			"m-0": "fd2e:6f44:5dd8:c956::16",
+		},
+	}
+}
+
 func wellKnownEtcdMemberList() []*etcdserverpb.Member {
 	return []*etcdserverpb.Member{
 		{
@@ -340,6 +430,16 @@ func wellKnownEtcdMemberList() []*etcdserverpb.Member {
 	}
 }
 
+func wellKnownEtcdMemberListIpv6() []*etcdserverpb.Member {
+	return []*etcdserverpb.Member{
+		{
+			Name:     "m-0",
+			ID:       8,
+			PeerURLs: []string{"https://[fd2e:6f44:5dd8:c956::16]:1234"},
+		},
+	}
+}
+
 func wellKnownMasterNode() *corev1.Node {
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "m-0", Labels: map[string]string{"node-role.kubernetes.io/master": ""}},
@@ -352,6 +452,18 @@ func wellKnownMasterNode() *corev1.Node {
 	}
 }
 
+func wellKnownMasterNodeIpv6() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "m-0", Labels: map[string]string{"node-role.kubernetes.io/master": ""}},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "fd2e:6f44:5dd8:c956::16",
+			},
+		}},
+	}
+}
+
 func wellKnownMasterMachine() *machinev1beta1.Machine {
 	return &machinev1beta1.Machine{
 		ObjectMeta: metav1.ObjectMeta{Name: "m-0", Labels: map[string]string{"machine.openshift.io/cluster-api-machine-role": "master"}},
@@ -359,6 +471,18 @@ func wellKnownMasterMachine() *machinev1beta1.Machine {
 			{
 				Type:    corev1.NodeInternalIP,
 				Address: "10.0.139.78",
+			},
+		}},
+	}
+}
+
+func wellKnownMasterMachineIpv6() *machinev1beta1.Machine {
+	return &machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "m-0", Labels: map[string]string{"machine.openshift.io/cluster-api-machine-role": "master"}},
+		Status: machinev1beta1.MachineStatus{Addresses: []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "fd2e:6f44:5dd8:c956::16",
 			},
 		}},
 	}

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
@@ -23,6 +23,145 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+func TestAttemptToRemoveLearningMember(t *testing.T) {
+	scenarios := []struct {
+		name                                     string
+		initialObjectsForMachineLister           []runtime.Object
+		initialObjectsForConfigMapTargetNSLister []runtime.Object
+		initialEtcdMemberList                    []*etcdserverpb.Member
+		validateFn                               func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient)
+	}{
+		{
+			name: "learning member pending deletion is removed",
+			initialObjectsForMachineLister: func() []runtime.Object {
+				m4 := machineWithHooksFor("m-4", "10.0.139.81")
+				m4.DeletionTimestamp = &metav1.Time{}
+				machines := wellKnownMasterMachines()
+				machines = append(machines, m4)
+				return machines
+			}(),
+			initialObjectsForConfigMapTargetNSLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
+			initialEtcdMemberList: func() []*etcdserverpb.Member {
+				members := append(wellKnownEtcdMemberList(), &etcdserverpb.Member{
+					Name:      "m-4",
+					ID:        4,
+					IsLearner: true,
+					PeerURLs:  []string{"https://10.0.139.81:1234"},
+				})
+				return members
+			}(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 3 {
+					t.Errorf("expected exactly 3 members, got %v", len(memberList))
+				}
+				for _, member := range memberList {
+					if member.ID == 4 {
+						t.Fatalf("expected the member: %v to be removed from the etcd cluster but it wasn't", member)
+					}
+				}
+			},
+		},
+
+		{
+			name:                  "voting member pending deletion is NOT removed",
+			initialEtcdMemberList: wellKnownEtcdMemberList(),
+			initialObjectsForMachineLister: func() []runtime.Object {
+				machines := wellKnownMasterMachines()
+				m0 := machines[0].(*machinev1beta1.Machine)
+				m0.DeletionTimestamp = &metav1.Time{}
+				return machines
+			}(),
+			initialObjectsForConfigMapTargetNSLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 3 {
+					t.Errorf("expected exactly 3 members, got %v", len(memberList))
+				}
+			},
+		},
+
+		{
+			name: "excessive voting member pending deletion is NOT removed",
+			initialEtcdMemberList: func() []*etcdserverpb.Member {
+				members := append(wellKnownEtcdMemberList(), &etcdserverpb.Member{
+					Name:     "m-4",
+					ID:       4,
+					PeerURLs: []string{"https://10.0.139.81:1234"},
+				})
+				return members
+			}(),
+			initialObjectsForMachineLister: func() []runtime.Object {
+				m4 := machineWithHooksFor("m-4", "10.0.139.81")
+				m4.DeletionTimestamp = &metav1.Time{}
+				machines := wellKnownMasterMachines()
+				machines = append(machines, m4)
+				return machines
+			}(),
+			initialObjectsForConfigMapTargetNSLister: func() []runtime.Object {
+				cm := wellKnownEtcdEndpointsConfigMap()
+				cm.Data["m-4"] = "10.0.139.81"
+				return []runtime.Object{cm}
+			}(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 4 {
+					t.Errorf("expected exactly 4 members, got %v", len(memberList))
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			configMapTargetNSIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, initialObj := range scenario.initialObjectsForConfigMapTargetNSLister {
+				configMapTargetNSIndexer.Add(initialObj)
+			}
+			configMapTargetNSLister := corev1listers.NewConfigMapLister(configMapTargetNSIndexer).ConfigMaps("openshift-etcd")
+
+			machineIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, initialObj := range scenario.initialObjectsForMachineLister {
+				machineIndexer.Add(initialObj)
+			}
+			machineLister := machinelistersv1beta1.NewMachineLister(machineIndexer)
+			machineSelector, err := labels.Parse("machine.openshift.io/cluster-api-machine-role=master")
+			if err != nil {
+				t.Fatal(err)
+			}
+			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(scenario.initialEtcdMemberList)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// act
+			target := clusterMemberRemovalController{
+				etcdClient:                        fakeEtcdClient,
+				masterMachineLister:               machineLister,
+				masterMachineSelector:             machineSelector,
+				configMapListerForTargetNamespace: configMapTargetNSLister,
+			}
+			err = target.attemptToRemoveLearningMember(context.TODO())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scenario.validateFn != nil {
+				scenario.validateFn(t, fakeEtcdClient)
+			}
+		})
+	}
+}
+
 func TestClusterMemberRemovalController(t *testing.T) {
 	alwaysTrueIsFunctionalMachineAPIFn := func() (bool, error) { return true, nil }
 
@@ -174,7 +313,9 @@ func wellKnownEtcdEndpointsConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "etcd-endpoints", Namespace: "openshift-etcd"},
 		Data: map[string]string{
-			"m-0": "10.0.139.78",
+			"m-1": "10.0.139.78",
+			"m-2": "10.0.139.79",
+			"m-3": "10.0.139.80",
 		},
 	}
 }
@@ -182,9 +323,19 @@ func wellKnownEtcdEndpointsConfigMap() *corev1.ConfigMap {
 func wellKnownEtcdMemberList() []*etcdserverpb.Member {
 	return []*etcdserverpb.Member{
 		{
-			Name:     "m-0",
-			ID:       8,
+			Name:     "m-1",
+			ID:       1,
 			PeerURLs: []string{"https://10.0.139.78:1234"},
+		},
+		{
+			Name:     "m-2",
+			ID:       2,
+			PeerURLs: []string{"https://10.0.139.79:1234"},
+		},
+		{
+			Name:     "m-3",
+			ID:       3,
+			PeerURLs: []string{"https://10.0.139.80:1234"},
 		},
 	}
 }
@@ -219,4 +370,30 @@ type fakeMachineAPI struct {
 
 func (dm *fakeMachineAPI) IsFunctional() (bool, error) {
 	return dm.isMachineAPIFunctional()
+}
+
+func machineFor(name, internalIP string) *machinev1beta1.Machine {
+	return &machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{"machine.openshift.io/cluster-api-machine-role": "master"}},
+		Status: machinev1beta1.MachineStatus{Addresses: []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: internalIP,
+			},
+		}},
+	}
+}
+
+func machineWithHooksFor(name, internalIP string) *machinev1beta1.Machine {
+	m := machineFor(name, internalIP)
+	m.Spec.LifecycleHooks.PreDrain = append(m.Spec.LifecycleHooks.PreDrain, machinev1beta1.LifecycleHook{Name: "EtcdQuorumOperator", Owner: "clusteroperator/etcd"})
+	return m
+}
+
+func wellKnownMasterMachines() []runtime.Object {
+	return []runtime.Object{
+		machineWithHooksFor("m-1", "10.0.139.78"),
+		machineWithHooksFor("m-2", "10.0.139.79"),
+		machineWithHooksFor("m-3", "10.0.139.80"),
+	}
 }


### PR DESCRIPTION
brings back https://github.com/openshift/cluster-etcd-operator/pull/784, https://github.com/openshift/cluster-etcd-operator/pull/780/commits/85f8acd62c00af0ee9cf00800b08b43884ed5e96, pulls https://github.com/openshift/cluster-etcd-operator/pull/785/commits/880b5e8957eaf4459531ac138ceee2f2f1b323d3 (ipv6 fix) and updates `IndexMachinesByNodeInternalIP` to collect all `InternalIPs` assigned to a machine.

since `ci/prow/e2e-metal-ipi-ovn-ipv6` currently fails on `failed to create cluster: failed doing terraform init: fork/exec ocp/ostest/terraform/bin/terraform: no such file or directory` which is not related to the ipv6 issue we were chasing yesterday we are unable to verify https://github.com/openshift/cluster-etcd-operator/pull/790/commits/d08b40b6f6c862dbb0f261bebada03449042c4d7 which broke the ipv6 tests. Thus we could merge this PR first to unblock the rest.