### PR TITLE
Bug 2076793: pkg/operator/upgradebackupcontroller: Pivot from Failing to ReleaseAccepted

### DIFF
--- a/pkg/operator/upgradebackupcontroller/upgradebackupcontroller.go
+++ b/pkg/operator/upgradebackupcontroller/upgradebackupcontroller.go
@@ -294,8 +294,8 @@ func createBackupPod(ctx context.Context, nodeName, recentBackupName, operatorIm
 // isRequireRecentBackup checks the conditions of ClusterVersion to verify if a backup is required.
 func isRequireRecentBackup(config *configv1.ClusterVersion) bool {
 	for _, condition := range config.Status.Conditions {
-		// Check if Failing is true and Message field containers the string RecentBackup.
-		if condition.Type == "Failing" && condition.Status == configv1.ConditionTrue {
+		// Check if ReleaseAccepted is false and Message field containers the string RecentBackup.
+		if condition.Type == "ReleaseAccepted" && condition.Status == configv1.ConditionFalse {
 			return strings.Contains(condition.Message, "RecentBackup")
 		}
 	}

--- a/pkg/operator/upgradebackupcontroller/upgradebackupcontroller_test.go
+++ b/pkg/operator/upgradebackupcontroller/upgradebackupcontroller_test.go
@@ -37,8 +37,8 @@ func Test_ensureRecentBackup(t *testing.T) {
 				u.FakePod("cluster-backup", u.WithPodStatus(corev1.PodFailed), u.WithCreationTimestamp(nowMinusDuration(failedPodBackoffDuration))),
 			},
 			clusterversionCondition: configv1.ClusterOperatorStatusCondition{
-				Type:    "Failing",
-				Status:  configv1.ConditionTrue,
+				Type:    "ReleaseAccepted",
+				Status:  configv1.ConditionFalse,
 				Message: fmt.Sprintf("Need RecentBackup"),
 			},
 			wantBackupStatus: configv1.ConditionFalse,
@@ -50,8 +50,8 @@ func Test_ensureRecentBackup(t *testing.T) {
 				u.FakePod("cluster-backup", u.WithPodStatus(corev1.PodFailed), u.WithCreationTimestamp(metav1.Now())),
 			},
 			clusterversionCondition: configv1.ClusterOperatorStatusCondition{
-				Type:    "Failing",
-				Status:  configv1.ConditionTrue,
+				Type:    "ReleaseAccepted",
+				Status:  configv1.ConditionFalse,
 				Message: fmt.Sprintf("Need RecentBackup"),
 			},
 			wantBackupStatus: configv1.ConditionFalse,
@@ -63,8 +63,8 @@ func Test_ensureRecentBackup(t *testing.T) {
 				u.FakePod("cluster-backup", u.WithPodStatus(corev1.PodPending)),
 			},
 			clusterversionCondition: configv1.ClusterOperatorStatusCondition{
-				Type:    "Failing",
-				Status:  configv1.ConditionTrue,
+				Type:    "ReleaseAccepted",
+				Status:  configv1.ConditionFalse,
 				Message: fmt.Sprintf("Need RecentBackup"),
 			},
 			wantBackupStatus: configv1.ConditionUnknown,
@@ -72,8 +72,8 @@ func Test_ensureRecentBackup(t *testing.T) {
 		{
 			name: "RecentBackup not required invalid type",
 			clusterversionCondition: configv1.ClusterOperatorStatusCondition{
-				Type:    "NotFailing",
-				Status:  configv1.ConditionTrue,
+				Type:    "NotReleaseAccepted",
+				Status:  configv1.ConditionFalse,
 				Message: fmt.Sprintf("Need RecentBackup"),
 			},
 			wantNilBackupCondition: true,
@@ -81,8 +81,8 @@ func Test_ensureRecentBackup(t *testing.T) {
 		{
 			name: "RecentBackup not required invalid message",
 			clusterversionCondition: configv1.ClusterOperatorStatusCondition{
-				Type:    "Failing",
-				Status:  configv1.ConditionTrue,
+				Type:    "ReleaseAccepted",
+				Status:  configv1.ConditionFalse,
 				Message: fmt.Sprintf("Invalid"),
 			},
 			wantNilBackupCondition: true,
@@ -94,8 +94,8 @@ func Test_ensureRecentBackup(t *testing.T) {
 				u.FakeNode("master-1"),
 			},
 			clusterversionCondition: configv1.ClusterOperatorStatusCondition{
-				Type:    "Failing",
-				Status:  configv1.ConditionTrue,
+				Type:    "ReleaseAccepted",
+				Status:  configv1.ConditionFalse,
 				Message: fmt.Sprintf("Need RecentBackup"),
 			},
 			wantBackupStatus: configv1.ConditionUnknown,


### PR DESCRIPTION
[cvo#683][1], backported [to 4.10.8][3] with [cvo#753][2], pivoted the "I'm waiting for RecentBackup" message from the Failing condition to a new `ReleaseAccepted` condition (`Failing` is now focused on "am I happy with the current release reconciliation?" and now excludes "I'm concerned about the requested desired target release, which I haven't accepted yet").  Catch up by looking at the new condition.

We don't need to look at `Failing` anymore, because the cluster-version has already made the pivot to `ReleaseAccepted`, and since the cluster-version operator is the first to update, we don't need to worry about newer etcd operators vs. older cluster-version operators.

[1]: https://github.com/openshift/cluster-version-operator/pull/683/commits/7221c93dfcd19f6c1f46614cec105ba36be2f61e#diff-db97dc5ae62ef3b4c4dabfdc43cbc3ae0ceae9b58748cadebde679e32b5bec2bR160
[2]: https://github.com/openshift/cluster-version-operator/pull/753/files#diff-db97dc5ae62ef3b4c4dabfdc43cbc3ae0ceae9b58748cadebde679e32b5bec2bR160
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=2064991#c7