### PR TITLE
fix races in etcdclient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/prometheus/common v0.28.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1
 	github.com/vishvananda/netlink v1.0.0
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/pkg/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/etcdcli/etcdcli_pool.go
+++ b/pkg/etcdcli/etcdcli_pool.go
@@ -1,0 +1,184 @@
+package etcdcli
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"k8s.io/klog/v2"
+)
+
+// EtcdClientPool fulfills these requirements:
+// * cache clients to avoid re-creating them all the time (TLS handshakes are expensive after all)
+// * return an exclusively unused client, no other can acquire the same client at that time
+// * health checking a client before using it (using list), return a new one if unhealthy and closing the old one
+// * update endpoints, to be always up to date with the changes
+// * return a used client to the pool, making it available to consume again
+type EtcdClientPool struct {
+	pool             chan *clientv3.Client
+	availableTickets chan int
+
+	newFunc       func() (*clientv3.Client, error)
+	endpointsFunc func() ([]string, error)
+	healthFunc    func(*clientv3.Client) error
+	closeFunc     func(*clientv3.Client) error
+}
+
+const retries = 3
+
+// have some small linear retries of 2s * retry in order to fail gracefully
+const linearRetryBaseSleep = 2 * time.Second
+
+// that controls the channel size, which controls how many unused clients we are keeping in buffer
+const maxNumCachedClients = 5
+
+// that controls how many clients are being created, you need to have a ticket to create a client
+// this protects etcd from being hit by too many clients at once, eg when it is down or recovering or hit by lots of QPS
+const maxNumClientTickets = 10
+const maxAcquireTime = 5 * time.Second
+
+// Get returns a client that can be used exclusively by the caller,
+// the caller must not close the client but return it using Return.
+// This is intentionally not a fast operation, Get will ensure the client returned will be healthy and retries on errors.
+// If no client is available, this method will block intentionally to protect etcd from being overwhelmed by too many clients at once.
+func (p *EtcdClientPool) Get() (*clientv3.Client, error) {
+	desiredEndpoints, err := p.endpointsFunc()
+	if err != nil {
+		return nil, fmt.Errorf("getting cache client could not retrieve endpoints: %w", err)
+	}
+
+	// retrying this a few times until the caller gets a healthy client
+	for i := 0; i < retries; i++ {
+		if i != 0 {
+			time.Sleep(linearRetryBaseSleep * time.Duration(i))
+		}
+
+		var client *clientv3.Client
+		select {
+		case client = <-p.pool:
+		default:
+			// blocks the creation when there are too many clients, after timeout we reject the request immediately without retry
+			select {
+			case <-p.availableTickets:
+			case <-time.After(maxAcquireTime):
+				return nil, fmt.Errorf("too many active cache clients, rejecting to create new one")
+			}
+
+			klog.Infof("creating a new cached client")
+			c, err := p.newFunc()
+			if err != nil {
+				klog.Warningf("could not create a new cached client after %d tries, trying again. Err: %v", i, err)
+				returnTicket(p.availableTickets)
+				continue
+			}
+
+			client = c
+		}
+
+		// we're sorting as reflect.DeepEqual is depending on order
+		sort.Strings(desiredEndpoints)
+		currentEndpoints := client.Endpoints()
+		// client returns a defensive copy, so should be fine to sort in-place
+		sort.Strings(currentEndpoints)
+		if !reflect.DeepEqual(desiredEndpoints, currentEndpoints) {
+			klog.Warningf("cached client detected change in endpoints [%s] vs. [%s]", currentEndpoints, desiredEndpoints)
+			// normally we could just set the endpoints directly, but this allows us to add some useful logging
+			client.SetEndpoints(desiredEndpoints...)
+		}
+
+		err = p.healthFunc(client)
+		if err != nil {
+			klog.Warningf("cached client considered unhealthy after %d tries, trying again. Err: %v", i, err)
+			// try to close the broken client and return the ticket to the pool
+			returnTicket(p.availableTickets)
+			err = p.closeFunc(client)
+			if err != nil {
+				klog.Errorf("could not close unhealthy cache client: %v", err)
+			}
+			continue
+		}
+
+		return client, nil
+	}
+
+	return nil, fmt.Errorf("giving up getting a cached client after %d tries", retries)
+}
+
+// Return will make the given client available for other callers through Get again.
+// When the underlying pool is filled it will close the client instead of waiting for a free spot.
+func (p *EtcdClientPool) Return(client *clientv3.Client) {
+	if client == nil {
+		return
+	}
+
+	select {
+	case p.pool <- client:
+	default:
+		returnTicket(p.availableTickets)
+		err := p.closeFunc(client)
+		if err != nil {
+			klog.Errorf("could not close cache client exceeding pool capacity: %v", err)
+		}
+	}
+}
+
+// returnTicket will attempt to return a ticket to the channel, but will not block when the channel is at capacity
+func returnTicket(tickets chan int) {
+	select {
+	case tickets <- 1:
+	default:
+	}
+}
+
+func NewDefaultEtcdClientPool(newFunc func() (*clientv3.Client, error), endpointsFunc func() ([]string, error)) *EtcdClientPool {
+	healthFunc := func(client *clientv3.Client) error {
+		if client == nil {
+			return fmt.Errorf("cached client was nil")
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, err := client.MemberList(ctx)
+		if err != nil {
+			if clientv3.IsConnCanceled(err) {
+				return fmt.Errorf("cache client health connection was canceled: %w", err)
+			}
+			return fmt.Errorf("error during cache client health connection check: %w", err)
+		}
+		return nil
+	}
+
+	closeFunc := func(client *clientv3.Client) error {
+		if client == nil {
+			return nil
+		}
+		klog.Infof("closing cached client")
+		return client.Close()
+	}
+
+	return NewEtcdClientPool(newFunc, endpointsFunc, healthFunc, closeFunc)
+}
+
+func NewEtcdClientPool(
+	newFunc func() (*clientv3.Client, error),
+	endpointsFunc func() ([]string, error),
+	healthFunc func(*clientv3.Client) error,
+	closeFunc func(*clientv3.Client) error) *EtcdClientPool {
+
+	// pre-populate tickets for client creation
+	tickets := make(chan int, maxNumClientTickets)
+	for i := 0; i < maxNumClientTickets; i++ {
+		tickets <- i
+	}
+
+	return &EtcdClientPool{
+		pool:             make(chan *clientv3.Client, maxNumCachedClients),
+		availableTickets: tickets,
+		newFunc:          newFunc,
+		endpointsFunc:    endpointsFunc,
+		healthFunc:       healthFunc,
+		closeFunc:        closeFunc,
+	}
+}

--- a/pkg/etcdcli/etcdcli_pool.go
+++ b/pkg/etcdcli/etcdcli_pool.go
@@ -120,7 +120,7 @@ func (p *EtcdClientPool) Return(client *clientv3.Client) {
 		returnTicket(p.availableTickets)
 		err := p.closeFunc(client)
 		if err != nil {
-			klog.Errorf("could not close cache client exceeding pool capacity: %v", err)
+			klog.Errorf("failed to close extra etcd client which is not being re-added in the client pool: %v", err)
 		}
 	}
 }

--- a/pkg/etcdcli/etcdcli_pool_test.go
+++ b/pkg/etcdcli/etcdcli_pool_test.go
@@ -1,0 +1,430 @@
+package etcdcli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/integration"
+)
+
+// rather poor men's approach to mocking
+type clientPoolRecorder struct {
+	pool *EtcdClientPool
+
+	numNewCalls      int
+	numEndpointCalls int
+	numHealthCalls   int
+	numCloseCalls    int
+
+	newFuncErrReturn     error
+	healthCheckErrReturn error
+	endpointErrReturn    error
+	closeFuncErrReturn   error
+	updatedEndpoints     []string
+}
+
+func TestClientGetReturnHappyPath(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+
+	client, err := poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, 1, poolRecorder.numNewCalls)
+	assert.Equal(t, 1, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 1, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+}
+
+func TestClientEndpointFailureReturnsImmediately(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	poolRecorder.endpointErrReturn = errors.New("fail")
+
+	client, err := poolRecorder.pool.Get()
+	require.Error(t, err, "expected endpoint error fail, but got %w", err)
+	assert.Nil(t, client)
+	assert.Equal(t, 0, poolRecorder.numNewCalls)
+	assert.Equal(t, 1, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 0, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+}
+
+func TestClientDoubleGetReturnsNewClient(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+
+	client, err := poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, 1, poolRecorder.numNewCalls)
+	assert.Equal(t, 1, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 1, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+	// not returning the given client
+	client, err = poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, 2, poolRecorder.numNewCalls)
+	assert.Equal(t, 2, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 2, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+}
+
+func TestClientReusesClientsReturned(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+
+	client, err := poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, 1, poolRecorder.numNewCalls)
+	assert.Equal(t, 1, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 1, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+	poolRecorder.pool.Return(client)
+	client, err = poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, 1, poolRecorder.numNewCalls)
+	assert.Equal(t, 2, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 2, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+}
+
+func TestClientClosesOnChannelCapacity(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	var clients []*clientv3.Client
+	for i := 0; i < maxNumCachedClients+1; i++ {
+		client, err := poolRecorder.pool.Get()
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+		clients = append(clients, client)
+	}
+
+	// returning all should make sure the last one tripping over capacity should get closed
+	for _, client := range clients {
+		poolRecorder.pool.Return(client)
+	}
+
+	assert.Equal(t, maxNumCachedClients+1, poolRecorder.numNewCalls)
+	assert.Equal(t, maxNumCachedClients+1, poolRecorder.numEndpointCalls)
+	assert.Equal(t, maxNumCachedClients+1, poolRecorder.numHealthCalls)
+	assert.Equal(t, 1, poolRecorder.numCloseCalls)
+}
+
+func TestNewClientWithTickets(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	var clients []*clientv3.Client
+	for i := 0; i < maxNumClientTickets; i++ {
+		client, err := poolRecorder.pool.Get()
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+		clients = append(clients, client)
+	}
+
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numNewCalls)
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numEndpointCalls)
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+
+	// this should block and return an error
+	client, err := poolRecorder.pool.Get()
+	assert.Nil(t, client)
+	assert.Errorf(t, err, "too many active cache clients, rejecting to create new one")
+	// returning one should unlock the get again
+	poolRecorder.pool.Return(clients[0])
+	client, err = poolRecorder.pool.Get()
+	assert.NotNil(t, client)
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numNewCalls)        // no new call added
+	assert.Equal(t, maxNumClientTickets+2, poolRecorder.numEndpointCalls) // called Get twice additionally
+	assert.Equal(t, maxNumClientTickets+1, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+}
+
+func TestClosesReturnTickets(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	var clients []*clientv3.Client
+	for i := 0; i < maxNumClientTickets; i++ {
+		client, err := poolRecorder.pool.Get()
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+		clients = append(clients, client)
+	}
+
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numNewCalls)
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numEndpointCalls)
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+
+	// return all clients to fill the internal cache and cause five to close
+	for i := 0; i < maxNumClientTickets; i++ {
+		poolRecorder.pool.Return(clients[i])
+	}
+	assert.Equal(t, maxNumCachedClients, poolRecorder.numCloseCalls)
+
+	// now we should be able to get the full amount of tickets again
+	for i := 0; i < maxNumClientTickets; i++ {
+		client, err := poolRecorder.pool.Get()
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+	}
+
+	// replenish the maxNumCachedClients that were closed earlier
+	assert.Equal(t, maxNumClientTickets+maxNumCachedClients, poolRecorder.numNewCalls)
+	assert.Equal(t, maxNumClientTickets*2, poolRecorder.numEndpointCalls)
+	assert.Equal(t, maxNumClientTickets*2, poolRecorder.numHealthCalls)
+	assert.Equal(t, maxNumCachedClients, poolRecorder.numCloseCalls)
+}
+
+func TestClosesReturnTicketsCloseError(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	var clients []*clientv3.Client
+	for i := 0; i < maxNumClientTickets; i++ {
+		client, err := poolRecorder.pool.Get()
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+		clients = append(clients, client)
+	}
+
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numNewCalls)
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numEndpointCalls)
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+
+	// return all clients to fill the internal cache and cause five to close
+	// first close should fail, but not impact anything and certainly not block
+	poolRecorder.closeFuncErrReturn = errors.New("fail")
+	for i := 0; i < maxNumClientTickets; i++ {
+		poolRecorder.pool.Return(clients[i])
+	}
+	assert.Equal(t, maxNumCachedClients, poolRecorder.numCloseCalls)
+
+	// now we should be able to get the full amount of tickets again
+	for i := 0; i < maxNumClientTickets; i++ {
+		client, err := poolRecorder.pool.Get()
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+	}
+
+	// replenish the maxNumCachedClients that were closed earlier
+	assert.Equal(t, maxNumClientTickets+maxNumCachedClients, poolRecorder.numNewCalls)
+	assert.Equal(t, maxNumClientTickets*2, poolRecorder.numEndpointCalls)
+	assert.Equal(t, maxNumClientTickets*2, poolRecorder.numHealthCalls)
+	assert.Equal(t, maxNumCachedClients, poolRecorder.numCloseCalls)
+}
+
+// this scenario used to lock-up etcd on start-up a lot, as the client does some initial connection testing that may fail
+// eventually it will be exhausting all the tickets
+func TestFailingOnCreationReturnsTickets(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	// this should already happen at maxNumClientTickets/numRetries, so we're testing this is working pretty well here.
+	for i := 0; i < maxNumClientTickets; i++ {
+		// this error should fail the first retry consistently
+		poolRecorder.newFuncErrReturn = fmt.Errorf("constant error")
+		client, err := poolRecorder.pool.Get()
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+	}
+
+	// replenish the maxNumCachedClients that were closed earlier
+	assert.Equal(t, maxNumClientTickets*2, poolRecorder.numNewCalls)
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numEndpointCalls)
+	assert.Equal(t, maxNumClientTickets, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+}
+
+func TestClientClosesAndCreatesOnError(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	client, err := poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, 1, poolRecorder.numNewCalls)
+	assert.Equal(t, 1, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 1, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+	poolRecorder.pool.Return(client)
+
+	poolRecorder.healthCheckErrReturn = fmt.Errorf("some error")
+
+	client, err = poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, 2, poolRecorder.numNewCalls)
+	assert.Equal(t, 2, poolRecorder.numEndpointCalls)
+	// 3 calls, since we first test the returned client resulting in failure, then we test the new client
+	assert.Equal(t, 3, poolRecorder.numHealthCalls)
+	assert.Equal(t, 1, poolRecorder.numCloseCalls)
+}
+
+func TestClientHealthCheckCloseErrorRetriesAndReturnsClient(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	client, err := poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, 1, poolRecorder.numNewCalls)
+	assert.Equal(t, 1, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 1, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+	poolRecorder.pool.Return(client)
+
+	poolRecorder.healthCheckErrReturn = fmt.Errorf("some health error")
+	poolRecorder.closeFuncErrReturn = fmt.Errorf("some close error")
+
+	client, err = poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, 2, poolRecorder.numNewCalls)
+	assert.Equal(t, 2, poolRecorder.numEndpointCalls)
+	// 3 calls, since we first test the returned client resulting in failure, then we test the new client
+	assert.Equal(t, 3, poolRecorder.numHealthCalls)
+	assert.Equal(t, 1, poolRecorder.numCloseCalls)
+}
+
+func TestClientUpdatesEndpoints(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	client, err := poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, 1, poolRecorder.numNewCalls)
+	assert.Equal(t, 1, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 1, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+	poolRecorder.pool.Return(client)
+
+	// by default, we're using client 0 going to m0, client 1 should go to m1
+	expectedEndpoints := testServer.Client(1).Endpoints()
+	poolRecorder.updatedEndpoints = expectedEndpoints
+
+	client, err = poolRecorder.pool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, expectedEndpoints, client.Endpoints())
+	assert.Equal(t, 1, poolRecorder.numNewCalls)
+	assert.Equal(t, 2, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 2, poolRecorder.numHealthCalls)
+	assert.Equal(t, 0, poolRecorder.numCloseCalls)
+}
+
+func TestClientTicketReturnNil(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	// should not panic
+	assert.NotPanics(t, func() {
+		poolRecorder.pool.Return(nil)
+	})
+}
+
+// we try to return many more clients than we actually handed out, this should fill the pool but not block when it's full
+func TestClientTicketMultiReturns(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testServer := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer testServer.Terminate(t)
+
+	poolRecorder := newTestPool(testServer)
+	for i := 0; i < maxNumClientTickets*3; i++ {
+		poolRecorder.pool.Return(testServer.RandClient())
+	}
+	assert.Equal(t, 0, poolRecorder.numNewCalls)
+	assert.Equal(t, 0, poolRecorder.numEndpointCalls)
+	assert.Equal(t, 0, poolRecorder.numHealthCalls)
+	assert.Equal(t, maxNumClientTickets*3-maxNumCachedClients, poolRecorder.numCloseCalls)
+}
+
+func newTestPool(testServer *integration.ClusterV3) *clientPoolRecorder {
+	rec := &clientPoolRecorder{}
+	endpointFunc := func() ([]string, error) {
+		rec.numEndpointCalls++
+		if rec.updatedEndpoints != nil {
+			endpoints := rec.updatedEndpoints
+			rec.updatedEndpoints = nil
+			return endpoints, nil
+		}
+
+		if rec.endpointErrReturn != nil {
+			err := rec.endpointErrReturn
+			rec.endpointErrReturn = nil
+			return nil, err
+		}
+
+		return testServer.Client(0).Endpoints(), nil
+	}
+
+	newFunc := func() (*clientv3.Client, error) {
+		rec.numNewCalls++
+		if rec.newFuncErrReturn != nil {
+			err := rec.newFuncErrReturn
+			rec.newFuncErrReturn = nil
+			return nil, err
+		}
+		return testServer.Client(0), nil
+	}
+
+	healthFunc := func(client *clientv3.Client) error {
+		rec.numHealthCalls++
+		err := rec.healthCheckErrReturn
+		rec.healthCheckErrReturn = nil
+		return err
+	}
+
+	closeFunc := func(client *clientv3.Client) error {
+		rec.numCloseCalls++
+		err := rec.closeFuncErrReturn
+		rec.closeFuncErrReturn = nil
+		return err
+	}
+
+	rec.pool = NewEtcdClientPool(newFunc, endpointFunc, healthFunc, closeFunc)
+	return rec
+}

--- a/pkg/etcdcli/etcdcli_pool_test.go
+++ b/pkg/etcdcli/etcdcli_pool_test.go
@@ -159,6 +159,7 @@ func TestNewClientWithTickets(t *testing.T) {
 	// returning one should unlock the get again
 	poolRecorder.pool.Return(clients[0])
 	client, err = poolRecorder.pool.Get()
+	require.NoError(t, err)
 	assert.NotNil(t, client)
 	assert.Equal(t, maxNumClientTickets, poolRecorder.numNewCalls)        // no new call added
 	assert.Equal(t, maxNumClientTickets+2, poolRecorder.numEndpointCalls) // called Get twice additionally
@@ -191,7 +192,7 @@ func TestClosesReturnTickets(t *testing.T) {
 	}
 	assert.Equal(t, maxNumCachedClients, poolRecorder.numCloseCalls)
 
-	// now we should be able to get the full amount of tickets again
+	// now we should be able to get the full amount of clients again
 	for i := 0; i < maxNumClientTickets; i++ {
 		client, err := poolRecorder.pool.Get()
 		require.NoError(t, err)
@@ -200,6 +201,8 @@ func TestClosesReturnTickets(t *testing.T) {
 
 	// replenish the maxNumCachedClients that were closed earlier
 	assert.Equal(t, maxNumClientTickets+maxNumCachedClients, poolRecorder.numNewCalls)
+	// no tickets are available anymore, as we have handed out all clients
+	assert.Equal(t, 0, len(poolRecorder.pool.availableTickets))
 	assert.Equal(t, maxNumClientTickets*2, poolRecorder.numEndpointCalls)
 	assert.Equal(t, maxNumClientTickets*2, poolRecorder.numHealthCalls)
 	assert.Equal(t, maxNumCachedClients, poolRecorder.numCloseCalls)
@@ -232,7 +235,7 @@ func TestClosesReturnTicketsCloseError(t *testing.T) {
 	}
 	assert.Equal(t, maxNumCachedClients, poolRecorder.numCloseCalls)
 
-	// now we should be able to get the full amount of tickets again
+	// now we should be able to get the full amount of clients again
 	for i := 0; i < maxNumClientTickets; i++ {
 		client, err := poolRecorder.pool.Get()
 		require.NoError(t, err)

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
@@ -126,6 +126,7 @@ func TestAttemptToRemoveLearningMember(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			// test data
+			eventRecorder := events.NewRecorder(fake.NewSimpleClientset().CoreV1().Events("operator"), "test-cluster-member-removal-controller", &corev1.ObjectReference{})
 			configMapTargetNSIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 			for _, initialObj := range scenario.initialObjectsForConfigMapTargetNSLister {
 				configMapTargetNSIndexer.Add(initialObj)
@@ -153,7 +154,7 @@ func TestAttemptToRemoveLearningMember(t *testing.T) {
 				masterMachineSelector:             machineSelector,
 				configMapListerForTargetNamespace: configMapTargetNSLister,
 			}
-			err = target.attemptToRemoveLearningMember(context.TODO())
+			err = target.attemptToRemoveLearningMember(context.TODO(), eventRecorder)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -368,6 +368,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		etcdClient,
 		configInformers.Config().V1().Infrastructures().Lister(),
 		controllerContext.EventRecorder,
+		kubeInformersForNamespaces,
 	)
 
 	upgradeBackupController := upgradebackupcontroller.NewUpgradeBackupController(

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -234,6 +234,13 @@ func FakeInfrastructureTopology(topologyMode configv1.TopologyMode) *configv1.In
 	}
 }
 
+func FakeConfigMap(namespace string, name string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Data:       data,
+	}
+}
+
 type FakePodLister struct {
 	PodList []*corev1.Pod
 }

--- a/vendor/github.com/stretchr/testify/assert/assertion_compare.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_compare.go
@@ -3,6 +3,7 @@ package assert
 import (
 	"fmt"
 	"reflect"
+	"time"
 )
 
 type CompareType int
@@ -30,6 +31,8 @@ var (
 	float64Type = reflect.TypeOf(float64(1))
 
 	stringType = reflect.TypeOf("")
+
+	timeType = reflect.TypeOf(time.Time{})
 )
 
 func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
@@ -299,6 +302,27 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 				return compareLess, true
 			}
 		}
+	// Check for known struct types we can check for compare results.
+	case reflect.Struct:
+		{
+			// All structs enter here. We're not interested in most types.
+			if !canConvert(obj1Value, timeType) {
+				break
+			}
+
+			// time.Time can compared!
+			timeObj1, ok := obj1.(time.Time)
+			if !ok {
+				timeObj1 = obj1Value.Convert(timeType).Interface().(time.Time)
+			}
+
+			timeObj2, ok := obj2.(time.Time)
+			if !ok {
+				timeObj2 = obj2Value.Convert(timeType).Interface().(time.Time)
+			}
+
+			return compare(timeObj1.UnixNano(), timeObj2.UnixNano(), reflect.Int64)
+		}
 	}
 
 	return compareEqual, false
@@ -310,7 +334,10 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 //    assert.Greater(t, float64(2), float64(1))
 //    assert.Greater(t, "b", "a")
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs)
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
@@ -320,7 +347,10 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //    assert.GreaterOrEqual(t, "b", "a")
 //    assert.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs)
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Less asserts that the first element is less than the second
@@ -329,7 +359,10 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //    assert.Less(t, float64(1), float64(2))
 //    assert.Less(t, "a", "b")
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs)
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
 // LessOrEqual asserts that the first element is less than or equal to the second
@@ -339,7 +372,10 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //    assert.LessOrEqual(t, "a", "b")
 //    assert.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs)
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Positive asserts that the specified element is positive
@@ -347,8 +383,11 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //    assert.Positive(t, 1)
 //    assert.Positive(t, 1.23)
 func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs)
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs...)
 }
 
 // Negative asserts that the specified element is negative
@@ -356,8 +395,11 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 //    assert.Negative(t, -1)
 //    assert.Negative(t, -1.23)
 func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs)
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs...)
 }
 
 func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {

--- a/vendor/github.com/stretchr/testify/assert/assertion_compare_can_convert.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_compare_can_convert.go
@@ -1,0 +1,16 @@
+//go:build go1.17
+// +build go1.17
+
+// TODO: once support for Go 1.16 is dropped, this file can be
+//       merged/removed with assertion_compare_go1.17_test.go and
+//       assertion_compare_legacy.go
+
+package assert
+
+import "reflect"
+
+// Wrapper around reflect.Value.CanConvert, for compatability
+// reasons.
+func canConvert(value reflect.Value, to reflect.Type) bool {
+	return value.CanConvert(to)
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_compare_legacy.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_compare_legacy.go
@@ -1,0 +1,16 @@
+//go:build !go1.17
+// +build !go1.17
+
+// TODO: once support for Go 1.16 is dropped, this file can be
+//       merged/removed with assertion_compare_go1.17_test.go and
+//       assertion_compare_can_convert.go
+
+package assert
+
+import "reflect"
+
+// Older versions of Go does not have the reflect.Value.CanConvert
+// method.
+func canConvert(value reflect.Value, to reflect.Type) bool {
+	return false
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_format.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_format.go
@@ -123,6 +123,18 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 	return ErrorAs(t, err, target, append([]interface{}{msg}, args...)...)
 }
 
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContains(t, theError, contains, append([]interface{}{msg}, args...)...)
+}
+
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {

--- a/vendor/github.com/stretchr/testify/assert/assertion_forward.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_forward.go
@@ -222,6 +222,30 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 	return ErrorAsf(a.t, err, target, msg, args...)
 }
 
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) bool {

--- a/vendor/github.com/stretchr/testify/assert/assertion_order.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_order.go
@@ -50,7 +50,7 @@ func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareT
 //    assert.IsIncreasing(t, []float{1, 2})
 //    assert.IsIncreasing(t, []string{"a", "b"})
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs)
+	return isOrdered(t, object, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
 // IsNonIncreasing asserts that the collection is not increasing
@@ -59,7 +59,7 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //    assert.IsNonIncreasing(t, []float{2, 1})
 //    assert.IsNonIncreasing(t, []string{"b", "a"})
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs)
+	return isOrdered(t, object, []CompareType{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
 // IsDecreasing asserts that the collection is decreasing
@@ -68,7 +68,7 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //    assert.IsDecreasing(t, []float{2, 1})
 //    assert.IsDecreasing(t, []string{"b", "a"})
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs)
+	return isOrdered(t, object, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
 // IsNonDecreasing asserts that the collection is not decreasing
@@ -77,5 +77,5 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //    assert.IsNonDecreasing(t, []float{1, 2})
 //    assert.IsNonDecreasing(t, []string{"a", "b"})
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs)
+	return isOrdered(t, object, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }

--- a/vendor/github.com/stretchr/testify/assert/assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/assertions.go
@@ -718,10 +718,14 @@ func NotEqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...inte
 // return (false, false) if impossible.
 // return (true, false) if element was not found.
 // return (true, true) if element was found.
-func includeElement(list interface{}, element interface{}) (ok, found bool) {
+func containsElement(list interface{}, element interface{}) (ok, found bool) {
 
 	listValue := reflect.ValueOf(list)
-	listKind := reflect.TypeOf(list).Kind()
+	listType := reflect.TypeOf(list)
+	if listType == nil {
+		return false, false
+	}
+	listKind := listType.Kind()
 	defer func() {
 		if e := recover(); e != nil {
 			ok = false
@@ -764,7 +768,7 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 		h.Helper()
 	}
 
-	ok, found := includeElement(s, contains)
+	ok, found := containsElement(s, contains)
 	if !ok {
 		return Fail(t, fmt.Sprintf("%#v could not be applied builtin len()", s), msgAndArgs...)
 	}
@@ -787,7 +791,7 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 		h.Helper()
 	}
 
-	ok, found := includeElement(s, contains)
+	ok, found := containsElement(s, contains)
 	if !ok {
 		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", s), msgAndArgs...)
 	}
@@ -831,7 +835,7 @@ func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok
 
 	for i := 0; i < subsetValue.Len(); i++ {
 		element := subsetValue.Index(i).Interface()
-		ok, found := includeElement(list, element)
+		ok, found := containsElement(list, element)
 		if !ok {
 			return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", list), msgAndArgs...)
 		}
@@ -852,7 +856,7 @@ func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) 
 		h.Helper()
 	}
 	if subset == nil {
-		return Fail(t, fmt.Sprintf("nil is the empty set which is a subset of every set"), msgAndArgs...)
+		return Fail(t, "nil is the empty set which is a subset of every set", msgAndArgs...)
 	}
 
 	subsetValue := reflect.ValueOf(subset)
@@ -875,7 +879,7 @@ func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) 
 
 	for i := 0; i < subsetValue.Len(); i++ {
 		element := subsetValue.Index(i).Interface()
-		ok, found := includeElement(list, element)
+		ok, found := containsElement(list, element)
 		if !ok {
 			return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", list), msgAndArgs...)
 		}
@@ -1000,27 +1004,21 @@ func Condition(t TestingT, comp Comparison, msgAndArgs ...interface{}) bool {
 type PanicTestFunc func()
 
 // didPanic returns true if the function passed to it panics. Otherwise, it returns false.
-func didPanic(f PanicTestFunc) (bool, interface{}, string) {
+func didPanic(f PanicTestFunc) (didPanic bool, message interface{}, stack string) {
+	didPanic = true
 
-	didPanic := false
-	var message interface{}
-	var stack string
-	func() {
-
-		defer func() {
-			if message = recover(); message != nil {
-				didPanic = true
-				stack = string(debug.Stack())
-			}
-		}()
-
-		// call the target function
-		f()
-
+	defer func() {
+		message = recover()
+		if didPanic {
+			stack = string(debug.Stack())
+		}
 	}()
 
-	return didPanic, message, stack
+	// call the target function
+	f()
+	didPanic = false
 
+	return
 }
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
@@ -1161,11 +1159,15 @@ func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs
 	bf, bok := toFloat(actual)
 
 	if !aok || !bok {
-		return Fail(t, fmt.Sprintf("Parameters must be numerical"), msgAndArgs...)
+		return Fail(t, "Parameters must be numerical", msgAndArgs...)
+	}
+
+	if math.IsNaN(af) && math.IsNaN(bf) {
+		return true
 	}
 
 	if math.IsNaN(af) {
-		return Fail(t, fmt.Sprintf("Expected must not be NaN"), msgAndArgs...)
+		return Fail(t, "Expected must not be NaN", msgAndArgs...)
 	}
 
 	if math.IsNaN(bf) {
@@ -1188,7 +1190,7 @@ func InDeltaSlice(t TestingT, expected, actual interface{}, delta float64, msgAn
 	if expected == nil || actual == nil ||
 		reflect.TypeOf(actual).Kind() != reflect.Slice ||
 		reflect.TypeOf(expected).Kind() != reflect.Slice {
-		return Fail(t, fmt.Sprintf("Parameters must be slice"), msgAndArgs...)
+		return Fail(t, "Parameters must be slice", msgAndArgs...)
 	}
 
 	actualSlice := reflect.ValueOf(actual)
@@ -1250,18 +1252,18 @@ func InDeltaMapValues(t TestingT, expected, actual interface{}, delta float64, m
 
 func calcRelativeError(expected, actual interface{}) (float64, error) {
 	af, aok := toFloat(expected)
-	if !aok {
-		return 0, fmt.Errorf("expected value %q cannot be converted to float", expected)
+	bf, bok := toFloat(actual)
+	if !aok || !bok {
+		return 0, fmt.Errorf("Parameters must be numerical")
+	}
+	if math.IsNaN(af) && math.IsNaN(bf) {
+		return 0, nil
 	}
 	if math.IsNaN(af) {
 		return 0, errors.New("expected value must not be NaN")
 	}
 	if af == 0 {
 		return 0, fmt.Errorf("expected value must have a value other than zero to calculate the relative error")
-	}
-	bf, bok := toFloat(actual)
-	if !bok {
-		return 0, fmt.Errorf("actual value %q cannot be converted to float", actual)
 	}
 	if math.IsNaN(bf) {
 		return 0, errors.New("actual value must not be NaN")
@@ -1298,7 +1300,7 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 	if expected == nil || actual == nil ||
 		reflect.TypeOf(actual).Kind() != reflect.Slice ||
 		reflect.TypeOf(expected).Kind() != reflect.Slice {
-		return Fail(t, fmt.Sprintf("Parameters must be slice"), msgAndArgs...)
+		return Fail(t, "Parameters must be slice", msgAndArgs...)
 	}
 
 	actualSlice := reflect.ValueOf(actual)
@@ -1372,6 +1374,27 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 			"expected: %q\n"+
 			"actual  : %q", expected, actual), msgAndArgs...)
 	}
+	return true
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !Error(t, theError, msgAndArgs...) {
+		return false
+	}
+
+	actual := theError.Error()
+	if !strings.Contains(actual, contains) {
+		return Fail(t, fmt.Sprintf("Error %#v does not contain %#v", actual, contains), msgAndArgs...)
+	}
+
 	return true
 }
 
@@ -1588,12 +1611,17 @@ func diff(expected interface{}, actual interface{}) string {
 	}
 
 	var e, a string
-	if et != reflect.TypeOf("") {
-		e = spewConfig.Sdump(expected)
-		a = spewConfig.Sdump(actual)
-	} else {
+
+	switch et {
+	case reflect.TypeOf(""):
 		e = reflect.ValueOf(expected).String()
 		a = reflect.ValueOf(actual).String()
+	case reflect.TypeOf(time.Time{}):
+		e = spewConfigStringerEnabled.Sdump(expected)
+		a = spewConfigStringerEnabled.Sdump(actual)
+	default:
+		e = spewConfig.Sdump(expected)
+		a = spewConfig.Sdump(actual)
 	}
 
 	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
@@ -1622,6 +1650,14 @@ var spewConfig = spew.ConfigState{
 	DisableCapacities:       true,
 	SortKeys:                true,
 	DisableMethods:          true,
+	MaxDepth:                10,
+}
+
+var spewConfigStringerEnabled = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
 	MaxDepth:                10,
 }
 

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -280,6 +280,36 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 	t.FailNow()
 }
 
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContains(t, theError, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContainsf(t, theError, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -223,6 +223,30 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 	ErrorAsf(a.t, err, target, msg, args...)
 }
 
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -362,7 +362,7 @@ github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
 ## explicit; go 1.12
 github.com/spf13/pflag
-# github.com/stretchr/testify v1.7.0
+# github.com/stretchr/testify v1.7.1
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require


### PR DESCRIPTION
there is a bug while caching the client, the order in which the endpoints are returned is not deterministic. That causes the cache client to be constantly created from scratch and invalidating the old (potentially while in use). 

the new client works in a pooling fashion, which handles the mutual exclusiveness of returning an existing or newly created client. HealthCheck+Member updates are handled during the retrieval, so is the close. Once a consumer is done, they simply return the client to the pool. 

added some more additional logging as well.