### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/0000_20_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_20_etcd-operator_06_deployment.yaml
@@ -24,9 +24,18 @@ spec:
       labels:
         app: etcd-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: etcd-operator
       containers:
       - name: etcd-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         image: quay.io/openshift/origin-cluster-etcd-operator
         imagePullPolicy: IfNotPresent
         ports:


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-etcd-operator/deployments/etcd-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"etcd-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities
 (container \"etcd-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"etcd-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"etcd-operator\" must se
t securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

Note: This is blocked until https://github.com/openshift/cluster-kube-apiserver-operator/pull/1338 merges.

/cc @stlaz 