### PR TITLE
RFE-2703: add prometheus rules for etcd memory usage

### DIFF
--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -188,3 +188,25 @@ spec:
       for: 3m
       labels:
         severity: critical
+    - alert: etcdHighMemoryUsageInfo
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": memory usage of {{ $value }} on
+        {{ $labels.node }} exceeds 40%. Etcd pods memory starvation could result
+        in degraded performance of the cluster.'
+        summary: etcd pod memory usage info.
+      expr: |
+        ((sum(node_memory_MemTotal_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) - sum(node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" ))) / sum(node_memory_MemTotal_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) * 100) > 40
+      for: 10m
+      labels:
+        severity: info
+    - alert: etcdHighMemoryUsageWarn
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": memory usage of {{ $value }} on
+        {{ $labels.node }} exceeds 60%. Etcd pods memory starvation could result
+        in degraded performance of the cluster.'
+        summary: etcd pod memory usage warning.
+      expr: |
+        ((sum(node_memory_MemTotal_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) - sum(node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" ))) / sum(node_memory_MemTotal_bytes AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )) * 100) > 60
+      for: 10m
+      labels:
+        severity: warning


### PR DESCRIPTION
This PR add two prometheus rules for etcd memory usage. 

First alert `etcdHighMemoryUsageInfo` is fired once the memory usage of the master node exceeds 40% as info level.
Second alert `etcdHighMemoryUsageWarn` is fired once the memory usage of the master node exceeds 60% as warn level.