### PR TITLE
test utils changes the way endpoints data key is calculated

### DIFF
--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -194,7 +194,7 @@ func WithEndpoint(memberID uint64, peerURl string) func(*corev1.ConfigMap) {
 		panic(err)
 	}
 	return func(endpoints *corev1.ConfigMap) {
-		endpoints.Data[fmt.Sprintf("%016x", memberID)] = ip
+		endpoints.Data[fmt.Sprintf("%x", memberID)] = ip
 	}
 }
 


### PR DESCRIPTION
after this change, the formatting matches the one used by the endpoints controller

it caused the following tests to fail occasionally:
```
FAIL: github.com/openshift/cluster-etcd-operator/pkg/operator/etcdendpointscontroller TestBootstrapAnnotationRemoval/NewConfigMapAfterDeletion 0s
FAIL: github.com/openshift/cluster-etcd-operator/pkg/operator/etcdendpointscontroller TestBootstrapAnnotationRemoval/NewClusterBootstrapRemoval 0s
FAIL: github.com/openshift/cluster-etcd-operator/pkg/operator/etcdendpointscontroller TestBootstrapAnnotationRemoval/NewClusterBootstrapNodesProgressing 0s
FAIL: github.com/openshift/cluster-etcd-operator/pkg/operator/etcdendpointscontroller TestBootstrapAnnotationRemoval/NewClusterBootstrapProgressing 0s
FAIL: github.com/openshift/cluster-etcd-operator/pkg/operator/etcdendpointscontroller TestBootstrapAnnotationRemoval/NewClusterSteadyState 0s
FAIL: github.com/openshift/cluster-etcd-operator/pkg/operator/etcdendpointscontroller TestBootstrapAnnotationRemoval/UpgradedClusterCreateConfigmap 0s
FAIL: github.com/openshift/cluster-etcd-operator/pkg/operator/etcdendpointscontroller TestBootstrapAnnotationRemoval 20ms
```