### PR TITLE
Bug 2077160: Adding Thomas to reviewers and me to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,9 +6,10 @@ reviewers:
   - hasbro17
   - EmilyM1
   - Elbehery
+  - tjungblu
 approvers:
   - deads2k
   - hasbro17
-  - hexfusion
   - sttts
+  - dusk125
 component: "Etcd"


### PR DESCRIPTION
@tjungblu needs review permissions

~~Adding the rest of the etcd team to approvers under the agreement that, except for very minor/insignificant changes, the person who lgtm will not also approve and vice-versa.~~
We found that adding everyone to approvers essentially makes it so there's only one required reviewer instead of two for each change. Adding myself to approvers to limit bottlenecks for now.