### PR TITLE
Add config for golangci-lint no-sprintf-host-port 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+linters:
+  disable-all: true
+  enable:
+    - nosprintfhostport
+  presets: []
+  fast: true

--- a/pkg/dnshelpers/util.go
+++ b/pkg/dnshelpers/util.go
@@ -24,18 +24,6 @@ func GetEscapedPreferredInternalIPAddressForNodeName(network *configv1.Network, 
 	}
 }
 
-func GetURLHostForIP(ip string) (string, error) {
-	isIPV4, err := IsIPv4(ip)
-	if err != nil {
-		return "", err
-	}
-	if isIPV4 {
-		return ip, nil
-	}
-
-	return "[" + ip + "]", nil
-}
-
 // GetPreferredInternalIPAddressForNodeName returns the first internal ip address of the correct family and the family
 func GetPreferredInternalIPAddressForNodeName(network *configv1.Network, node *corev1.Node) (string, string, error) {
 	ipFamily, err := GetPreferredIPFamily(network)


### PR DESCRIPTION
This enables a single linter for now. Once this merges,  I'll setup the
lint job.

This enables the [no-sprintf-host-port](https://github.com/stbenjam/no-sprintf-host-port) linter to prevent URL
constructions that are incompatible with IPv6. These breakages
are [common in this repo](https://github.com/openshift/cluster-etcd-operator/pulls?q=is%3Apr+ipv6+bracket+is%3Aclosed+).

The Go linter no-sprintf-host-port checks that sprintf is not used to
construct a host:port combination in a URL. A frequent pattern is for a
developer to construct a URL like this:

```go
fmt.Sprintf("http://%s:%d/foo", host, port)
```

However, if "host" is an IPv6 address like `2001:4860:4860::8888`, the
URL constructed will be invalid. IPv6 addresses must be bracketed, like this:

```
http://[2001:4860:4860::8888]:9443
```