### PR TITLE
Bug 2087983: remove etcd_perf before restore

### DIFF
--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -26,6 +26,11 @@ spec:
         env | grep ETCD | grep -v NODE
         export ETCD_NODE_PEER_URL=https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:2380
 
+        # checking if there are any fio perf file left behind that could be deleted without problems
+        if [ ! -z $(ls -A "/var/lib/etcd/etcd_perf*") ]; then
+          rm -f /var/lib/etcd/etcd_perf*
+        fi
+
         # checking if data directory is empty, if not etcdctl restore will fail
         if [ ! -z $(ls -A "/var/lib/etcd") ]; then
           echo "please delete the contents of data directory before restoring, running the restore script will do this for you"

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1007,6 +1007,11 @@ spec:
         env | grep ETCD | grep -v NODE
         export ETCD_NODE_PEER_URL=https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:2380
 
+        # checking if there are any fio perf file left behind that could be deleted without problems
+        if [ ! -z $(ls -A "/var/lib/etcd/etcd_perf*") ]; then
+          rm -f /var/lib/etcd/etcd_perf*
+        fi
+
         # checking if data directory is empty, if not etcdctl restore will fail
         if [ ! -z $(ls -A "/var/lib/etcd") ]; then
           echo "please delete the contents of data directory before restoring, running the restore script will do this for you"


### PR DESCRIPTION
This commit deletes "etcd_perf" files that could present if someone has ran a fio test under /var/lib/etcd
like specified in the OpenShift docs about the recommended host practices.

As this file is known as non essential, it could be freely deleted by anticipation by the restore pod when
restoring a cluster to a previous state.