### PR TITLE
[release-4.9] Bug 2086119: Add summary to etcd alert rules

### DIFF
--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -100,7 +100,10 @@ spec:
         severity: warning
     - alert: etcdBackendQuotaLowSpace
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        summary: etcd cluster database size exceeds the defined quota.
+        description: 'etcd cluster "{{ $labels.job }}": database size exceeds the
+          defined quota on etcd instance {{ $labels.instance }}, please defrag or
+          increase the quota as the writes to etcd will be disabled when it is full.'
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdBackendQuotaLowSpace.md
       expr: |
         (etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100 > 95
@@ -109,7 +112,10 @@ spec:
         severity: critical
     - alert: etcdExcessiveDatabaseGrowth
       annotations:
-        description: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes leading to 50% increase in database size over the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        summary: etcd cluster database size increased by 50 percent over the past four hours.
+        description: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes
+          leading to 50% increase in database size over the past four hours on etcd
+          instance {{ $labels.instance }}, please check as it might be disruptive.'
       expr: |
         increase(((etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100)[240m:1m]) > 50
       for: 10m


### PR DESCRIPTION
This PR adds summary to etcd alert rules.

According to [Enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#style-guide), all prometheus alerts should have Summary and Description.