### PR TITLE
Bug 2083942: Exclude learners from etcdclient

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+linters:
+  disable-all: true
+  enable:
+    - nosprintfhostport
+  presets: []
+  fast: true

--- a/pkg/dnshelpers/util.go
+++ b/pkg/dnshelpers/util.go
@@ -24,18 +24,6 @@ func GetEscapedPreferredInternalIPAddressForNodeName(network *configv1.Network, 
 	}
 }
 
-func GetURLHostForIP(ip string) (string, error) {
-	isIPV4, err := IsIPv4(ip)
-	if err != nil {
-		return "", err
-	}
-	if isIPV4 {
-		return ip, nil
-	}
-
-	return "[" + ip + "]", nil
-}
-
 // GetPreferredInternalIPAddressForNodeName returns the first internal ip address of the correct family and the family
 func GetPreferredInternalIPAddressForNodeName(network *configv1.Network, node *corev1.Node) (string, string, error) {
 	ipFamily, err := GetPreferredIPFamily(network)


### PR DESCRIPTION
Basically we consider the `etcd-endpoints` configmap the source of truth, which doesn't include the learners. When we can't get it, we fall back to listing nodes again.

Also adding in the net.join changes from #820 while I'm changing the lines around it.