### PR TITLE
Bug 2085997: brings back initial delay seconds to the previous value

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -197,7 +197,7 @@ ${COMPUTED_ENV_VARS}
         port: 9980
         path: readyz
         scheme: HTTPS
-      initialDelaySeconds: 180
+      initialDelaySeconds: 10
       timeoutSeconds: 10
       failureThreshold: 3
       periodSeconds: 5

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -795,7 +795,7 @@ ${COMPUTED_ENV_VARS}
         port: 9980
         path: readyz
         scheme: HTTPS
-      initialDelaySeconds: 180
+      initialDelaySeconds: 10
       timeoutSeconds: 10
       failureThreshold: 3
       periodSeconds: 5


### PR DESCRIPTION
reverts https://github.com/openshift/cluster-etcd-operator/pull/838/commits/138a12c7e07e98840cb23d1b2708a39a47f6e0e9