### PR TITLE
Bug 2085997: defines a startupProbe for etcd container

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -197,11 +197,20 @@ ${COMPUTED_ENV_VARS}
         port: 9980
         path: readyz
         scheme: HTTPS
-      initialDelaySeconds: 10
       timeoutSeconds: 10
       failureThreshold: 3
       periodSeconds: 5
       successThreshold: 1
+    startupProbe:
+      httpGet:
+        port: 9980
+        path: readyz
+        scheme: HTTPS
+      initialDelaySeconds: 10
+      timeoutSeconds: 1
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 18
     securityContext:
       privileged: true
     volumeMounts:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -795,11 +795,20 @@ ${COMPUTED_ENV_VARS}
         port: 9980
         path: readyz
         scheme: HTTPS
-      initialDelaySeconds: 10
       timeoutSeconds: 10
       failureThreshold: 3
       periodSeconds: 5
       successThreshold: 1
+    startupProbe:
+      httpGet:
+        port: 9980
+        path: readyz
+        scheme: HTTPS
+      initialDelaySeconds: 10
+      timeoutSeconds: 1
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 18
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
The kubelet uses startup probes to know when a container application has started. Once a probe is configured, it disables liveness and readiness checks until it succeeds.

We give the etcd container a three-minute wait with a 10s startup time minimum (initial delay).