### PR TITLE
fix partial update cluster version

### DIFF
--- a/pkg/operator/ceohelpers/common.go
+++ b/pkg/operator/ceohelpers/common.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/klog/v2"
 	"net"
 	"net/url"
 
@@ -188,5 +189,6 @@ func GetCurrentClusterVersion(cv *configv1.ClusterVersion) (string, error) {
 			return c.Version, nil
 		}
 	}
-	return "", fmt.Errorf("unable to retrieve cluster version, no completed update was found in cluster version status history: %v", cv.Status.History)
+	klog.Warningf("unable to retrieve cluster version, no completed update was found in cluster version status history: %v", cv.Status.History)
+	return "", nil
 }


### PR DESCRIPTION
This PR fixes a bug from https://github.com/openshift/cluster-etcd-operator/pull/835

When the ClusterVersion does not contain `CompletedUpdate` condition, the UpgradeBackup operator goes degraded.
This PR replaces Error with a warning, to avoid going degraded in CI environment.