### PR TITLE
[Bug 2090929] cluster-backup.sh script has a conflict to use the '/etc/kubernetes/static-pod-certs' folder if a custom API certificate is defined

### DIFF
--- a/bindata/etcd/cluster-backup.sh
+++ b/bindata/etcd/cluster-backup.sh
@@ -104,9 +104,18 @@ trap 'rm -f ${BACKUP_TAR_FILE} ${SNAPSHOT_FILE}' ERR
 source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
 source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
 
-# TODO handle properly
-if [ ! -f "$ETCDCTL_CACERT" ] && [ ! -d "${CONFIG_FILE_DIR}/static-pod-certs" ]; then
-  ln -s "${CONFIG_FILE_DIR}"/static-pod-resources/etcd-certs "${CONFIG_FILE_DIR}"/static-pod-certs
+# replacing the value of variables sourced form etcd.env to use the local node folders if the script is not running into the cluster-backup pod
+if [ ! -f "${ETCDCTL_CACERT}" ]; then
+  echo "Certificate ${ETCDCTL_CACERT} is missing. Checking in different directory"
+  export ETCDCTL_CACERT=$(echo ${ETCDCTL_CACERT} | sed -e "s|static-pod-certs|static-pod-resources/etcd-certs|")
+  export ETCDCTL_CERT=$(echo ${ETCDCTL_CERT} | sed -e "s|static-pod-certs|static-pod-resources/etcd-certs|")
+  export ETCDCTL_KEY=$(echo ${ETCDCTL_KEY} | sed -e "s|static-pod-certs|static-pod-resources/etcd-certs|")
+  if [ ! -f "${ETCDCTL_CACERT}" ]; then
+    echo "Certificate ${ETCDCTL_CACERT} is also missing in the second directory. Exiting!"
+    exit 1
+  else
+    echo "Certificate ${ETCDCTL_CACERT} found!"
+  fi
 fi
 
 backup_latest_kube_static_resources "${BACKUP_TAR_FILE}"


### PR DESCRIPTION
Create PR from BZ 2090929, which I've created.

I've noticed that the script can be called from the pod cluster-backup-pod.yaml, so kept the test about `${ETCDCTL_CACERT}`, which should work within the pod.

Breaking the script if certificate `${ETCDCTL_CACERT}` is still missing after the variable update.

Tested in one of the quicklab cluster:
~~~
sh-4.4# /usr/local/bin/cluster-backup.sh /home/core/assets/backup
Certificate /etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt is missing. Checking in different directory
Certificate /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-serving-ca/ca-bundle.crt found!
found latest kube-apiserver: /etc/kubernetes/static-pod-resources/kube-apiserver-pod-13
found latest kube-controller-manager: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-6
found latest kube-scheduler: /etc/kubernetes/static-pod-resources/kube-scheduler-pod-6
found latest etcd: /etc/kubernetes/static-pod-resources/etcd-pod-7
etcdctl is already installed
{"level":"info","ts":1654144693.4069068,"caller":"snapshot/v3_snapshot.go:68","msg":"created temporary db file","path":"/home/core/assets/backup/snapshot_2022-06-02_043812.db.part"}
{"level":"info","ts":1654144693.4192934,"logger":"client","caller":"v3/maintenance.go:211","msg":"opened snapshot stream; downloading"}
{"level":"info","ts":1654144693.4193556,"caller":"snapshot/v3_snapshot.go:76","msg":"fetching snapshot","endpoint":"https://10.0.90.68:2379"}
{"level":"info","ts":1654144695.8325534,"logger":"client","caller":"v3/maintenance.go:219","msg":"completed snapshot read; closing"}
{"level":"info","ts":1654144696.3401666,"caller":"snapshot/v3_snapshot.go:91","msg":"fetched snapshot","endpoint":"https://10.0.90.68:2379","size":"279 MB","took":"2 seconds ago"}
{"level":"info","ts":1654144696.34038,"caller":"snapshot/v3_snapshot.go:100","msg":"saved","path":"/home/core/assets/backup/snapshot_2022-06-02_043812.db"}
Snapshot saved at /home/core/assets/backup/snapshot_2022-06-02_043812.db
Deprecated: Use `etcdutl snapshot status` instead.

{"hash":1062198468,"revision":2940340,"totalKey":28021,"totalSize":279216128}
snapshot db and kube resources are successfully saved to /home/core/assets/backup
~~~