### PR TITLE
Bug 2097431: fix degraded missing cluster version

### DIFF
--- a/pkg/operator/ceohelpers/common.go
+++ b/pkg/operator/ceohelpers/common.go
@@ -6,8 +6,6 @@ import (
 	"net"
 	"net/url"
 
-	configv1 "github.com/openshift/api/config/v1"
-
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
@@ -179,16 +177,4 @@ func VotingMemberIPListSet(configMapLister corev1listers.ConfigMapNamespaceListe
 	}
 
 	return currentVotingMemberIPListSet, nil
-}
-
-func GetCurrentClusterVersion(cv *configv1.ClusterVersion) (string, error) {
-	if cv == nil {
-		return "", fmt.Errorf("ClusterVersion is nil: %v", cv)
-	}
-	for _, c := range cv.Status.History {
-		if c.State == configv1.CompletedUpdate {
-			return c.Version, nil
-		}
-	}
-	return "", fmt.Errorf("unable to retrieve cluster version, no completed update was found in cluster version status history: %v", cv.Status.History)
 }

--- a/pkg/operator/upgradebackupcontroller/upgradebackupcontroller.go
+++ b/pkg/operator/upgradebackupcontroller/upgradebackupcontroller.go
@@ -3,7 +3,7 @@ package upgradebackupcontroller
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
+	"github.com/openshift/library-go/pkg/operator/status"
 	"strings"
 	"time"
 
@@ -161,10 +161,7 @@ func (c *UpgradeBackupController) ensureRecentBackup(ctx context.Context, cluste
 		return nil, err
 	}
 
-	currentVersion, err := ceohelpers.GetCurrentClusterVersion(clusterVersion)
-	if err != nil {
-		return nil, err
-	}
+	currentVersion := status.VersionForOperatorFromEnv()
 
 	// Check cluster version status for backup condition.
 	if !isRequireRecentBackup(clusterVersion, clusterOperatorStatus) {
@@ -342,11 +339,10 @@ func isBackupConditionExist(conditions []configv1.ClusterOperatorStatusCondition
 }
 
 func isNewBackupRequired(config *configv1.ClusterVersion, clusterOperatorStatus *configv1.ClusterOperatorStatus) (bool, error) {
-	currentVersion, err := ceohelpers.GetCurrentClusterVersion(config)
-	if err != nil {
-		return false, err
+	currentVersion := status.VersionForOperatorFromEnv()
+	if currentVersion == "" {
+		return false, nil
 	}
-
 	// check in ClusterVersion update history for update in progress (i.e. state: Partial)
 	// then check the condition of etcd operator
 	// if backup for current cluster version was taken, return false

--- a/pkg/operator/upgradebackupcontroller/upgradebackupcontroller_test.go
+++ b/pkg/operator/upgradebackupcontroller/upgradebackupcontroller_test.go
@@ -123,8 +123,7 @@ func Test_ensureRecentBackup(t *testing.T) {
 				Conditions: []configv1.ClusterOperatorStatusCondition{
 					{Type: backupConditionType, Reason: backupSuccess, Message: "UpgradeBackup pre 4.9 located at path "}},
 			},
-			wantBackupStatus: configv1.ConditionUnknown,
-			wantEventCount:   1, // pod created event
+			wantNilBackupCondition: true,
 		},
 		{
 			name: "RecentBackup not required, backup exist for current version",


### PR DESCRIPTION
Fix going degraded on missing cluster version. 

As a result of https://github.com/openshift/cluster-etcd-operator/pull/835, the `Backupupgrade` controller while detecting the cluster version, during install and upgrade, raises an error and goes degraded. Such noise is not needed. 

