### PR TITLE
Bug 1884568: Add etcd pod liveness probe

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -201,6 +201,15 @@ ${COMPUTED_ENV_VARS}
       failureThreshold: 3
       periodSeconds: 5
       successThreshold: 1
+    livenessProbe:
+      httpGet:
+        path: healthz
+        port: 9980
+        scheme: HTTPS
+      timeoutSeconds: 10
+      periodSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
     startupProbe:
       httpGet:
         port: 9980

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -808,6 +808,15 @@ ${COMPUTED_ENV_VARS}
       failureThreshold: 3
       periodSeconds: 5
       successThreshold: 1
+    livenessProbe:
+      httpGet:
+        path: healthz
+        port: 9980
+        scheme: HTTPS
+      timeoutSeconds: 10
+      periodSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
     startupProbe:
       httpGet:
         port: 9980


### PR DESCRIPTION
This PR adds a liveness probe to etcd pod yaml. 

Currently the etcd cluster considered to be `healthy` if the `etcdctl cluster-health` cmd returns some unhealthy members, while maintaining the quorum. On the other hand, the cmd considers the cluster `unhealthy`, if any of the members is `unreachable`. 

In OCP, we need to detect if a etcd process is not functioning. Currently etcd-container within etcd-pod is being restarted by kubelet when it is not running (e.g. SIGKILL). This PRs adds a liveness probe to detect when etcd process is not functioning (e.g. SIGSTOP). 