### PR TITLE
Exits with a non-zero code in case Etcd backup fails

### DIFF
--- a/bindata/etcd/cluster-backup.sh
+++ b/bindata/etcd/cluster-backup.sh
@@ -126,5 +126,11 @@ ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot sa
 
 # Check the integrity of the snapshot
 check_snapshot_status "${SNAPSHOT_FILE}"
+snapshot_failed=$?
+
+# If check_snapshot_status returned 1 it failed, so exit with code 1
+if [[ $snapshot_failed -eq 1 ]]; then
+  exit 1
+fi
 
 echo "snapshot db and kube resources are successfully saved to ${BACKUP_DIR}"

--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -42,7 +42,6 @@ function check_snapshot_status() {
   local snap_file="$1"
   if ! etcdctl snapshot status "${snap_file}" -w json; then
     echo "Backup integrity verification failed. Backup appears corrupted. Aborting!"
-    exit 1
   fi
 }
 

--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -42,7 +42,7 @@ function check_snapshot_status() {
   local snap_file="$1"
   if ! etcdctl snapshot status "${snap_file}" -w json; then
     echo "Backup integrity verification failed. Backup appears corrupted. Aborting!"
-    return 1
+    exit 1
   fi
 }
 

--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -42,6 +42,7 @@ function check_snapshot_status() {
   local snap_file="$1"
   if ! etcdctl snapshot status "${snap_file}" -w json; then
     echo "Backup integrity verification failed. Backup appears corrupted. Aborting!"
+    return 1
   fi
 }
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -535,6 +535,7 @@ function check_snapshot_status() {
   local snap_file="$1"
   if ! etcdctl snapshot status "${snap_file}" -w json; then
     echo "Backup integrity verification failed. Backup appears corrupted. Aborting!"
+    return 1
   fi
 }
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -296,6 +296,12 @@ ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot sa
 
 # Check the integrity of the snapshot
 check_snapshot_status "${SNAPSHOT_FILE}"
+snapshot_failed=$?
+
+# If check_snapshot_status returned 1 it failed, so exit with code 1
+if [[ $snapshot_failed -eq 1 ]]; then
+  exit 1
+fi
 
 echo "snapshot db and kube resources are successfully saved to ${BACKUP_DIR}"
 `)
@@ -529,7 +535,6 @@ function check_snapshot_status() {
   local snap_file="$1"
   if ! etcdctl snapshot status "${snap_file}" -w json; then
     echo "Backup integrity verification failed. Backup appears corrupted. Aborting!"
-    return 1
   fi
 }
 


### PR DESCRIPTION
So cluster-backup.sh exits with non-zero and this return code is usable for monitoring purposes.