### PR TITLE
remove etcd-health-monitor sidecar from pod manifest

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -271,41 +271,6 @@ ${COMPUTED_ENV_VARS}
         name: cert-dir
       - mountPath: /var/lib/etcd/
         name: data-dir
-  - name: etcd-health-monitor
-    image: ${OPERATOR_IMAGE}
-    imagePullPolicy: IfNotPresent
-    terminationMessagePolicy: FallbackToLogsOnError
-    command: [ "cluster-etcd-operator", "monitor" ]
-    args:
-      - --targets=$(ETCDCTL_ENDPOINTS)
-      - --probe-interval=1s
-      - --log-outputs=stderr
-      - --log-outputs=/var/log/etcd/etcd-health-probe.log
-      - --enable-log-rotation
-      - --pod-name=$(POD_NAME)
-      - --static-pod-version=$(ETCD_STATIC_POD_VERSION)
-      - --cert-file=$(ETCDCTL_CERT)
-      - --key-file=$(ETCDCTL_KEY)
-      - --cacert-file=$(ETCDCTL_CACERT)
-    env:
-${COMPUTED_ENV_VARS}
-      - name: "ETCD_STATIC_POD_VERSION"
-        value: "REVISION"
-      - name: "OPENSHIFT_PROFILE"
-        value: "web"
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-    volumeMounts:
-      - mountPath: /var/log/etcd/
-        name: log-dir
-      - mountPath: /etc/kubernetes/static-pod-certs
-        name: cert-dir
-    resources:
-      requests:
-        memory: 70Mi
-        cpu: 50m
   - name: etcd-readyz
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -878,41 +878,6 @@ ${COMPUTED_ENV_VARS}
         name: cert-dir
       - mountPath: /var/lib/etcd/
         name: data-dir
-  - name: etcd-health-monitor
-    image: ${OPERATOR_IMAGE}
-    imagePullPolicy: IfNotPresent
-    terminationMessagePolicy: FallbackToLogsOnError
-    command: [ "cluster-etcd-operator", "monitor" ]
-    args:
-      - --targets=$(ETCDCTL_ENDPOINTS)
-      - --probe-interval=1s
-      - --log-outputs=stderr
-      - --log-outputs=/var/log/etcd/etcd-health-probe.log
-      - --enable-log-rotation
-      - --pod-name=$(POD_NAME)
-      - --static-pod-version=$(ETCD_STATIC_POD_VERSION)
-      - --cert-file=$(ETCDCTL_CERT)
-      - --key-file=$(ETCDCTL_KEY)
-      - --cacert-file=$(ETCDCTL_CACERT)
-    env:
-${COMPUTED_ENV_VARS}
-      - name: "ETCD_STATIC_POD_VERSION"
-        value: "REVISION"
-      - name: "OPENSHIFT_PROFILE"
-        value: "web"
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-    volumeMounts:
-      - mountPath: /var/log/etcd/
-        name: log-dir
-      - mountPath: /etc/kubernetes/static-pod-certs
-        name: cert-dir
-    resources:
-      requests:
-        memory: 70Mi
-        cpu: 50m
   - name: etcd-readyz
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This PR removes `etcd-health-monitor` side-car from Etcd Pod manifest. 

During https://github.com/openshift/cluster-etcd-operator/pull/869, we have found out that the `etcd-health-monitor` side car is of no use. Therefore, removing it. 