### PR TITLE
fixing metrics proxy log spam

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -248,6 +248,7 @@ ${COMPUTED_ENV_VARS}
           --endpoints https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:9978 \
           --metrics-addr https://${LISTEN_ON_ALL_IPS}:9979 \
           --listen-addr ${LOCALHOST_IP}:9977 \
+          --advertise-client-url ""  \
           --key /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key \
           --key-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.key \
           --cert /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt \

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -855,6 +855,7 @@ ${COMPUTED_ENV_VARS}
           --endpoints https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:9978 \
           --metrics-addr https://${LISTEN_ON_ALL_IPS}:9979 \
           --listen-addr ${LOCALHOST_IP}:9977 \
+          --advertise-client-url ""  \
           --key /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key \
           --key-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.key \
           --cert /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt \


### PR DESCRIPTION
From customer on slack: 

I can observe on all OCP 4.10 cluster that the etcd-metrics container is flooding logs with a connection to a port which does not listening on any etcd container.
```
{"level":"info","ts":"2022-06-22T12:59:19.139Z","caller":"zapgrpc/zapgrpc.go:174","msg":"[core] Subchannel picks a new address \"127.0.0.1:23790\" to connect"}
{"level":"warn","ts":"2022-06-22T12:59:19.146Z","caller":"zapgrpc/zapgrpc.go:191","msg":"[core] grpc: addrConn.createTransport failed to connect to {127.0.0.1:23790 127.0.0.1 <nil> 0 <nil>}. Err: connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:23790: connect: connection refused\". Reconnecting..."}
```

there's a typo in the pod yaml, with an excessive "s" it uses the default value from:
https://github.com/etcd-io/etcd/blob/main/server/etcdmain/grpc_proxy.go#L130

which is not able to connect to anywhere.
edit: not a typo, but just not supplied. Supplying an empty string will disable the client, as we don't make use of the health probes on that container that should be alright.