### PR TITLE
Bug 2106044: Fix etcd minor upgrade backup

### DIFF
--- a/pkg/operator/upgradebackupcontroller/upgradebackupcontroller.go
+++ b/pkg/operator/upgradebackupcontroller/upgradebackupcontroller.go
@@ -351,7 +351,7 @@ func isNewBackupRequired(config *configv1.ClusterVersion, clusterOperatorStatus 
 		if update.State == configv1.PartialUpdate {
 			klog.V(4).Infof("in progress update is detected, cluster current version is %v, progressing towards cluster version %v", currentVersion, update.Version)
 			currentBackupVersion := getCurrentBackupVersion(clusterOperatorStatus)
-			if currentBackupVersion == "" || currentBackupVersion == currentVersion {
+			if currentBackupVersion == currentVersion {
 				return false, nil
 			}
 			if cmp := version.CompareSimple(update.Version, currentVersion); cmp > 0 {


### PR DESCRIPTION
This PR ensure minor OCP upgrades result in cluster backup. 

Currently during testing, an upgrade from 4.10.18 -> 4.10.20 did not result in backup taken. This PR fixes this behaviour and ensure a backup is taken as a result of any OCP upgrade.