### PR TITLE
Bug 2089199: Remove etcd dashboards from Hypershift

### DIFF
--- a/jsonnet/dashboard.jsonnet
+++ b/jsonnet/dashboard.jsonnet
@@ -5,7 +5,6 @@ local etcdMixin = (import 'github.com/etcd-io/etcd/contrib/mixin/mixin.libsonnet
   kind: 'ConfigMap',
   metadata: {
     annotations: {
-      'include.release.openshift.io/ibm-cloud-managed': 'true',
       'include.release.openshift.io/self-managed-high-availability': 'true',
       'include.release.openshift.io/single-node-developer': 'true',
     },

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "b75aa3eb4ccca7f719e7b43969e0796c8224eaed",
+      "version": "e087c349e120be98a27790ac434832df0a54b2a2",
       "sum": "IkDHlaE0gvvcPjSNurFT+jQ2aCOAbqHF1WVmXbAgkds="
     }
   ],

--- a/manifests/0000_20_etcd-operator_00_namespace.yaml
+++ b/manifests/0000_20_etcd-operator_00_namespace.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""

--- a/manifests/0000_20_etcd-operator_01_operator.cr.yaml
+++ b/manifests/0000_20_etcd-operator_01_operator.cr.yaml
@@ -3,7 +3,6 @@ kind: Etcd
 metadata:
   name: cluster
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/manifests/0000_20_etcd-operator_02_service.yaml
+++ b/manifests/0000_20_etcd-operator_02_service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: etcd-operator-serving-cert

--- a/manifests/0000_20_etcd-operator_03_configmap.yaml
+++ b/manifests/0000_20_etcd-operator_03_configmap.yaml
@@ -4,7 +4,6 @@ metadata:
   namespace: openshift-etcd-operator
   name: etcd-operator-config
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 data:
@@ -16,7 +15,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
@@ -27,7 +25,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/manifests/0000_20_etcd-operator_03_secret.yaml
+++ b/manifests/0000_20_etcd-operator_03_secret.yaml
@@ -3,7 +3,6 @@ kind: Secret
 type: SecretTypeTLS
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/manifests/0000_20_etcd-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_20_etcd-operator_04_clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   name: system:openshift:operator:etcd-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:

--- a/manifests/0000_20_etcd-operator_05_serviceaccount.yaml
+++ b/manifests/0000_20_etcd-operator_05_serviceaccount.yaml
@@ -4,6 +4,5 @@ metadata:
   namespace: openshift-etcd-operator
   name: etcd-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_20_etcd-operator_10_flowschema.yaml
+++ b/manifests/0000_20_etcd-operator_10_flowschema.yaml
@@ -3,7 +3,6 @@ kind: FlowSchema
 metadata:
   name: openshift-etcd-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/0000_90_cluster-etcd-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-etcd-operator_01-dashboards.yaml
@@ -1352,7 +1352,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:

--- a/manifests/0000_90_etcd-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_etcd-operator_01_prometheusrole.yaml
@@ -5,7 +5,6 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-etcd-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:

--- a/manifests/0000_90_etcd-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_90_etcd-operator_02_prometheusrolebinding.yaml
@@ -4,7 +4,6 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-etcd-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:

--- a/manifests/0000_90_etcd-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_etcd-operator_03_servicemonitor.yaml
@@ -4,7 +4,6 @@ metadata:
   name: etcd-operator
   namespace: openshift-etcd-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:


### PR DESCRIPTION
This PR removes the grafana etcd-dashboard from Hypershift. 

https://github.com/openshift/cluster-etcd-operator/pull/837 was merged, and it moves the dashboard to CEO, to be removed automatically from Hypershift releases. However, QA identified the dashboard still exist. The annotation `include.release.openshift.io/ibm-cloud-managed` need to be removed from the etcd-dashboard ConfigMap. 