### PR TITLE
[RELEASE-4.10] Bug 2095667: Etcd readiness probe leaves many zombie process after heavy load

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -193,15 +193,13 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      httpGet:
-        port: 9980
-        path: readyz
-        scheme: HTTPS
-      initialDelaySeconds: 10
-      timeoutSeconds: 10
-      failureThreshold: 3
-      periodSeconds: 5
-      successThreshold: 1
+    tcpSocket:
+    port: 2380
+    failureThreshold: 3
+    initialDelaySeconds: 3
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 5
     livenessProbe:
       httpGet:
         path: healthz

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -193,13 +193,15 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-    tcpSocket:
-    port: 2380
-    failureThreshold: 3
-    initialDelaySeconds: 3
-    periodSeconds: 5
-    successThreshold: 1
-    timeoutSeconds: 5
+      httpGet:
+        port: 9980
+        path: readyz
+        scheme: HTTPS
+      failureThreshold: 3
+      initialDelaySeconds: 3
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 5
     livenessProbe:
       httpGet:
         path: healthz

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -93,8 +93,10 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      tcpSocket:
-        port: 2380
+      httpGet:
+        port: 9980
+        path: readyz
+        scheme: HTTPS
       failureThreshold: 3
       initialDelaySeconds: 3
       periodSeconds: 5

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -801,13 +801,15 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-    tcpSocket:
-    port: 2380
-    failureThreshold: 3
-    initialDelaySeconds: 3
-    periodSeconds: 5
-    successThreshold: 1
-    timeoutSeconds: 5
+      httpGet:
+        port: 9980
+        path: readyz
+        scheme: HTTPS
+      failureThreshold: 3
+      initialDelaySeconds: 3
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 5
     livenessProbe:
       httpGet:
         path: healthz
@@ -1216,8 +1218,10 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      tcpSocket:
-        port: 2380
+      httpGet:
+        port: 9980
+        path: readyz
+        scheme: HTTPS
       failureThreshold: 3
       initialDelaySeconds: 3
       periodSeconds: 5

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -801,15 +801,13 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      httpGet:
-        port: 9980
-        path: readyz
-        scheme: HTTPS
-      initialDelaySeconds: 10
-      timeoutSeconds: 10
-      failureThreshold: 3
-      periodSeconds: 5
-      successThreshold: 1
+    tcpSocket:
+    port: 2380
+    failureThreshold: 3
+    initialDelaySeconds: 3
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 5
     livenessProbe:
       httpGet:
         path: healthz


### PR DESCRIPTION
This has the readiness updates that Mustafa had made to 4.10 pulled in and the tcp updates