### PR TITLE
ensure-env: propagate error

### DIFF
--- a/pkg/cmd/ensureenv/ensureenv.go
+++ b/pkg/cmd/ensureenv/ensureenv.go
@@ -41,17 +41,18 @@ func NewEnsureEnvCommand(errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ensure-env",
 		Short: "Ensures that the IP address related environment variables are correct",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := ensure.Validate(); err != nil {
 				klog.Error(err.Error())
 				fmt.Fprint(ensure.errOut, err)
-				return
+				return err
 			}
 			if err := ensure.Run(); err != nil {
 				klog.Error(err.Error())
 				fmt.Fprint(ensure.errOut, err)
-				return
+				return err
 			}
+			return nil
 		},
 	}
 


### PR DESCRIPTION
https://github.com/openshift/cluster-etcd-operator/pull/726 introduced a new sub-command `ensure-env`. The old code is designed to exit 1 in various cases. The refactor missed propagating the error so the [caller](https://github.com/openshift/cluster-etcd-operator/blob/master/cmd/cluster-etcd-operator/main.go#L48-L49) would exit 1.