### PR TITLE
Hypershift: Stop trying to apply etcd prometheusrule

### DIFF
--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   name: etcd-prometheus-rules


### PR DESCRIPTION
This never had any targets in Hypershift so it is pointless. Since
b4537b9f59077fddfcbb3bc6e75021376040b715 it started to cause errors,
because the namespace isn't applied anymore:
```
  - lastTransitionTime: "2022-08-26T17:09:57Z"
    message: 'Could not update prometheusrule "openshift-etcd-operator/etcd-prometheus-rules"
      (537 of 566): resource may have been deleted'
```

We currently worked around this in Hypershift itself by deleting that
manifest, but that is not a great solution: https://github.com/openshift/hypershift/pull/1699/commits/2c927d9985059ddb3ad26332e088dcd2286ba94e

/assign Elbehery
/cc @tjungblu 