### PR TITLE
OCPBUGS-675: add nil check in checkSingleMemberHealth()

### DIFF
--- a/pkg/etcdcli/health.go
+++ b/pkg/etcdcli/health.go
@@ -132,7 +132,9 @@ func checkSingleMemberHealth(ctx context.Context, member *etcdserverpb.Member) h
 		}
 		hc.Healthy = true
 	} else {
-		klog.Errorf("health check for memberID (%v) failed: err(%v)", resp.Header.MemberId, err)
+		if resp.Header != nil {
+			klog.Errorf("health check for memberID (%v) failed: err(%v)", resp.Header.MemberId, err)
+		}
 		hc.Error = fmt.Errorf("health check failed: %w", err)
 	}
 


### PR DESCRIPTION
Since you're using resp.Header to get the member ID will likely need to have a check as on line 128 that resp is not nil.

Background saw crash during bootstrap in etcd-operator:
```
I0829 14:46:02.736582       1 controller_manager.go:54] StaticPodStateController controller terminated
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1e940ab]

goroutine 2701 [running]:
github.com/openshift/cluster-etcd-operator/pkg/etcdcli.checkSingleMemberHealth({0x29374c0, 0xc00217d920}, 0xc0021fb110)
        github.com/openshift/cluster-etcd-operator/pkg/etcdcli/health.go:135 +0x34b
github.com/openshift/cluster-etcd-operator/pkg/etcdcli.getMemberHealth.func1()
        github.com/openshift/cluster-etcd-operator/pkg/etcdcli/health.go:58 +0x7f
created by github.com/openshift/cluster-etcd-operator/pkg/etcdcli.getMemberHealth
        github.com/openshift/cluster-etcd-operator/pkg/etcdcli/health.go:54 +0x2ac
```