### PR TITLE
OCPBUGS-675: preserve log message on failures

### DIFF
--- a/pkg/etcdcli/health.go
+++ b/pkg/etcdcli/health.go
@@ -132,9 +132,7 @@ func checkSingleMemberHealth(ctx context.Context, member *etcdserverpb.Member) h
 		}
 		hc.Healthy = true
 	} else {
-		if resp.Header != nil {
-			klog.Errorf("health check for memberID (%v) failed: err(%v)", resp.Header.MemberId, err)
-		}
+		klog.Errorf("health check for member (%v) failed: err(%v)", member.Name, err)
 		hc.Error = fmt.Errorf("health check failed: %w", err)
 	}
 


### PR DESCRIPTION
It's actually silly to take the member id from the response header when we know exactly which client url we're talking to in the first place.