### PR TITLE
Remove quorum guard pod after the pod is removed from the cluster

### DIFF
--- a/pkg/operator/ceohelpers/common.go
+++ b/pkg/operator/ceohelpers/common.go
@@ -88,6 +88,17 @@ func FilterMachinesWithMachineDeletionHook(machines []*machinev1beta1.Machine) [
 	return filteredMachines
 }
 
+// FilterMachinesWithoutMachineDeletionHook a convenience function for filtering only machines without the machine deletion hook present
+func FilterMachinesWithoutMachineDeletionHook(machines []*machinev1beta1.Machine) []*machinev1beta1.Machine {
+	var filteredMachines []*machinev1beta1.Machine
+	for _, machine := range machines {
+		if !HasMachineDeletionHook(machine) {
+			filteredMachines = append(filteredMachines, machine)
+		}
+	}
+	return filteredMachines
+}
+
 // FilterMachinesPendingDeletion a convenience function for filtering machines pending deletion
 func FilterMachinesPendingDeletion(machines []*machinev1beta1.Machine) []*machinev1beta1.Machine {
 	var filteredMachines []*machinev1beta1.Machine

--- a/pkg/operator/machinedeletionhooks/machinedeletionhooks.go
+++ b/pkg/operator/machinedeletionhooks/machinedeletionhooks.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -28,7 +29,9 @@ type machineDeletionHooksController struct {
 	etcdClient                            etcdcli.EtcdClient
 	machineClient                         machinev1beta1client.MachineInterface
 	masterMachineLister                   machinelistersv1beta1.MachineLister
+	kubeClient                            kubernetes.Interface
 	configMapListerForKubeSystemNamespace corev1listers.ConfigMapNamespaceLister
+	podListerForOpenShiftEtcdNamespace    corev1listers.PodNamespaceLister
 	// machineAPIChecker determines if the precondition for this controller is met,
 	// this controller can be run only on a cluster that exposes a functional Machine API
 	machineAPIChecker     ceohelpers.MachineAPIChecker
@@ -44,6 +47,7 @@ func NewMachineDeletionHooksController(
 	operatorClient operatorv1helpers.OperatorClient,
 	machineClient machinev1beta1client.MachineInterface,
 	etcdClient etcdcli.EtcdClient,
+	kubeClient kubernetes.Interface,
 	machineAPIChecker ceohelpers.MachineAPIChecker,
 	masterMachineSelector labels.Selector,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
@@ -52,10 +56,12 @@ func NewMachineDeletionHooksController(
 	c := &machineDeletionHooksController{
 		machineClient:                         machineClient,
 		etcdClient:                            etcdClient,
+		kubeClient:                            kubeClient,
 		machineAPIChecker:                     machineAPIChecker,
 		masterMachineSelector:                 masterMachineSelector,
 		masterMachineLister:                   machinelistersv1beta1.NewMachineLister(masterMachineInformer.GetIndexer()),
 		configMapListerForKubeSystemNamespace: kubeInformersForNamespaces.InformersFor("kube-system").Core().V1().ConfigMaps().Lister().ConfigMaps("kube-system"),
+		podListerForOpenShiftEtcdNamespace:    kubeInformersForNamespaces.InformersFor("openshift-etcd").Core().V1().Pods().Lister().Pods("openshift-etcd"),
 	}
 	return factory.New().
 		WithSync(c.sync).
@@ -83,6 +89,14 @@ func (c *machineDeletionHooksController) sync(ctx context.Context, syncCtx facto
 	if err := c.attemptToDeleteMachineDeletionHook(ctx, syncCtx.Recorder()); err != nil {
 		errs = append(errs, err)
 	}
+
+	// attempt to remove quorum guard pods from machines that are pending deletion and haven't got a deletion hook.
+	// This prevents a deadlock when multiple machines are pending deletion simultaneously, but the nodes cannot be drained
+	// because the guard pod on each node is unready (due to non-member etcd pod) and violates the PDB.
+	if err := c.attemptToDeleteQuorumGuard(ctx, syncCtx.Recorder()); err != nil {
+		errs = append(errs, err)
+	}
+
 	return kerrors.NewAggregate(errs)
 }
 
@@ -144,6 +158,56 @@ func (c *machineDeletionHooksController) attemptToDeleteMachineDeletionHook(ctx 
 		klog.V(2).Infof("successfully removed the deletion hook from machine %v", machinePendingDeletion.Name)
 		recorder.Eventf("MachineDeletionHook", "successfully removed the deletion hook from machine %v as it doesn't have a member", machinePendingDeletion.Name)
 	}
+	return nil
+}
+
+// delete the quorum guard pod once we are sure that the node is going away (we've removed the deletion hook).
+// Once we remove the quorum guard, it won't be recreated meaning the machine controller can successfully drain the machine.
+func (c *machineDeletionHooksController) attemptToDeleteQuorumGuard(ctx context.Context, recorder events.Recorder) error {
+	masterMachines, err := c.masterMachineLister.List(c.masterMachineSelector)
+	if err != nil {
+		return err
+	}
+
+	machinesPendingDeletion := ceohelpers.FilterMachinesPendingDeletion(masterMachines)
+	machinesPendingDeletionWithoutHooks := ceohelpers.FilterMachinesWithoutMachineDeletionHook(machinesPendingDeletion)
+	if len(machinesPendingDeletionWithoutHooks) == 0 {
+		klog.V(4).Infof("currently, we don't have a machine pending deletion")
+		return nil
+	}
+
+	guardPods, err := c.podListerForOpenShiftEtcdNamespace.List(labels.SelectorFromSet(map[string]string{
+		"app": "guard",
+	}))
+	if err != nil {
+		return err
+	}
+
+	guardPodsByNodeName := mapPodsByNodeName(guardPods)
+
+	for _, machine := range machinesPendingDeletionWithoutHooks {
+		if machine.Status.NodeRef == nil {
+			// No node means there won't be a guard pod.
+			klog.V(4).Infof("machine %q does not have a node, it cannot have a guard pod to remove", machine.Name)
+			continue
+		}
+
+		guardPodsForMachine := guardPodsByNodeName[machine.Status.NodeRef.Name]
+		if len(guardPodsForMachine) == 0 {
+			klog.V(4).Infof("node %q is does not have a guard pod, skipping", machine.Status.NodeRef.Name)
+			continue
+		}
+
+		for _, pod := range guardPodsForMachine {
+			if err := c.kubeClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+		}
+
+		klog.V(2).Infof("successfully removed the guard pod from machine %v", machine.Name)
+		recorder.Eventf("QuorumGuardRemoved", "successfully removed the guard pod from machine %v as it is being removed from the cluster", machine.Name)
+	}
+
 	return nil
 }
 
@@ -218,4 +282,14 @@ func removeMachineDeletionHook(machine *machinev1beta1.Machine) {
 		newPreDrainHooks = append(newPreDrainHooks, hook)
 	}
 	machine.Spec.LifecycleHooks.PreDrain = newPreDrainHooks
+}
+
+func mapPodsByNodeName(pods []*corev1.Pod) map[string][]*corev1.Pod {
+	out := make(map[string][]*corev1.Pod)
+
+	for _, pod := range pods {
+		out[pod.Spec.NodeName] = append(out[pod.Spec.NodeName], pod.DeepCopy())
+	}
+
+	return out
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -334,6 +334,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorClient,
 		machineClient,
 		etcdClient,
+		kubeClient,
 		machineAPI,
 		masterMachineLabelSelector,
 		kubeInformersForNamespaces,


### PR DESCRIPTION
Opening this to start a discussion.

I've been working on the ControlPlaneMachineSet and trying to automate replacement of the Control Plane Machines using our on-delete strategy.

One of the things we expect to be able to do is to create multiple replacement machines simultaneously (when a user deletes multiple machines simultaneously) and have the etcd operator handle moving etcd onto the new machines in quick succession.

This seems to work well!

However, what doesn't work currently is that the quorum guard on the old machines ends up failing, members that have been removed from the etcd cluster fail the health check. This means you now have multiple failing quorum guard pods.
The PDB blocks these from being removed.

To avoid this, we can be remove the quorum guard pod from a machine that we know has been removed from the quorum.
This prevents the quorum guard pod from blocking the machine being drained and allows the cluster to remove the old machines.
If we remove the quorum guard pod and the node is marked unschedulable (because it's being drained), it won't be recreated.

I've done some manual testing of this and it seems like things are working now.

Would be interested to see what others think to know if there's some edge cases I haven't considered, but I believe this should be safe to add.