### PR TITLE
OCPBUGS-1000: Allow scale-down of unhealthy member

### DIFF
--- a/pkg/etcdcli/helpers.go
+++ b/pkg/etcdcli/helpers.go
@@ -77,6 +77,11 @@ func (f *fakeEtcdClient) MemberList(ctx context.Context) ([]*etcdserverpb.Member
 	return f.members, nil
 }
 
+func (f *fakeEtcdClient) VotingMemberList(ctx context.Context) ([]*etcdserverpb.Member, error) {
+	members, _ := f.MemberList(ctx)
+	return filterVotingMembers(members), nil
+}
+
 func (f *fakeEtcdClient) MemberRemove(ctx context.Context, memberID uint64) error {
 	var memberExists bool
 	for _, m := range f.members {
@@ -139,12 +144,22 @@ func (f *fakeEtcdClient) UnhealthyMembers(ctx context.Context) ([]*etcdserverpb.
 	return []*etcdserverpb.Member{}, nil
 }
 
+func (f *fakeEtcdClient) UnhealthyVotingMembers(ctx context.Context) ([]*etcdserverpb.Member, error) {
+	members, _ := f.UnhealthyMembers(ctx)
+	return filterVotingMembers(members), nil
+}
+
 func (f *fakeEtcdClient) HealthyMembers(ctx context.Context) ([]*etcdserverpb.Member, error) {
 	if f.opts.healthyMember > 0 {
 		// healthy start from end
 		return f.members[f.opts.unhealthyMember:], nil
 	}
 	return []*etcdserverpb.Member{}, nil
+}
+
+func (f *fakeEtcdClient) HealthyVotingMembers(ctx context.Context) ([]*etcdserverpb.Member, error) {
+	members, _ := f.HealthyMembers(ctx)
+	return filterVotingMembers(members), nil
 }
 
 func (f *fakeEtcdClient) MemberStatus(ctx context.Context, member *etcdserverpb.Member) string {

--- a/pkg/etcdcli/interfaces.go
+++ b/pkg/etcdcli/interfaces.go
@@ -58,15 +58,24 @@ type MemberRemover interface {
 }
 
 type MemberLister interface {
+	// MemberList lists all members in a cluster
 	MemberList(ctx context.Context) ([]*etcdserverpb.Member, error)
+	// VotingMemberList lists all non learner members in a cluster
+	VotingMemberList(ctx context.Context) ([]*etcdserverpb.Member, error)
 }
 
 type HealthyMemberLister interface {
+	// HealthyMembers lists all healthy members in a cluster
 	HealthyMembers(ctx context.Context) ([]*etcdserverpb.Member, error)
+	// HealthyVotingMembers lists all non learner healthy members in a cluster
+	HealthyVotingMembers(ctx context.Context) ([]*etcdserverpb.Member, error)
 }
 
 type UnhealthyMemberLister interface {
+	// UnhealthyMembers lists all unhealthy members in a cluster
 	UnhealthyMembers(ctx context.Context) ([]*etcdserverpb.Member, error)
+	// UnhealthyVotingMembers lists all non learner unhealthy members in a cluster
+	UnhealthyVotingMembers(ctx context.Context) ([]*etcdserverpb.Member, error)
 }
 
 type MemberStatusChecker interface {

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -182,7 +182,7 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 	// map machines pending deletion to node internal ip
 	votingMachinesPendingDeletionIndex := ceohelpers.IndexMachinesByNodeInternalIP(votingMachinesPendingDeletion)
 	// find unhealthy machine pending deletion to remove first from the cluster, without violating quorum
-	var unhealthyMachinePendingDeletion []*machinev1beta1.Machine
+	var unhealthyMachinesPendingDeletion []*machinev1beta1.Machine
 	if len(unhealthyMembers) > 0 {
 		var unhealthyMembersURLs []string
 		for _, unhealthyMember := range unhealthyMembers {
@@ -192,7 +192,7 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 			}
 			unhealthyMemberMachine, ok := votingMachinesPendingDeletionIndex[unhealthyMemberNodeInternalIP]
 			if ok {
-				unhealthyMachinePendingDeletion = append(unhealthyMachinePendingDeletion, unhealthyMemberMachine)
+				unhealthyMachinesPendingDeletion = append(unhealthyMachinesPendingDeletion, unhealthyMemberMachine)
 			}
 			if len(unhealthyMember.PeerURLs) > 0 {
 				unhealthyMembersURLs = append(unhealthyMembersURLs, unhealthyMember.PeerURLs[0])
@@ -200,8 +200,8 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 				unhealthyMembersURLs = append(unhealthyMembersURLs, unhealthyMember.Name)
 			}
 		}
-		if len(unhealthyMachinePendingDeletion) > 0 {
-			klog.V(4).Infof("found unhealthy voting members with machine pending deletion: %v", unhealthyMachinePendingDeletion)
+		if len(unhealthyMachinesPendingDeletion) > 0 {
+			klog.V(4).Infof("found unhealthy voting members with machine pending deletion: %v", unhealthyMachinesPendingDeletion)
 			klog.V(4).Infof("unhealthy members found: %v", unhealthyMembersURLs)
 		} else {
 			return fmt.Errorf("cannot proceed with scaling down, unhealthy members found: %v", unhealthyMembersURLs)
@@ -210,8 +210,8 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 
 	// remove the unhealthy machine pending deletion first
 	// if no unhealthy machine pending deletion found, then attempt to scale down the healthy machines pending deletion
-	if len(unhealthyMachinePendingDeletion) > 0 {
-		votingMachinesPendingDeletion = append(unhealthyMachinePendingDeletion, votingMachinesPendingDeletion...)
+	if len(unhealthyMachinesPendingDeletion) > 0 {
+		votingMachinesPendingDeletion = append(unhealthyMachinesPendingDeletion, votingMachinesPendingDeletion...)
 	}
 	var allErrs []error
 	for _, votingMachinePendingDeletion := range votingMachinesPendingDeletion {

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -130,43 +130,35 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 		return nil
 	}
 
+	// machines with master role and deletion hook
 	memberMachines, err := ceohelpers.CurrentMemberMachinesWithDeletionHooks(c.masterMachineSelector, c.masterMachineLister)
 	if err != nil {
 		return err
 	}
 
-	var votingMachines []*machinev1beta1.Machine
+	var votingMembersMachines []*machinev1beta1.Machine
 	for memberMachineIP, memberMachine := range ceohelpers.IndexMachinesByNodeInternalIP(memberMachines) {
 		if currentVotingMemberIPListSet.Has(memberMachineIP) {
-			votingMachines = append(votingMachines, memberMachine)
+			votingMembersMachines = append(votingMembersMachines, memberMachine)
 		}
 	}
 
-	votingMachinesPendingDeletion := ceohelpers.FilterMachinesPendingDeletion(votingMachines)
-	if len(votingMachinesPendingDeletion) == 0 {
+	votingMembersMachinesPendingDeletion := ceohelpers.FilterMachinesPendingDeletion(votingMembersMachines)
+	if len(votingMembersMachinesPendingDeletion) == 0 {
 		return nil
 	}
 
-	// based on the data in the cache it looks like we have something to do
-	// get the live members, to observe the current state and the member IDs
-	members, err := c.etcdClient.MemberList(ctx)
+	// do not trust data in the cache, compare with the current state
+	healthyLiveVotingMembers, err := c.getHealthyVotingMembers(ctx)
 	if err != nil {
 		return err
 	}
 
-	var liveVotingMembers []*etcdserverpb.Member
-	for _, member := range members {
-		if member.IsLearner {
-			continue
-		}
-		liveVotingMembers = append(liveVotingMembers, member)
-	}
-
-	// do not trust data in the cache, compare with the current state
-	if len(liveVotingMembers) <= desiredControlPlaneReplicasCount {
-		klog.V(2).Infof("Ignoring scale down since the number of live etcd voting members (%d) < desired number of control-plane replicas (%d) ", len(liveVotingMembers), desiredControlPlaneReplicasCount)
+	// scaling down invariant
+	if len(healthyLiveVotingMembers) < desiredControlPlaneReplicasCount {
+		klog.V(2).Infof("Ignoring scale down since the number of healthy live etcd voting members (%d) < desired number of control-plane replicas (%d) ", len(healthyLiveVotingMembers), desiredControlPlaneReplicasCount)
 		if time.Now().After(c.lastTimeScaleDownEventWasSent.Add(5 * time.Minute)) {
-			recorder.Eventf("ScaleDown", "Ignoring scale down since the number of live etcd voting members (%d) < desired number of control-plane replicas (%d) ", len(liveVotingMembers), desiredControlPlaneReplicasCount)
+			recorder.Eventf("ScaleDown", "Ignoring scale down since the number of healthy live etcd voting members (%d) < desired number of control-plane replicas (%d) ", len(healthyLiveVotingMembers), desiredControlPlaneReplicasCount)
 			c.lastTimeScaleDownEventWasSent = time.Now()
 		}
 		return nil
@@ -180,9 +172,9 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 	}
 
 	// map machines pending deletion to node internal ip
-	votingMachinesPendingDeletionIndex := ceohelpers.IndexMachinesByNodeInternalIP(votingMachinesPendingDeletion)
+	votingMemberMachinesPendingDeletionIndex := ceohelpers.IndexMachinesByNodeInternalIP(votingMembersMachinesPendingDeletion)
 	// find unhealthy machine pending deletion to remove first from the cluster, without violating quorum
-	var unhealthyMachinesPendingDeletion []*machinev1beta1.Machine
+	var unhealthyVotingMemberMachinesPendingDeletion []*machinev1beta1.Machine
 	if len(unhealthyMembers) > 0 {
 		var unhealthyMembersURLs []string
 		for _, unhealthyMember := range unhealthyMembers {
@@ -190,9 +182,9 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 			if err != nil {
 				return fmt.Errorf("cannot get node internal ip for unhealthy member %v: %w", unhealthyMember, err)
 			}
-			unhealthyMemberMachine, ok := votingMachinesPendingDeletionIndex[unhealthyMemberNodeInternalIP]
+			unhealthyVotingMemberMachinePendingDeletion, ok := votingMemberMachinesPendingDeletionIndex[unhealthyMemberNodeInternalIP]
 			if ok {
-				unhealthyMachinesPendingDeletion = append(unhealthyMachinesPendingDeletion, unhealthyMemberMachine)
+				unhealthyVotingMemberMachinesPendingDeletion = append(unhealthyVotingMemberMachinesPendingDeletion, unhealthyVotingMemberMachinePendingDeletion)
 			}
 			if len(unhealthyMember.PeerURLs) > 0 {
 				unhealthyMembersURLs = append(unhealthyMembersURLs, unhealthyMember.PeerURLs[0])
@@ -200,22 +192,28 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 				unhealthyMembersURLs = append(unhealthyMembersURLs, unhealthyMember.Name)
 			}
 		}
-		if len(unhealthyMachinesPendingDeletion) > 0 {
-			klog.V(4).Infof("found unhealthy voting members with machine pending deletion: %v", unhealthyMachinesPendingDeletion)
+		if len(unhealthyVotingMemberMachinesPendingDeletion) > 0 {
+			klog.V(4).Infof("found unhealthy voting members with machine pending deletion: %v", unhealthyVotingMemberMachinesPendingDeletion)
 			klog.V(4).Infof("unhealthy members found: %v", unhealthyMembersURLs)
 		} else {
-			return fmt.Errorf("cannot proceed with scaling down, unhealthy members found: %v", unhealthyMembersURLs)
+			return fmt.Errorf("cannot proceed with scaling down, unhealthy voting members found: %v, none are pending deletion", unhealthyMembersURLs)
 		}
 	}
 
 	// remove the unhealthy machine pending deletion first
 	// if no unhealthy machine pending deletion found, then attempt to scale down the healthy machines pending deletion
-	if len(unhealthyMachinesPendingDeletion) > 0 {
-		votingMachinesPendingDeletion = append(unhealthyMachinesPendingDeletion, votingMachinesPendingDeletion...)
+	if len(unhealthyVotingMemberMachinesPendingDeletion) > 0 {
+		votingMembersMachinesPendingDeletion = append(unhealthyVotingMemberMachinesPendingDeletion, votingMembersMachinesPendingDeletion...)
 	}
+
+	liveVotingMembers, err := c.getAllVotingMembers(ctx)
+	if err != nil {
+		return err
+	}
+
 	var allErrs []error
-	for _, votingMachinePendingDeletion := range votingMachinesPendingDeletion {
-		removed, errs := c.attemptToRemoveMemberFor(ctx, liveVotingMembers, votingMachinePendingDeletion, recorder)
+	for _, votingMemberMachinePendingDeletion := range votingMembersMachinesPendingDeletion {
+		removed, errs := c.attemptToRemoveMemberFor(ctx, liveVotingMembers, votingMemberMachinePendingDeletion, recorder)
 		if removed {
 			break // we want to remove only one member at a time
 		}
@@ -413,6 +411,24 @@ func (c *clusterMemberRemovalController) attemptToRemoveMemberFor(ctx context.Co
 	return removed, errs
 }
 
+func (c *clusterMemberRemovalController) getHealthyVotingMembers(ctx context.Context) ([]*etcdserverpb.Member, error) {
+	healthyMembers, err := c.etcdClient.HealthyMembers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	healthyLiveVotingMembers := getVotingMembers(healthyMembers)
+	return healthyLiveVotingMembers, nil
+}
+
+func (c *clusterMemberRemovalController) getAllVotingMembers(ctx context.Context) ([]*etcdserverpb.Member, error) {
+	allMembers, err := c.etcdClient.MemberList(ctx)
+	if err != nil {
+		return nil, err
+	}
+	liveVotingMembers := getVotingMembers(allMembers)
+	return liveVotingMembers, nil
+}
+
 func hasInternalIP(machine *machinev1beta1.Machine, memberInternalIP string) bool {
 	for _, addr := range machine.Status.Addresses {
 		if addr.Type == corev1.NodeInternalIP && addr.Address == memberInternalIP {
@@ -420,4 +436,15 @@ func hasInternalIP(machine *machinev1beta1.Machine, memberInternalIP string) boo
 		}
 	}
 	return false
+}
+
+func getVotingMembers(members []*etcdserverpb.Member) []*etcdserverpb.Member {
+	var votingMembers []*etcdserverpb.Member
+	for _, member := range members {
+		if member.IsLearner {
+			continue
+		}
+		votingMembers = append(votingMembers, member)
+	}
+	return votingMembers
 }

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
@@ -685,7 +685,7 @@ func TestAttemptToScaleDown(t *testing.T) {
 				return []runtime.Object{cm}
 			}(),
 			fakeEtcdClientOptions: etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1}),
-			expectedError:         fmt.Errorf("cannot proceed wth scaling down, unhealthy members found: [https://10.0.139.78:1234]"),
+			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy members found: [https://10.0.139.78:1234]"),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
@@ -426,6 +426,7 @@ func TestAttemptToScaleDown(t *testing.T) {
 				cm.Data["m-4"] = "10.0.139.81"
 				return []runtime.Object{cm}
 			}(),
+			fakeEtcdClientOptions: etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 4, Unhealthy: 0}),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {
@@ -636,6 +637,7 @@ func TestAttemptToScaleDown(t *testing.T) {
 				cm.Data["m-5"] = "10.0.139.82"
 				return []runtime.Object{cm}
 			}(),
+			fakeEtcdClientOptions: etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 5, Unhealthy: 0}),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {
@@ -645,18 +647,11 @@ func TestAttemptToScaleDown(t *testing.T) {
 					t.Errorf("expected exactly 4 members, got %v", len(memberList))
 				}
 
-				// either m4 or m5 could have been deleted, but not both
-				var m4Found, m5Found bool
+				// expected m4 to be deleted, m5 not to be deleted
 				for _, member := range memberList {
 					if member.ID == 4 {
-						m4Found = true
+						t.Errorf("not expected member with id %d", member.ID)
 					}
-					if member.ID == 5 {
-						m5Found = true
-					}
-				}
-				if m4Found && m5Found {
-					t.Fatal("expected either m4 or m5 to be deleted but not both")
 				}
 			},
 		},
@@ -685,7 +680,7 @@ func TestAttemptToScaleDown(t *testing.T) {
 				return []runtime.Object{cm}
 			}(),
 			fakeEtcdClientOptions: etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1}),
-			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy members found: [https://10.0.139.78:1234]"),
+			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy voting members found: [https://10.0.139.78:1234], none are pending deletion"),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {
@@ -734,6 +729,11 @@ func TestAttemptToScaleDown(t *testing.T) {
 				if len(memberList) != 3 {
 					t.Errorf("expected exactly 3 members, got %v", len(memberList))
 				}
+				for _, member := range memberList {
+					if member.ID == 1 {
+						t.Errorf("not expected member with id %d", member.ID)
+					}
+				}
 			},
 		},
 		{
@@ -760,7 +760,7 @@ func TestAttemptToScaleDown(t *testing.T) {
 				return []runtime.Object{cm}
 			}(),
 			fakeEtcdClientOptions: etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1}),
-			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy members found: [https://10.0.139.78:1234]"),
+			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy voting members found: [https://10.0.139.78:1234], none are pending deletion"),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {
@@ -768,6 +768,61 @@ func TestAttemptToScaleDown(t *testing.T) {
 				}
 				if len(memberList) != 4 {
 					t.Errorf("expected exactly 4 members, got %v", len(memberList))
+				}
+			},
+		},
+		{
+			name:                       "scale down only by one machine at a time when more than one machine pending deletion while quorum maintained",
+			initialObservedConfigInput: wellKnownReplicasCountSet,
+			initialEtcdMemberList: func() []*etcdserverpb.Member {
+				members := append(wellKnownEtcdMemberList(), &etcdserverpb.Member{
+					Name:     "m-4",
+					ID:       4,
+					PeerURLs: []string{"https://10.0.139.81:1234"},
+				}, &etcdserverpb.Member{
+					Name:     "m-5",
+					ID:       5,
+					PeerURLs: []string{"https://10.0.139.82:1234"},
+				})
+				return members
+			}(),
+			initialObjectsForMachineLister: func() []runtime.Object {
+				m4 := machineWithHooksFor("m-4", "10.0.139.81")
+				m5 := machineWithHooksFor("m-5", "10.0.139.82")
+				machines := wellKnownMasterMachines()
+				// override the default health config for test scenario
+				m1, ok := machines[0].(*machinev1beta1.Machine)
+				if !ok {
+					t.Fatalf("expected type *machinev1beta1.Machine, but got %T instead", m1)
+				}
+				m1.DeletionTimestamp = &metav1.Time{}
+				m2, ok := machines[1].(*machinev1beta1.Machine)
+				if !ok {
+					t.Fatalf("expected type *machinev1beta1.Machine, but got %T instead", m2)
+				}
+				m2.DeletionTimestamp = &metav1.Time{}
+				machines = append(machines, m4, m5)
+				return machines
+			}(),
+			initialObjectsForConfigMapTargetNSLister: func() []runtime.Object {
+				cm := wellKnownEtcdEndpointsConfigMap()
+				cm.Data["m-4"] = "10.0.139.81"
+				cm.Data["m-5"] = "10.0.139.82"
+				return []runtime.Object{cm}
+			}(),
+			fakeEtcdClientOptions: etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 2}),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 4 {
+					t.Errorf("expected exactly 4 members, got %v", len(memberList))
+				}
+				for _, member := range memberList {
+					if member.ID == 1 {
+						t.Errorf("not expected member with id %d", member.ID)
+					}
 				}
 			},
 		},

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -232,6 +232,11 @@ func FakeEtcdMemberWithoutServer(member int) *etcdserverpb.Member {
 	}
 }
 
+func AsLearner(member *etcdserverpb.Member) *etcdserverpb.Member {
+	member.IsLearner = true
+	return member
+}
+
 func fakeMemberId() uint64 {
 	return uint64(rand.Uint32())<<32 + uint64(rand.Uint32())
 }


### PR DESCRIPTION
Currently the clustermemberremoval controller will automatically remove an etcd member when the pre-conditions for scale down are met, i.e we have a machine pending deletion and N+1 voting members where N is the desired control-plane size.
However, if we have the scaling down conditions met, but the etcd cluster is unhealthy (i.e. unhealthy voting member found), 
clustermemberremoval will not attempt to scale down. 

This PR relaxes the scaling down condition, which allows clustermemberremoval to remove unhealthy voting member, if the current voting members count is N+1, while N is the `desiredControlPlaneReplicaCount`.