### PR TITLE
timeout for quorum check

### DIFF
--- a/pkg/operator/ceohelpers/bootstrap_test.go
+++ b/pkg/operator/ceohelpers/bootstrap_test.go
@@ -1,6 +1,7 @@
 package ceohelpers
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -369,6 +370,7 @@ func Test_CheckSafeToScaleCluster(t *testing.T) {
 			}
 
 			actualErr := CheckSafeToScaleCluster(
+				context.Background(),
 				fakeConfigMapLister,
 				fakeStaticPodClient,
 				fakeNamespaceMapLister,

--- a/pkg/operator/ceohelpers/qourum_check.go
+++ b/pkg/operator/ceohelpers/qourum_check.go
@@ -1,6 +1,8 @@
 package ceohelpers
 
 import (
+	"context"
+
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -12,7 +14,7 @@ type QuorumChecker interface {
 	// IsSafeToUpdateRevision checks the current etcd cluster and returns true if the cluster can tolerate the
 	// loss of a single etcd member. Such loss is common during new static pod revision.
 	// Returns True when it is absolutely safe, false if not. Error otherwise, which always indicates it is unsafe.
-	IsSafeToUpdateRevision() (bool, error)
+	IsSafeToUpdateRevision(ctx context.Context) (bool, error)
 }
 
 // QuorumCheck is just a convenience struct around bootstrap.go
@@ -24,8 +26,8 @@ type QuorumCheck struct {
 	etcdClient      etcdcli.EtcdClient
 }
 
-func (c *QuorumCheck) IsSafeToUpdateRevision() (bool, error) {
-	err := CheckSafeToScaleCluster(c.configMapLister, c.operatorClient, c.namespaceLister, c.infraLister, c.etcdClient)
+func (c *QuorumCheck) IsSafeToUpdateRevision(ctx context.Context) (bool, error) {
+	err := CheckSafeToScaleCluster(ctx, c.configMapLister, c.operatorClient, c.namespaceLister, c.infraLister, c.etcdClient)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/operator/ceohelpers/qourum_check_test.go
+++ b/pkg/operator/ceohelpers/qourum_check_test.go
@@ -1,6 +1,7 @@
 package ceohelpers
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -137,7 +138,7 @@ func TestQuorumCheck_IsSafeToUpdateRevision(t *testing.T) {
 				fakeOperatorClient,
 				fakeEtcdClient)
 
-			safe, err := quorumChecker.IsSafeToUpdateRevision()
+			safe, err := quorumChecker.IsSafeToUpdateRevision(context.Background())
 			assert.Equal(t, scenario.expectedErr, err)
 			assert.Equal(t, scenario.safe, safe)
 		})

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -109,7 +109,7 @@ func NewEtcdCertSignerController(
 }
 
 func (c *EtcdCertSignerController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	safe, err := c.quorumChecker.IsSafeToUpdateRevision()
+	safe, err := c.quorumChecker.IsSafeToUpdateRevision(ctx)
 	if err != nil {
 		return fmt.Errorf("EtcdCertSignerController can't evaluate whether quorum is safe: %w", err)
 	}

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go
@@ -142,7 +142,7 @@ func (c *EtcdEndpointsController) syncConfigMap(ctx context.Context, recorder ev
 
 	required.Data = endpointAddresses
 
-	safe, err := c.quorumChecker.IsSafeToUpdateRevision()
+	safe, err := c.quorumChecker.IsSafeToUpdateRevision(ctx)
 	if err != nil {
 		return fmt.Errorf("EtcdEndpointsController can't evaluate whether quorum is safe: %w", err)
 	}

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -81,7 +81,7 @@ func NewTargetConfigController(
 }
 
 func (c TargetConfigController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	safe, err := c.quorumChecker.IsSafeToUpdateRevision()
+	safe, err := c.quorumChecker.IsSafeToUpdateRevision(ctx)
 	if err != nil {
 		return fmt.Errorf("TargetConfigController can't evaluate whether quorum is safe: %w", err)
 	}


### PR DESCRIPTION
The health check is known to hang sometimes since https://github.com/openshift/cluster-etcd-operator/pull/862 - it might also get stuck on the listing, thus explicitly adding a 10s timeout to the whole operation here instead of `context.Background`.

Not sure whether that's resolving the issue in https://github.com/openshift/installer/pull/6124 yet.
