### PR TITLE
ETCD-328: automatic replacement of an unhealthy member machine

### DIFF
--- a/pkg/etcdcli/health.go
+++ b/pkg/etcdcli/health.go
@@ -240,7 +240,7 @@ func HasStarted(member *etcdserverpb.Member) bool {
 // loss of a single etcd member. Such loss is common during new static pod revision.
 func IsQuorumFaultTolerant(memberHealth []healthCheck) bool {
 	totalMembers := len(memberHealth)
-	quorum := totalMembers/2 + 1
+	quorum := MinimumTolerableQuorum(totalMembers)
 	healthyMembers := len(GetHealthyMemberNames(memberHealth))
 	switch {
 	case totalMembers-quorum < 1:
@@ -256,7 +256,7 @@ func IsQuorumFaultTolerant(memberHealth []healthCheck) bool {
 // IsQuorumFaultTolerantErr is the same as IsQuorumFaultTolerant but with an error return instead of the log
 func IsQuorumFaultTolerantErr(memberHealth []healthCheck) error {
 	totalMembers := len(memberHealth)
-	quorum := totalMembers/2 + 1
+	quorum := MinimumTolerableQuorum(totalMembers)
 	healthyMembers := len(GetHealthyMemberNames(memberHealth))
 	switch {
 	case totalMembers-quorum < 1:
@@ -319,4 +319,8 @@ func (c *raftTermsCollector) Collect(ch chan<- prometheus.Metric) {
 			member,
 		)
 	}
+}
+
+func MinimumTolerableQuorum(members int) int {
+	return (members / 2) + 1
 }

--- a/pkg/etcdcli/health.go
+++ b/pkg/etcdcli/health.go
@@ -240,7 +240,11 @@ func HasStarted(member *etcdserverpb.Member) bool {
 // loss of a single etcd member. Such loss is common during new static pod revision.
 func IsQuorumFaultTolerant(memberHealth []healthCheck) bool {
 	totalMembers := len(memberHealth)
-	quorum := MinimumTolerableQuorum(totalMembers)
+	quorum, err := MinimumTolerableQuorum(totalMembers)
+	if err != nil {
+		klog.Errorf("etcd cluster could not determine minimum quorum required. total number of members is %v. minimum quorum required is %v: %w", totalMembers, quorum, err)
+		return false
+	}
 	healthyMembers := len(GetHealthyMemberNames(memberHealth))
 	switch {
 	case totalMembers-quorum < 1:
@@ -256,7 +260,10 @@ func IsQuorumFaultTolerant(memberHealth []healthCheck) bool {
 // IsQuorumFaultTolerantErr is the same as IsQuorumFaultTolerant but with an error return instead of the log
 func IsQuorumFaultTolerantErr(memberHealth []healthCheck) error {
 	totalMembers := len(memberHealth)
-	quorum := MinimumTolerableQuorum(totalMembers)
+	quorum, err := MinimumTolerableQuorum(totalMembers)
+	if err != nil {
+		return fmt.Errorf("etcd cluster could not determine minimum quorum required. total number of members is %v. minimum quorum required is %v: %w", totalMembers, quorum, err)
+	}
 	healthyMembers := len(GetHealthyMemberNames(memberHealth))
 	switch {
 	case totalMembers-quorum < 1:
@@ -321,6 +328,9 @@ func (c *raftTermsCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func MinimumTolerableQuorum(members int) int {
-	return (members / 2) + 1
+func MinimumTolerableQuorum(members int) (int, error) {
+	if members <= 0 {
+		return 0, fmt.Errorf("invalid etcd member length: %v", members)
+	}
+	return (members / 2) + 1, nil
 }

--- a/pkg/etcdcli/health_test.go
+++ b/pkg/etcdcli/health_test.go
@@ -2,6 +2,7 @@ package etcdcli
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 
@@ -257,6 +258,51 @@ func healthyMember(member int) healthCheck {
 			ClientURLs: []string{fmt.Sprintf("https://10.0.0.%d:2379", member)},
 		},
 		Healthy: true,
+	}
+}
+
+func TestMinimumTolerableQuorum(t *testing.T) {
+
+	scenarios := []struct {
+		name   string
+		input  int
+		expErr error
+		exp    int
+	}{
+		{
+			name:   "valid input `3`",
+			input:  3,
+			expErr: nil,
+			exp:    2,
+		},
+		{
+			name:   "valid input `5`",
+			input:  5,
+			expErr: nil,
+			exp:    3,
+		},
+		{
+			name:   "invalid input `0`",
+			input:  0,
+			expErr: fmt.Errorf("invalid etcd member length: %v", 0),
+			exp:    0,
+		},
+		{
+			name:   "invalid input `-10`",
+			input:  -10,
+			expErr: fmt.Errorf("invalid etcd member length: %v", -10),
+			exp:    0,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// act
+			actual, err := MinimumTolerableQuorum(scenario.input)
+			// assert
+			require.Equal(t, scenario.expErr, err)
+			require.Equal(t, scenario.exp, actual)
+		})
 	}
 }
 

--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -372,7 +372,7 @@ func (c *ClusterMemberController) isEtcdContainerRunningNotReady(node *corev1.No
 // The voting members are read from the etcd-endpoints configmap
 func (c *ClusterMemberController) allNodesMapToVotingMembers(nodes []*corev1.Node) ([]*corev1.Node, error) {
 	var nonVotingMemberNodes []*corev1.Node
-	currentVotingMemberIPListSet, err := ceohelpers.VotingMemberIPListSet(c.configMapLister)
+	currentVotingMemberIPListSet, err := ceohelpers.VotingMemberIPListSet(context.Background(), c.etcdClient)
 	if err != nil {
 		return nonVotingMemberNodes, fmt.Errorf("failed to get the set of voting members: %v", err)
 	}

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -198,16 +198,16 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 				unhealthyMembersURLs = append(unhealthyMembersURLs, unhealthyMember.Name)
 			}
 		}
-		if len(unhealthyVotingMemberMachinesPendingDeletion) <= 0 {
-			klog.V(2).Infof("cannot proceed with scaling down, unhealthy etcd members found: %v", unhealthyMembersURLs)
-			return fmt.Errorf("cannot proceed with scaling down, unhealthy etcd members found: %v", unhealthyMembersURLs)
+		if len(unhealthyVotingMemberMachinesPendingDeletion) == 0 {
+			klog.V(2).Infof("cannot proceed with scaling down, unhealthy voting etcd members found: %v but none are pending deletion", unhealthyMembersURLs)
+			return fmt.Errorf("cannot proceed with scaling down, unhealthy voting etcd members found: %v but none are pending deletion", unhealthyMembersURLs)
 		}
 	}
 
 	// remove the unhealthy machine pending deletion first
 	// if no unhealthy machine pending deletion found, then attempt to scale down the healthy machines pending deletion
 	if len(unhealthyVotingMemberMachinesPendingDeletion) > 0 {
-		klog.V(2).Infof("found unhealthy etcd members with machine pending deletion: %v", unhealthyVotingMemberMachinesPendingDeletion)
+		klog.V(2).Infof("found unhealthy voting etcd members with machine pending deletion: %v", unhealthyVotingMemberMachinesPendingDeletion)
 		votingMembersMachinesPendingDeletion = append(unhealthyVotingMemberMachinesPendingDeletion, votingMembersMachinesPendingDeletion...)
 	}
 

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -128,8 +128,6 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 
 	liveVotingMembers, err := c.getAllVotingMembers(ctx)
 	if err != nil {
-		// TODO : update status condition
-		// TODO : should go degraded ?
 		return fmt.Errorf("could not list etcd members: %w", err)
 	}
 
@@ -164,9 +162,9 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 
 	// scaling down invariant
 	if len(healthyLiveVotingMembers) < minimumTolerableQuorum(desiredControlPlaneReplicasCount) {
-		klog.V(2).Infof("Ignoring scale down since the number of healthy live etcd members (%d) < desired number of control-plane replicas (%d) ", len(healthyLiveVotingMembers), desiredControlPlaneReplicasCount)
+		klog.V(2).Infof("ignoring scale down since the number of healthy live etcd members (%d) < minimum required to maintain quorum (%d) ", len(healthyLiveVotingMembers), minimumTolerableQuorum(desiredControlPlaneReplicasCount))
 		if time.Now().After(c.lastTimeScaleDownEventWasSent.Add(5 * time.Minute)) {
-			recorder.Eventf("ScaleDown", "Ignoring scale down since the number of healthy live etcd members (%d) < desired number of control-plane replicas (%d) ", len(healthyLiveVotingMembers), desiredControlPlaneReplicasCount)
+			recorder.Eventf("ScaleDown", "Ignoring scale down since the number of healthy live etcd members (%d) < < minimum required to maintain quorum (%d) ", len(healthyLiveVotingMembers), minimumTolerableQuorum(desiredControlPlaneReplicasCount))
 			c.lastTimeScaleDownEventWasSent = time.Now()
 		}
 		return nil

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
@@ -804,7 +804,7 @@ func TestAttemptToScaleDown(t *testing.T) {
 				return []runtime.Object{cm}
 			}(),
 			fakeEtcdClientOptions: etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1}),
-			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy etcd members found: [https://10.0.139.78:1234]"),
+			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy voting etcd members found: [https://10.0.139.78:1234] but none are pending deletion"),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {
@@ -884,7 +884,7 @@ func TestAttemptToScaleDown(t *testing.T) {
 				return []runtime.Object{cm}
 			}(),
 			fakeEtcdClientOptions: etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1}),
-			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy etcd members found: [https://10.0.139.78:1234]"),
+			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy voting etcd members found: [https://10.0.139.78:1234] but none are pending deletion"),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
@@ -680,7 +680,7 @@ func TestAttemptToScaleDown(t *testing.T) {
 				return []runtime.Object{cm}
 			}(),
 			fakeEtcdClientOptions: etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1}),
-			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy voting members found: [https://10.0.139.78:1234], none are pending deletion"),
+			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy etcd members found: [https://10.0.139.78:1234]"),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {
@@ -760,7 +760,7 @@ func TestAttemptToScaleDown(t *testing.T) {
 				return []runtime.Object{cm}
 			}(),
 			fakeEtcdClientOptions: etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1}),
-			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy voting members found: [https://10.0.139.78:1234], none are pending deletion"),
+			expectedError:         fmt.Errorf("cannot proceed with scaling down, unhealthy etcd members found: [https://10.0.139.78:1234]"),
 			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
 				memberList, err := fakeEtcdClient.MemberList(context.TODO())
 				if err != nil {


### PR DESCRIPTION
This PR attempts to allow replacing an unhealthy etcd member from the cluster, with a replacement as learner. It relaxes the scaling down invariant to the minimum tolerable threshold in order to maintain Quorum.