### PR TITLE
library-go vendoring for installer cmd timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openshift/api v0.0.0-20220831183848-09c070622e2c
 	github.com/openshift/build-machinery-go v0.0.0-20220720161851-9b4f0386f6b0
 	github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea
-	github.com/openshift/library-go v0.0.0-20221004015544-d6c64d0262cc
+	github.com/openshift/library-go v0.0.0-20221021005159-d93563844063
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/common v0.32.1

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220720161851-9b4f0386f6b0 h1:uc
 github.com/openshift/build-machinery-go v0.0.0-20220720161851-9b4f0386f6b0/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea h1:7JbjIzWt3Q75ErY1PAZ+gCA+bErI6HSlpffHFmMMzqM=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea/go.mod h1:+J8DqZC60acCdpYkwVy/KH4cudgWiFZRNOBeghCzdGA=
-github.com/openshift/library-go v0.0.0-20221004015544-d6c64d0262cc h1:bmOGYOuO1pV6mSxIBwf9Q76pCV/18utG0DYlh4NJPeU=
-github.com/openshift/library-go v0.0.0-20221004015544-d6c64d0262cc/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
+github.com/openshift/library-go v0.0.0-20221021005159-d93563844063 h1:Mn2LKR04FBEiXk1g2r6cB98G7M3sCUp58qb89Uz5kcE=
+github.com/openshift/library-go v0.0.0-20221021005159-d93563844063/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/config/serving/server.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/serving/server.go
@@ -2,14 +2,17 @@ package serving
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -17,7 +20,7 @@ import (
 )
 
 func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, authenticationConfig operatorv1alpha1.DelegatedAuthentication, authorizationConfig operatorv1alpha1.DelegatedAuthorization,
-	kubeConfigFile string) (*genericapiserver.Config, error) {
+	kubeConfigFile string, kubeClient *kubernetes.Clientset, le *configv1.LeaderElection) (*genericapiserver.Config, error) {
 	scheme := runtime.NewScheme()
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
 	config := genericapiserver.NewConfig(serializer.NewCodecFactory(scheme))
@@ -31,8 +34,6 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 		return nil, err
 	}
 
-	var lastApplyErr error
-
 	pollCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
@@ -44,16 +45,16 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 
 		// In some cases the API server can return connection refused when getting the "extension-apiserver-authentication"
 		// config map.
-		err := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
-			lastApplyErr = authenticationOptions.ApplyTo(&config.Authentication, config.SecureServing, config.OpenAPIConfig)
-			if lastApplyErr != nil {
-				klog.V(4).Infof("Error initializing delegating authentication (will retry): %v", lastApplyErr)
-				return false, nil
+		if le != nil && !le.Disable {
+			err := assertAPIConnection(pollCtx, kubeClient, le)
+			if err != nil {
+				return nil, fmt.Errorf("failed checking apiserver connectivity: %w", err)
 			}
-			return true, nil
-		}, pollCtx.Done())
+		}
+
+		err = authenticationOptions.ApplyTo(&config.Authentication, config.SecureServing, config.OpenAPIConfig)
 		if err != nil {
-			return nil, lastApplyErr
+			return nil, fmt.Errorf("error initializing delegating authentication: %w", err)
 		}
 	}
 
@@ -68,18 +69,35 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 
 		// In some cases the API server can return connection refused when getting the "extension-apiserver-authentication"
 		// config map.
-		err := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
-			lastApplyErr = authorizationOptions.ApplyTo(&config.Authorization)
-			if lastApplyErr != nil {
-				klog.V(4).Infof("Error initializing delegating authorization (will retry): %v", err)
-				return false, nil
+		if le != nil && !le.Disable {
+			err := assertAPIConnection(pollCtx, kubeClient, le)
+			if err != nil {
+				return nil, fmt.Errorf("failed checking connectivity: %w", err)
 			}
-			return true, nil
-		}, pollCtx.Done())
+		}
+
+		err := authorizationOptions.ApplyTo(&config.Authorization)
 		if err != nil {
-			return nil, lastApplyErr
+			return nil, fmt.Errorf("error initializing delegating authentication: %w", err)
 		}
 	}
 
 	return config, nil
+}
+
+func assertAPIConnection(ctx context.Context, kubeClient *kubernetes.Clientset, le *configv1.LeaderElection) error {
+	var lastErr error
+	err := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
+		_, lastErr = kubeClient.CoordinationV1().Leases(le.Namespace).Get(ctx, le.Name, metav1.GetOptions{})
+		if lastErr != nil && !apierrors.IsNotFound(lastErr) {
+			klog.V(4).Infof("Error checking for connectivity to apiserver (GET lease %s/%s): %v", le.Namespace, le.Name, lastErr)
+			return false, nil
+		}
+		return true, nil
+	}, ctx.Done())
+	if err != nil {
+		return lastErr
+	}
+
+	return nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
@@ -269,7 +269,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 
 	var server *genericapiserver.GenericAPIServer
 	if b.servingInfo != nil {
-		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig)
+		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig, kubeClient, b.leaderElection)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -157,6 +157,7 @@ func (o *InstallOptions) Complete() error {
 	protoConfig := rest.CopyConfig(clientConfig)
 	protoConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
 	protoConfig.ContentType = "application/vnd.kubernetes.protobuf"
+	protoConfig.Timeout = 14 * time.Second
 
 	o.KubeClient, err = kubernetes.NewForConfig(protoConfig)
 	if err != nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -368,7 +368,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 }
 
 func (c *StaticResourceController) Name() string {
-	return "StaticResourceController"
+	return c.name
 }
 
 func (c *StaticResourceController) RelatedObjects() ([]configv1.ObjectReference, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -276,7 +276,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20221004015544-d6c64d0262cc
+# github.com/openshift/library-go v0.0.0-20221021005159-d93563844063
 ## explicit; go 1.18
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
Continuing research via [Trt-589](https://issues.redhat.com//browse/Trt-589) into an issue where installer pods timeout, shutdown and enter a failed state triggering KubePodNotReady alerts. library-go was updated to lower the installer cmd timeout (from 1m to 14s) to allow for more frequent retries. Bumping the version to pull those changes in.