### PR TITLE
OCPBUGS-4193: later bootstrap removal in delayed scaling

### DIFF
--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
@@ -168,10 +168,11 @@ func (c *BootstrapTeardownController) canRemoveEtcdBootstrap(ctx context.Context
 		if len(members) < 4 {
 			return false, hasBootstrap, bootstrapMemberID, nil
 		}
-	case ceohelpers.DelayedHAScalingStrategy, ceohelpers.UnsafeScalingStrategy:
-		// TODO(thomas): it's unclear whether DelayedHAScalingStrategy needs special treatment here
-		// we assume it needs < 3, waiting for two nodes+boostrap to continue installation.
-		// context: https://github.com/openshift/cluster-etcd-operator/pull/951
+	case ceohelpers.DelayedHAScalingStrategy:
+		if len(members) < 3 {
+			return false, hasBootstrap, bootstrapMemberID, nil
+		}
+	case ceohelpers.UnsafeScalingStrategy:
 		if len(members) < 2 {
 			return false, hasBootstrap, bootstrapMemberID, nil
 		}

--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller_test.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller_test.go
@@ -1,0 +1,143 @@
+package bootstrapteardown
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
+	u "github.com/openshift/cluster-etcd-operator/pkg/testutils"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+)
+
+func TestCanRemoveEtcdBootstrap(t *testing.T) {
+
+	defaultEtcdMembers := []*etcdserverpb.Member{
+		u.FakeEtcdMemberWithoutServer(1),
+		u.FakeEtcdMemberWithoutServer(2),
+		u.FakeEtcdMemberWithoutServer(3),
+	}
+
+	tests := map[string]struct {
+		etcdMembers     []*etcdserverpb.Member
+		clientFakeOpts  etcdcli.FakeClientOption
+		scalingStrategy ceohelpers.BootstrapScalingStrategy
+		safeToRemove    bool
+		hasBootstrap    bool
+		bootstrapId     uint64
+	}{
+		"default happy path no bootstrap": {
+			etcdMembers:     defaultEtcdMembers,
+			scalingStrategy: ceohelpers.HAScalingStrategy,
+			safeToRemove:    false,
+			hasBootstrap:    false,
+			bootstrapId:     uint64(0),
+		},
+		"HA happy path with bootstrap": {
+			etcdMembers:     append(defaultEtcdMembers, u.FakeEtcdBoostrapMember(0)),
+			scalingStrategy: ceohelpers.HAScalingStrategy,
+			safeToRemove:    true,
+			hasBootstrap:    true,
+			bootstrapId:     uint64(0),
+		},
+		"HA happy path with bootstrap and not enough members": {
+			etcdMembers: []*etcdserverpb.Member{
+				u.FakeEtcdBoostrapMember(0),
+				u.FakeEtcdMemberWithoutServer(1),
+				u.FakeEtcdMemberWithoutServer(2),
+			},
+			scalingStrategy: ceohelpers.HAScalingStrategy,
+			safeToRemove:    false,
+			hasBootstrap:    true,
+			bootstrapId:     uint64(0),
+		},
+		"HA with unhealthy member": {
+			etcdMembers:     append(defaultEtcdMembers, u.FakeEtcdBoostrapMember(0)),
+			clientFakeOpts:  etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Unhealthy: 1, Healthy: 3}),
+			scalingStrategy: ceohelpers.HAScalingStrategy,
+			safeToRemove:    false,
+			hasBootstrap:    true,
+			bootstrapId:     uint64(0),
+		},
+		"HA with unhealthy bootstrap": {
+			etcdMembers: []*etcdserverpb.Member{
+				u.FakeEtcdBoostrapMember(0),
+				u.FakeEtcdMemberWithoutServer(1),
+				u.FakeEtcdMemberWithoutServer(2),
+				u.FakeEtcdMemberWithoutServer(3),
+			},
+			clientFakeOpts:  etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Unhealthy: 1, Healthy: 3}),
+			scalingStrategy: ceohelpers.HAScalingStrategy,
+			safeToRemove:    true,
+			hasBootstrap:    true,
+			bootstrapId:     uint64(0),
+		},
+		"DelayedScaling happy path no bootstrap": {
+			etcdMembers:     defaultEtcdMembers,
+			scalingStrategy: ceohelpers.DelayedHAScalingStrategy,
+			safeToRemove:    false,
+			hasBootstrap:    false,
+			bootstrapId:     uint64(0),
+		},
+		"DelayedScaling happy path with bootstrap": {
+			etcdMembers:     append(defaultEtcdMembers, u.FakeEtcdBoostrapMember(0)),
+			scalingStrategy: ceohelpers.DelayedHAScalingStrategy,
+			safeToRemove:    true,
+			hasBootstrap:    true,
+			bootstrapId:     uint64(0),
+		},
+		"DelayedScaling happy path with bootstrap and just enough members": {
+			etcdMembers: []*etcdserverpb.Member{
+				u.FakeEtcdBoostrapMember(0),
+				u.FakeEtcdMemberWithoutServer(1),
+				u.FakeEtcdMemberWithoutServer(2),
+			},
+			scalingStrategy: ceohelpers.DelayedHAScalingStrategy,
+			safeToRemove:    true,
+			hasBootstrap:    true,
+			bootstrapId:     uint64(0),
+		},
+		"DelayedScaling happy path with bootstrap and not enough members": {
+			etcdMembers: []*etcdserverpb.Member{
+				u.FakeEtcdBoostrapMember(0),
+				u.FakeEtcdMemberWithoutServer(1),
+			},
+			scalingStrategy: ceohelpers.DelayedHAScalingStrategy,
+			safeToRemove:    true, // TODO(thomas): this could be false
+			hasBootstrap:    true,
+			bootstrapId:     uint64(0),
+		},
+		"UnsafeScaling happy path with bootstrap and enough members": {
+			etcdMembers: []*etcdserverpb.Member{
+				u.FakeEtcdBoostrapMember(0),
+				u.FakeEtcdMemberWithoutServer(1),
+			},
+			scalingStrategy: ceohelpers.UnsafeScalingStrategy,
+			safeToRemove:    true,
+			hasBootstrap:    true,
+			bootstrapId:     uint64(0),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if test.clientFakeOpts == nil {
+				test.clientFakeOpts = etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Unhealthy: 0})
+			}
+			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(test.etcdMembers, test.clientFakeOpts)
+			require.NoError(t, err)
+
+			c := &BootstrapTeardownController{
+				etcdClient: fakeEtcdClient,
+			}
+
+			safeToRemoveBootstrap, hasBootstrap, bootstrapId, err := c.canRemoveEtcdBootstrap(context.TODO(), test.scalingStrategy)
+			require.NoError(t, err)
+			require.Equal(t, test.safeToRemove, safeToRemoveBootstrap, "safe to remove")
+			require.Equal(t, test.hasBootstrap, hasBootstrap, "has bootstrap")
+			require.Equal(t, test.bootstrapId, bootstrapId, "bootstrap id")
+		})
+	}
+
+}

--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller_test.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller_test.go
@@ -104,7 +104,7 @@ func TestCanRemoveEtcdBootstrap(t *testing.T) {
 				u.FakeEtcdMemberWithoutServer(1),
 			},
 			scalingStrategy: ceohelpers.DelayedHAScalingStrategy,
-			safeToRemove:    true, // TODO(thomas): this could be false
+			safeToRemove:    false,
 			hasBootstrap:    true,
 			bootstrapId:     uint64(0),
 		},

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -232,6 +232,15 @@ func FakeEtcdMemberWithoutServer(member int) *etcdserverpb.Member {
 	}
 }
 
+func FakeEtcdBoostrapMember(member int) *etcdserverpb.Member {
+	return &etcdserverpb.Member{
+		Name:       "etcd-bootstrap",
+		ClientURLs: []string{fmt.Sprintf("https://10.0.0.%d:2907", member+1)},
+		PeerURLs:   []string{fmt.Sprintf("https://10.0.0.%d:2380", member+1)},
+		ID:         uint64(member),
+	}
+}
+
 func AsLearner(member *etcdserverpb.Member) *etcdserverpb.Member {
 	member.IsLearner = true
 	return member


### PR DESCRIPTION
including the tests from https://github.com/openshift/cluster-etcd-operator/pull/955