### PR TITLE
OCPBUGS-5516: avoid lister cache inconsistency in etcd cert signer

### DIFF
--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -379,7 +379,6 @@ func setupControllerWithEtcd(t *testing.T, objects []runtime.Object, etcdMembers
 		kubeClient:     fakeKubeClient,
 		operatorClient: fakeOperatorClient,
 		nodeLister:     corev1listers.NewNodeLister(indexer),
-		secretLister:   corev1listers.NewSecretLister(indexer),
 		secretClient:   fakeKubeClient.CoreV1(),
 		quorumChecker:  quorumChecker,
 	}


### PR DESCRIPTION
This is to avoid restore inconsistencies where we rely on the lister cache. For the cert generation we should directly get the secret from the API like the apply does.