### PR TITLE
pkg/operator/defragcontroller: Fix "stabalize" -> "stabilize" typo

### DIFF
--- a/pkg/operator/defragcontroller/defragcontroller.go
+++ b/pkg/operator/defragcontroller/defragcontroller.go
@@ -204,7 +204,7 @@ func (c *DefragController) runDefrag(ctx context.Context, recorder events.Record
 					}
 					return true, nil
 				}); err != nil {
-				errors = append(errors, fmt.Errorf("timeout waiting for cluster to stabalize after defrag: %w", err))
+				errors = append(errors, fmt.Errorf("timeout waiting for cluster to stabilize after defrag: %w", err))
 			}
 		} else {
 			// no fragmentation needed is also a success


### PR DESCRIPTION
The typo snuck into logs with the initial controller implementation in 4a197b0d2c (#625).