### PR TITLE
pkg/operator/etcdmemberscontroller: Slugify "No quorum" to "NoQuorum"

### DIFF
--- a/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
+++ b/pkg/operator/etcdmemberscontroller/etcdmemberscontroller.go
@@ -138,7 +138,7 @@ func (c *EtcdMembersController) reportEtcdMembers(ctx context.Context, recorder 
 		_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    "EtcdMembersAvailable",
 			Status:  operatorv1.ConditionFalse,
-			Reason:  "No quorum",
+			Reason:  "NoQuorum",
 			Message: memberHealth.Status(),
 		}))
 		if updateErr != nil {


### PR DESCRIPTION
From [the API docs][1]:

> reason is the CamelCase reason for the condition's current status.

This change will get us `EtcdMembers_NoQuorum` instead of the current `EtcdMembers_No quorum`

[1]: https://github.com/openshift/api/blob/cce310ad2932f6de24491052d506926e484c082c/config/v1/types_cluster_operator.go#L131-L133