### PR TITLE
adding a skip hash to restore pod yaml, to be able to restore from the db file

### DIFF
--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -59,7 +59,8 @@ spec:
          --initial-cluster=$ETCD_INITIAL_CLUSTER \
          --initial-cluster-token "openshift-etcd-${UUID}" \
          --initial-advertise-peer-urls $ETCD_NODE_PEER_URL \
-         --data-dir="/var/lib/etcd/restore-${UUID}"
+         --data-dir="/var/lib/etcd/restore-${UUID}" \
+         --skip-hash-check=true
 
         mv /var/lib/etcd/restore-${UUID}/* /var/lib/etcd/
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1049,7 +1049,8 @@ spec:
          --initial-cluster=$ETCD_INITIAL_CLUSTER \
          --initial-cluster-token "openshift-etcd-${UUID}" \
          --initial-advertise-peer-urls $ETCD_NODE_PEER_URL \
-         --data-dir="/var/lib/etcd/restore-${UUID}"
+         --data-dir="/var/lib/etcd/restore-${UUID}" \
+         --skip-hash-check=true
 
         mv /var/lib/etcd/restore-${UUID}/* /var/lib/etcd/
 


### PR DESCRIPTION
Adding this PR to just add `--skip-hash-check=true` to the restore command to be able to restore from the `db` file if the snapshot is not generated.

Signed-off-by: Vladislav Walek <22072258+vwalek@users.noreply.github.com>