### PR TITLE
OCPBUGS-7374: set default timeouts in etcdcli

### DIFF
--- a/pkg/cmd/verify/backupstorage.go
+++ b/pkg/cmd/verify/backupstorage.go
@@ -132,6 +132,8 @@ func (v *verifyBackupStorage) isStorageAdequate(ctx context.Context) (bool, erro
 	}
 	defer cli.Close()
 
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	members, err := cli.MemberList(ctx)
 	if err != nil {
 		klog.Warningf("failed checking member list: %v", err)

--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -39,6 +39,7 @@ const (
 	BootstrapIPAnnotationKey = "alpha.installer.openshift.io/etcd-bootstrap"
 	DefaultDialTimeout       = 15 * time.Second
 	DefragDialTimeout        = 60 * time.Second
+	DefaultClientTimeout     = 30 * time.Second
 )
 
 type etcdClientGetter struct {
@@ -135,7 +136,7 @@ func newEtcdClientWithClientOpts(endpoints []string, skipConnectionTest bool, op
 	}
 
 	// Test client connection.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultClientTimeout)
 	defer cancel()
 	_, err = cli.MemberList(ctx)
 	if err != nil {
@@ -156,6 +157,8 @@ func (g *etcdClientGetter) MemberAddAsLearner(ctx context.Context, peerURL strin
 
 	defer g.clientPool.Return(cli)
 
+	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
+	defer cancel()
 	membersResp, err := cli.MemberList(ctx)
 	if err != nil {
 		return err
@@ -203,6 +206,8 @@ func (g *etcdClientGetter) MemberPromote(ctx context.Context, member *etcdserver
 		}
 	}()
 
+	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
+	defer cancel()
 	_, err = cli.MemberPromote(ctx, member.ID)
 	return err
 }
@@ -228,6 +233,8 @@ func (g *etcdClientGetter) MemberUpdatePeerURL(ctx context.Context, id uint64, p
 
 	defer g.clientPool.Return(cli)
 
+	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
+	defer cancel()
 	_, err = cli.MemberUpdate(ctx, id, peerURLs)
 	if err != nil {
 		return err
@@ -243,6 +250,8 @@ func (g *etcdClientGetter) MemberRemove(ctx context.Context, memberID uint64) er
 
 	defer g.clientPool.Return(cli)
 
+	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
+	defer cancel()
 	_, err = cli.MemberRemove(ctx, memberID)
 	if err == nil {
 		g.eventRecorder.Eventf("MemberRemove", "removed member with ID: %v", memberID)
@@ -258,6 +267,8 @@ func (g *etcdClientGetter) MemberList(ctx context.Context) ([]*etcdserverpb.Memb
 
 	defer g.clientPool.Return(cli)
 
+	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
+	defer cancel()
 	membersResp, err := cli.MemberList(ctx)
 	if err != nil {
 		return nil, err
@@ -282,6 +293,8 @@ func (g *etcdClientGetter) Status(ctx context.Context, clientURL string) (*clien
 	}
 
 	defer g.clientPool.Return(cli)
+	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
+	defer cancel()
 	return cli.Status(ctx, clientURL)
 }
 
@@ -319,6 +332,8 @@ func (g *etcdClientGetter) UnhealthyMembers(ctx context.Context) ([]*etcdserverp
 
 	defer g.clientPool.Return(cli)
 
+	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
+	defer cancel()
 	etcdCluster, err := cli.MemberList(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get member list %v", err)
@@ -357,6 +372,8 @@ func (g *etcdClientGetter) HealthyMembers(ctx context.Context) ([]*etcdserverpb.
 
 	defer g.clientPool.Return(cli)
 
+	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
+	defer cancel()
 	etcdCluster, err := cli.MemberList(ctx)
 	if err != nil {
 		return nil, err
@@ -386,6 +403,8 @@ func (g *etcdClientGetter) MemberHealth(ctx context.Context) (memberHealth, erro
 
 	defer g.clientPool.Return(cli)
 
+	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
+	defer cancel()
 	etcdCluster, err := cli.MemberList(ctx)
 	if err != nil {
 		return nil, err
@@ -419,6 +438,8 @@ func (g *etcdClientGetter) MemberStatus(ctx context.Context, member *etcdserverp
 	if len(member.ClientURLs) == 0 && member.Name == "" {
 		return EtcdMemberStatusNotStarted
 	}
+	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
+	defer cancel()
 	_, err = cli.Status(ctx, member.ClientURLs[0])
 	if err != nil {
 		klog.Errorf("error getting etcd member %s status: %#v", member.Name, err)

--- a/pkg/etcdcli/etcdcli_pool.go
+++ b/pkg/etcdcli/etcdcli_pool.go
@@ -138,7 +138,7 @@ func NewDefaultEtcdClientPool(newFunc func() (*clientv3.Client, error), endpoint
 		if client == nil {
 			return fmt.Errorf("cached client was nil")
 		}
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultClientTimeout)
 		defer cancel()
 		_, err := client.MemberList(ctx)
 		if err != nil {


### PR DESCRIPTION
The ceo operator connect to etcd without timeout, which may lead to some ceo controllers(like EtcdEndpointsController, EtcdCertSignerController and so on ) may be stuck in etcd member list interface about 15minutes, which finally may be closed by the operating system after 15 minutes

[issue1000: fix ceo connection timeout ](https://github.com/openshift/cluster-etcd-operator/issues/1000)

1. this problem can be reproduced by rm one master node, and the pprof top info will show like this:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/30207518/218005561-1792bc6a-547b-42fb-936d-f1d6d6d33e75.png">

2. maybe the 60s is not suitable for most conditions，we can discuss about this

Signed-off-by: lan.tian <lance5890@163.com>