### PR TITLE
document adaptation with ceo

### DIFF
--- a/docs/etcd-tls-assets.md
+++ b/docs/etcd-tls-assets.md
@@ -594,7 +594,7 @@ of all these certs and secrets.
 ### Prune controller
 
 Launches a pruner pod - again under the `installer-sa` service account
-- on each node that runs `cluster-kube-apiserver-operator prune` to
+- on each node that runs `cluster-etcd-operator prune` to
 delete old revisions from disk. Also deletes old revisions of the API
 resources.
 


### PR DESCRIPTION
1. The Prune func are general methods for all static pod(like  kube-apiserver,  kube-controller-manager, kube-scheduler, etcd)
2. But in the ceo docs, the description should  be used for cluster-etcd-operator as an example, to avoid misleading