### PR TITLE
OCPBUGS-1153: Add etcd operator roles and clusterrole

### DIFF
--- a/manifests/0000_20_etcd-operator_11_clusterrole.yaml
+++ b/manifests/0000_20_etcd-operator_11_clusterrole.yaml
@@ -1,0 +1,83 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-operator-cluster-role
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    - nodes
+    - secrets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+  - apiGroups:
+    - config.openshift.io
+    resources:
+    - apiservers
+    - clusteroperators
+    - clusterversions
+    - infrastructures
+    - networks
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - config.openshift.io
+    resourceNames:
+    - etcd
+    resources:
+    - clusteroperators/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - operator.openshift.io
+    resources:
+    - etcds
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - operator.openshift.io
+    resourceNames:
+    - cluster
+    resources:
+    - etcds/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - clusterrolebindings
+    verbs:
+    - get
+    - list
+    - watch

--- a/manifests/0000_20_etcd-operator_12_operatorrole.yaml
+++ b/manifests/0000_20_etcd-operator_12_operatorrole.yaml
@@ -1,0 +1,97 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-operator-role
+  namespace: openshift-etcd-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  rules:
+  - apiGroups:
+    - ""
+    resourceNames:
+    - openshift-cluster-etcd-operator-lock
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - coordination.k8s.io
+    resourceNames:
+    - openshift-cluster-etcd-operator-lock
+    resources:
+    - leases
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    - pods
+    - serviceaccounts
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resourceNames:
+    - etcd-all-certs-6
+    resources:
+    - secrets
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resourceNames:
+    - etcd
+    resources:
+    - services
+    verbs:
+    - get
+  - apiGroups:
+    - apps
+    resourceNames:
+    - etcd-quorum-guard
+    resources:
+    - deployments
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - policy
+    resourceNames:
+    - etcd-quorum-guard
+    resources:
+    - poddisruptionbudgets
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resourceNames:
+    - revision-status-1
+    resources:
+    - configmaps
+    verbs:
+    - delete

--- a/manifests/0000_20_etcd-operator_13_rrolebinding.yaml
+++ b/manifests/0000_20_etcd-operator_13_rrolebinding.yaml
@@ -1,13 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: system:openshift:operator:etcd-operator
+  namespace: openshift-etcd-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:
-  kind: ClusterRole
-  name: etcd-operator-cluster-role
+  kind: Role
+  name: etcd-operator-role
 subjects:
 - kind: ServiceAccount
   namespace: openshift-etcd-operator


### PR DESCRIPTION
This PR add replaces usage ClusterRole cluster-admin with ClusterRole and Role for etcd operator.

The ClusterRole and Role added in this PR are reverse engineering using https://github.com/liggitt/audit2rbac.
After inspecting the kube-apiserver audit logs using the tools, I was able to identify the resources and verbs required by the operator.

resolves https://issues.redhat.com/browse/OCPBUGS-1153