### PR TITLE
WIP service: remove prometheus scrape annotations, update selector

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app: etcd
     k8s-app: etcd
-    etcd: "true"
     revision: "REVISION"
 spec:
   initContainers:

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: etcd
     k8s-app: etcd
-    etcd: "true"
     revision: "REVISION"
 spec:
   containers:

--- a/bindata/etcd/svc.yaml
+++ b/bindata/etcd/svc.yaml
@@ -5,8 +5,6 @@ metadata:
   name: etcd
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
-    prometheus.io/scrape: "true"
-    prometheus.io/scheme: https
   labels:
     # this label is used to indicate that it should be scraped by prometheus
     k8s-app: etcd

--- a/bindata/etcd/svc.yaml
+++ b/bindata/etcd/svc.yaml
@@ -10,7 +10,7 @@ metadata:
     k8s-app: etcd
 spec:
   selector:
-    etcd: "true"
+    k8s-app: etcd
   ports:
     - name: etcd
       port: 2379

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -622,7 +622,6 @@ metadata:
   labels:
     app: etcd
     k8s-app: etcd
-    etcd: "true"
     revision: "REVISION"
 spec:
   initContainers:
@@ -996,7 +995,6 @@ metadata:
   labels:
     app: etcd
     k8s-app: etcd
-    etcd: "true"
     revision: "REVISION"
 spec:
   containers:
@@ -1198,7 +1196,7 @@ metadata:
     k8s-app: etcd
 spec:
   selector:
-    etcd: "true"
+    k8s-app: etcd
   ports:
     - name: etcd
       port: 2379

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1193,8 +1193,6 @@ metadata:
   name: etcd
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
-    prometheus.io/scrape: "true"
-    prometheus.io/scheme: https
   labels:
     # this label is used to indicate that it should be scraped by prometheus
     k8s-app: etcd


### PR DESCRIPTION
Scrape annotations are no longer used, metrics are being collected using ServiceMonitor.
Service selector is updated to stop CEO from rewriting service spec generated on bootstrap.

This stops SNO nodes from unnecessary service update - i.e https://github.com/vrutkovs/resourcewatch-sno/commit/6a8147ed061a45a7cc9d9d68705fbfa529404d1c