### PR TITLE
manifests: bump loglevel of operator to normal

### DIFF
--- a/manifests/0000_20_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_20_etcd-operator_06_deployment.yaml
@@ -45,7 +45,6 @@ spec:
         command: ["cluster-etcd-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
-        - "-v=4"
         - "--terminate-on-files=/var/run/secrets/serving-cert/tls.crt"
         - "--terminate-on-files=/var/run/secrets/serving-cert/tls.key"
         resources:


### PR DESCRIPTION
[issue 1061](https://github.com/openshift/cluster-etcd-operator/issues/1061)