### PR TITLE
[OSD-16903] Limit etcdDatabaseHighFragmentationRatio to 100MB+

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "d358e35f3e614b171009d6599a63460eac03d019",
-      "sum": "IkDHlaE0gvvcPjSNurFT+jQ2aCOAbqHF1WVmXbAgkds="
+      "version": "d3233fec0ab260b957198d9f636497f9f3e7cec4",
+      "sum": "GdePvMDfLQcVhwzk/Ephi/jC27ywGObLB5t0eC0lXd4="
     }
   ],
   "legacyImports": false

--- a/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/mixin.libsonnet
+++ b/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/mixin.libsonnet
@@ -241,7 +241,7 @@
           {
             alert: 'etcdDatabaseHighFragmentationRatio',
             expr: |||
-              (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+              (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/test.yaml
+++ b/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/test.yaml
@@ -1,17 +1,15 @@
-rule_files:
-  - manifests/etcd-prometheusRules.yaml
-
+---
+rule_files: [manifests/etcd-prometheusRules.yaml]
 evaluation_interval: 1m
-
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{job="etcd",instance="10.10.10.0"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0'
-      - series: 'up{job="etcd",instance="10.10.10.1"}'
-        values: '1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0'
-      - series: 'up{job="etcd",instance="10.10.10.2"}'
-        values: '1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0'
+      - series: up{job="etcd",instance="10.10.10.0"}
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0
+      - series: up{job="etcd",instance="10.10.10.1"}
+        values: 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+      - series: up{job="etcd",instance="10.10.10.2"}
+        values: 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0
     alert_rule_test:
       - eval_time: 3m
         alertname: etcdInsufficientMembers
@@ -27,7 +25,7 @@ tests:
               severity: critical
             exp_annotations:
               description: 'etcd cluster "etcd": members are down (3).'
-              summary: 'etcd cluster members are down.'
+              summary: etcd cluster members are down.
       - eval_time: 7m
         alertname: etcdInsufficientMembers
       - eval_time: 11m
@@ -38,7 +36,7 @@ tests:
               severity: critical
             exp_annotations:
               description: 'etcd cluster "etcd": insufficient members (1).'
-              summary: 'etcd cluster has insufficient number of members.'
+              summary: etcd cluster has insufficient number of members.
       - eval_time: 15m
         alertname: etcdInsufficientMembers
         exp_alerts:
@@ -47,16 +45,15 @@ tests:
               severity: critical
             exp_annotations:
               description: 'etcd cluster "etcd": insufficient members (0).'
-              summary: 'etcd cluster has insufficient number of members.'
-
+              summary: etcd cluster has insufficient number of members.
   - interval: 1m
     input_series:
-      - series: 'up{job="etcd",instance="10.10.10.0"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0'
-      - series: 'up{job="etcd",instance="10.10.10.1"}'
-        values: '1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'up{job="etcd",instance="10.10.10.2"}'
-        values: '1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+      - series: up{job="etcd",instance="10.10.10.0"}
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+      - series: up{job="etcd",instance="10.10.10.1"}
+        values: 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0
+      - series: up{job="etcd",instance="10.10.10.2"}
+        values: 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     alert_rule_test:
       - eval_time: 14m
         alertname: etcdMembersDown
@@ -66,16 +63,15 @@ tests:
               severity: critical
             exp_annotations:
               description: 'etcd cluster "etcd": members are down (3).'
-              summary: 'etcd cluster members are down.'
-
+              summary: etcd cluster members are down.
   - interval: 1m
     input_series:
-      - series: 'up{job="etcd",instance="10.10.10.0"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0'
-      - series: 'up{job="etcd",instance="10.10.10.1"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0'
-      - series: 'etcd_network_peer_sent_failures_total{To="member-1",job="etcd",endpoint="test"}'
-        values: '0 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18'
+      - series: up{job="etcd",instance="10.10.10.0"}
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0
+      - series: up{job="etcd",instance="10.10.10.1"}
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+      - series: etcd_network_peer_sent_failures_total{To="member-1",job="etcd",endpoint="test"}
+        values: 0 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
     alert_rule_test:
       - eval_time: 13m
         alertname: etcdMembersDown
@@ -85,16 +81,15 @@ tests:
               severity: critical
             exp_annotations:
               description: 'etcd cluster "etcd": members are down (1).'
-              summary: 'etcd cluster members are down.'
-
+              summary: etcd cluster members are down.
   - interval: 1m
     input_series:
-      - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.0"}'
-        values: '0 0 2 0 0 1 0 0 0 0 0 0 0 0 0 0'
-      - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.1"}'
-        values: '0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.2"}'
-        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.0"}
+        values: 0 0 2 0 0 1 0 0 0 0 0 0 0 0 0 0
+      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.1"}
+        values: 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0
+      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.2"}
+        values: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     alert_rule_test:
       - eval_time: 10m
         alertname: etcdHighNumberOfLeaderChanges
@@ -104,61 +99,59 @@ tests:
               severity: warning
             exp_annotations:
               description: 'etcd cluster "etcd": 4 leader changes within the last 15 minutes. Frequent elections may be a sign of insufficient resources, high network latency, or disruptions by other components and should be investigated.'
-              summary: 'etcd cluster has high number of leader changes.'
+              summary: etcd cluster has high number of leader changes.
   - interval: 1m
     input_series:
-      - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.0"}'
-        values: '0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.1"}'
-        values: '0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.2"}'
-        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.0"}
+        values: 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0
+      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.1"}
+        values: 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0
+      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.2"}
+        values: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     alert_rule_test:
       - eval_time: 10m
         alertname: etcdHighNumberOfLeaderChanges
         exp_alerts:
-
   - interval: 1m
     input_series:
-      - series: 'etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.0"}'
-        values: '0+8192x240'
-      - series: 'etcd_server_quota_backend_bytes{job="etcd",instance="10.10.10.0"}'
-        values: '524288+0x240'
-      - series: 'etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.1"}'
-        values: '0+1024x240'
-      - series: 'etcd_server_quota_backend_bytes{job="etcd",instance="10.10.10.1"}'
-        values: '524288+0x240'
+      - series: etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.0"}
+        values: 0+8192x240
+      - series: etcd_server_quota_backend_bytes{job="etcd",instance="10.10.10.0"}
+        values: 524288+0x240
+      - series: etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.1"}
+        values: 0+1024x240
+      - series: etcd_server_quota_backend_bytes{job="etcd",instance="10.10.10.1"}
+        values: 524288+0x240
     alert_rule_test:
       - eval_time: 11m
         alertname: etcdExcessiveDatabaseGrowth
         exp_alerts:
           - exp_labels:
-              instance: '10.10.10.0'
+              instance: 10.10.10.0
               job: etcd
               severity: warning
             exp_annotations:
               description: 'etcd cluster "etcd": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance 10.10.10.0, please check as it might be disruptive.'
-              summary: 'etcd cluster database growing very fast.'
-
+              summary: etcd cluster database growing very fast.
   - interval: 1m
     input_series:
-      - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{job="etcd",instance="10.10.10.0"}'
-        values: '30000+0x10'
-      - series: 'etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.0"}'
-        values: '100000+0x10'
-      - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{job="etcd",instance="10.10.10.1"}'
-        values: '70000+0x10'
-      - series: 'etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.1"}'
-        values: '100000+0x10'
+      - series: etcd_mvcc_db_total_size_in_use_in_bytes{job="etcd",instance="10.10.10.0"}
+        values: 300000000+0x10
+      - series: etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.0"}
+        values: 1000000000+0x10
+      - series: etcd_mvcc_db_total_size_in_use_in_bytes{job="etcd",instance="10.10.10.1"}
+        values: 700000000+0x10
+      - series: etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.1"}
+        values: 1000000000+0x10
     alert_rule_test:
       - eval_time: 11m
         alertname: etcdDatabaseHighFragmentationRatio
         exp_alerts:
           - exp_labels:
-              instance: '10.10.10.0'
+              instance: 10.10.10.0
               job: etcd
               severity: warning
             exp_annotations:
               description: 'etcd cluster "etcd": database size in use on instance 10.10.10.0 is 30% of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
               runbook_url: https://etcd.io/docs/v3.5/op-guide/maintenance/#defragmentation
-              summary: 'etcd database size in use is less than 50% of the actual allocated storage.'
+              summary: etcd database size in use is less than 50% of the actual allocated storage.

--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -112,7 +112,7 @@ spec:
         runbook_url: https://etcd.io/docs/v3.5/op-guide/maintenance/#defragmentation
         summary: etcd database size in use is less than 50% of the actual allocated storage.
       expr: |
-        (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
Limiting alerting of higher percentages in small databases should improve how actionable the alert will be and is present in upstream: https://github.com/etcd-io/etcd/commit/1002346ceb37f1b097d52d72823a1ab7401bfd52 