### PR TITLE
add rev bumps and etcdutl

### DIFF
--- a/bindata/etcd/cluster-backup.sh
+++ b/bindata/etcd/cluster-backup.sh
@@ -122,6 +122,8 @@ backup_latest_kube_static_resources "${BACKUP_TAR_FILE}"
 
 # Download etcdctl and get the etcd snapshot
 dl_etcdctl
+
+# snapshot save will continue to stay in etcdctl
 ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot save "${SNAPSHOT_FILE}"
 
 # Check the integrity of the snapshot
@@ -130,6 +132,7 @@ snapshot_failed=$?
 
 # If check_snapshot_status returned 1 it failed, so exit with code 1
 if [[ $snapshot_failed -eq 1 ]]; then
+  echo "snapshot failed with exit code ${snapshot_failed}"
   exit 1
 fi
 

--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -8,39 +8,45 @@ MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
 RESTORE_ETCD_POD_YAML="${CONFIG_FILE_DIR}/static-pod-resources/etcd-certs/configmaps/restore-etcd-pod/pod.yaml"
 ETCDCTL_BIN_DIR="${CONFIG_FILE_DIR}/static-pod-resources/bin"
 PATH=${PATH}:${ETCDCTL_BIN_DIR}
-KUBECONFIG="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost.kubeconfig"
-export KUBECONFIG
+export KUBECONFIG="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost.kubeconfig"
+export ETCD_ETCDCTL_BIN="etcdctl"
 
-# download etcdctl from upstream release assets
+# download etcdctl from download release image
 function dl_etcdctl {
   if [ -x "$(command -v etcdctl)" ]; then
     echo "etcdctl is already installed"
+    if [ -x "$(command -v etcdutl)" ]; then
+      echo "etcdutl is already installed"
+      export ETCD_ETCDUTL_BIN=etcdutl
+    fi
+
     return
   fi
+
   local etcdimg=${ETCD_IMAGE}
   local etcdctr=$(podman create ${etcdimg} --authfile=/var/lib/kubelet/config.json)
   local etcdmnt=$(podman mount "${etcdctr}")
   [ ! -d ${ETCDCTL_BIN_DIR} ] && mkdir -p ${ETCDCTL_BIN_DIR}
   cp ${etcdmnt}/bin/etcdctl ${ETCDCTL_BIN_DIR}/
+  if [ -f "${etcdmnt}/bin/etcdutl" ]; then
+    cp ${etcdmnt}/bin/etcdutl ${ETCDCTL_BIN_DIR}/
+    export ETCD_ETCDUTL_BIN=etcdutl
+  fi
+
   umount "${etcdmnt}"
   podman rm "${etcdctr}"
   etcdctl version
 }
 
-# execute etcdctl command inside of running etcdctl container
-function exec_etcdctl {
-  local command="$@"
-  local container_id=$(sudo crictl ps --label io.kubernetes.container.name=etcdctl -o json | jq -r '.containers[0].id') || true
-  if [ -z "$container_id" ]; then
-    echo "etcdctl container is not running"
-    exit 1
-  fi
-  crictl exec -it $container_id /bin/sh -c "etcdctl $command"
-}
-
 function check_snapshot_status() {
   local snap_file="$1"
-  if ! etcdctl snapshot status "${snap_file}" -w json; then
+
+  ETCD_CLIENT="${ETCD_ETCDCTL_BIN}"
+  if [ -n "${ETCD_ETCDUTL_BIN}" ]; then
+    ETCD_CLIENT="${ETCD_ETCDUTL_BIN}"
+  fi
+
+  if ! ${ETCD_CLIENT} snapshot status "${snap_file}" -w json; then
     echo "Backup integrity verification failed. Backup appears corrupted. Aborting!"
     return 1
   fi

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -20,7 +20,10 @@ spec:
       - |
         #!/bin/sh
         set -euo pipefail
-
+        
+        # this can be controlled by cluster-restore.sh, which will replace this line entirely when enabled at runtime
+        export ETCD_ETCDCTL_RESTORE_ENABLE_BUMP="false"
+        
         export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
         export ETCD_INITIAL_CLUSTER="${ETCD_NAME}=https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:2380"
         env | grep ETCD | grep -v NODE
@@ -36,6 +39,12 @@ spec:
           echo "please delete the contents of data directory before restoring, running the restore script will do this for you"
           exit 1
         fi
+        
+        ETCD_ETCDCTL_BIN="etcdctl"
+        if [ -x "$(command -v etcdutl)" ]; then
+          echo "found newer etcdutl, using that instead of etcdctl"
+          ETCD_ETCDCTL_BIN="etcdutl"
+        fi      
 
         # check if we have backup file to be restored
         # if the file exist, check if it has not changed size in last 5 seconds
@@ -51,15 +60,22 @@ spec:
             exit 1
           fi
         fi
-
+        
+        BUMP_ARGS=""
+        if [[ "${ETCD_ETCDCTL_RESTORE_ENABLE_BUMP}" == "true" ]]; then
+          echo "enabling restore bump"
+          BUMP_ARGS="--bump-revision 1000000000 --mark-compacted"
+        fi
+                
         UUID=$(uuidgen)
         echo "restoring to a single node cluster"
-        ETCDCTL_API=3 /usr/bin/etcdctl snapshot restore /var/lib/etcd-backup/snapshot.db \
+        ${ETCD_ETCDCTL_BIN} snapshot restore /var/lib/etcd-backup/snapshot.db \
          --name  $ETCD_NAME \
          --initial-cluster=$ETCD_INITIAL_CLUSTER \
          --initial-cluster-token "openshift-etcd-${UUID}" \
          --initial-advertise-peer-urls $ETCD_NODE_PEER_URL \
-         --data-dir="/var/lib/etcd/restore-${UUID}"
+         --data-dir="/var/lib/etcd/restore-${UUID}" \
+         ${BUMP_ARGS}
 
         mv /var/lib/etcd/restore-${UUID}/* /var/lib/etcd/
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -292,6 +292,8 @@ backup_latest_kube_static_resources "${BACKUP_TAR_FILE}"
 
 # Download etcdctl and get the etcd snapshot
 dl_etcdctl
+
+# snapshot save will continue to stay in etcdctl
 ETCDCTL_ENDPOINTS="https://${NODE_NODE_ENVVAR_NAME_IP}:2379" etcdctl snapshot save "${SNAPSHOT_FILE}"
 
 # Check the integrity of the snapshot
@@ -300,6 +302,7 @@ snapshot_failed=$?
 
 # If check_snapshot_status returned 1 it failed, so exit with code 1
 if [[ $snapshot_failed -eq 1 ]]; then
+  echo "snapshot failed with exit code ${snapshot_failed}"
   exit 1
 fi
 
@@ -334,6 +337,7 @@ set -o errtrace
 # There are several customization switches based on env variables:
 # ETCD_RESTORE_SKIP_MOVE_CP_STATIC_PODS - when set this script will not move the other (non-etcd) static pod yamls
 # ETCD_ETCDCTL_RESTORE - when set this script will use ` + "`" + `etcdctl snapshot restore` + "`" + ` instead of a restore pod yaml
+# ETCD_ETCDCTL_RESTORE_ENABLE_BUMP - when set this script will spawn the restore pod with a large enough revision bump
 
 if [[ $EUID -ne 0 ]]; then
   echo "This script must be run as root"
@@ -432,6 +436,11 @@ fi
 dl_etcdctl
 check_snapshot_status "${SNAPSHOT_FILE}"
 
+ETCD_CLIENT="${ETCD_ETCDCTL_BIN+etcdctl}"
+if [ -n "${ETCD_ETCDUTL_BIN}" ]; then
+  ETCD_CLIENT="${ETCD_ETCDUTL_BIN}"
+fi
+
 # Move static pod manifests out of MANIFEST_DIR, if required
 if [ -z "${ETCD_RESTORE_SKIP_MOVE_CP_STATIC_PODS}" ]; then
   mv_static_pods "${AUX_STATIC_POD_LIST[@]}"
@@ -464,14 +473,23 @@ if [ -z "${ETCD_ETCDCTL_RESTORE}" ]; then
   cp -p "${SNAPSHOT_FILE}" "${ETCD_DATA_DIR_BACKUP}"/snapshot.db
 
   echo "starting restore-etcd static pod"
-  cp -p "${RESTORE_ETCD_POD_YAML}" "${MANIFEST_DIR}/etcd-pod.yaml"
+  # ideally this can be solved with jq and a real env var, but we don't have it available at this point
+  if [ -n "${ETCD_ETCDCTL_RESTORE_ENABLE_BUMP}" ]; then
+    sed "s/export ETCD_ETCDCTL_RESTORE_ENABLE_BUMP=\"false\"/export ETCD_ETCDCTL_RESTORE_ENABLE_BUMP=\"true\"/" "${RESTORE_ETCD_POD_YAML}" > "${MANIFEST_DIR}/etcd-pod.yaml"
+  else
+     cp -p "${RESTORE_ETCD_POD_YAML}" "${MANIFEST_DIR}/etcd-pod.yaml"
+  fi
+
 else
   echo "removing etcd data dir..."
   rm -rf "${ETCD_DATA_DIR}"
   mkdir -p "${ETCD_DATA_DIR}"
 
   echo "starting snapshot restore through etcdctl..."
-  etcdctl snapshot restore "${SNAPSHOT_FILE}" --data-dir="${ETCD_DATA_DIR}"
+  if ! ${ETCD_CLIENT} snapshot restore "${SNAPSHOT_FILE}" --data-dir="${ETCD_DATA_DIR}"; then
+      echo "Snapshot restore failed. Aborting!"
+      exit 1
+  fi
 
   # start the original etcd static pod again through the new snapshot
   echo "restoring old etcd pod to start etcd again"
@@ -533,39 +551,45 @@ MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
 RESTORE_ETCD_POD_YAML="${CONFIG_FILE_DIR}/static-pod-resources/etcd-certs/configmaps/restore-etcd-pod/pod.yaml"
 ETCDCTL_BIN_DIR="${CONFIG_FILE_DIR}/static-pod-resources/bin"
 PATH=${PATH}:${ETCDCTL_BIN_DIR}
-KUBECONFIG="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost.kubeconfig"
-export KUBECONFIG
+export KUBECONFIG="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost.kubeconfig"
+export ETCD_ETCDCTL_BIN="etcdctl"
 
-# download etcdctl from upstream release assets
+# download etcdctl from download release image
 function dl_etcdctl {
   if [ -x "$(command -v etcdctl)" ]; then
     echo "etcdctl is already installed"
+    if [ -x "$(command -v etcdutl)" ]; then
+      echo "etcdutl is already installed"
+      export ETCD_ETCDUTL_BIN=etcdutl
+    fi
+
     return
   fi
+
   local etcdimg=${ETCD_IMAGE}
   local etcdctr=$(podman create ${etcdimg} --authfile=/var/lib/kubelet/config.json)
   local etcdmnt=$(podman mount "${etcdctr}")
   [ ! -d ${ETCDCTL_BIN_DIR} ] && mkdir -p ${ETCDCTL_BIN_DIR}
   cp ${etcdmnt}/bin/etcdctl ${ETCDCTL_BIN_DIR}/
+  if [ -f "${etcdmnt}/bin/etcdutl" ]; then
+    cp ${etcdmnt}/bin/etcdutl ${ETCDCTL_BIN_DIR}/
+    export ETCD_ETCDUTL_BIN=etcdutl
+  fi
+
   umount "${etcdmnt}"
   podman rm "${etcdctr}"
   etcdctl version
 }
 
-# execute etcdctl command inside of running etcdctl container
-function exec_etcdctl {
-  local command="$@"
-  local container_id=$(sudo crictl ps --label io.kubernetes.container.name=etcdctl -o json | jq -r '.containers[0].id') || true
-  if [ -z "$container_id" ]; then
-    echo "etcdctl container is not running"
-    exit 1
-  fi
-  crictl exec -it $container_id /bin/sh -c "etcdctl $command"
-}
-
 function check_snapshot_status() {
   local snap_file="$1"
-  if ! etcdctl snapshot status "${snap_file}" -w json; then
+
+  ETCD_CLIENT="${ETCD_ETCDCTL_BIN}"
+  if [ -n "${ETCD_ETCDUTL_BIN}" ]; then
+    ETCD_CLIENT="${ETCD_ETCDUTL_BIN}"
+  fi
+
+  if ! ${ETCD_CLIENT} snapshot status "${snap_file}" -w json; then
     echo "Backup integrity verification failed. Backup appears corrupted. Aborting!"
     return 1
   fi
@@ -1042,7 +1066,10 @@ spec:
       - |
         #!/bin/sh
         set -euo pipefail
-
+        
+        # this can be controlled by cluster-restore.sh, which will replace this line entirely when enabled at runtime
+        export ETCD_ETCDCTL_RESTORE_ENABLE_BUMP="false"
+        
         export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
         export ETCD_INITIAL_CLUSTER="${ETCD_NAME}=https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:2380"
         env | grep ETCD | grep -v NODE
@@ -1058,6 +1085,12 @@ spec:
           echo "please delete the contents of data directory before restoring, running the restore script will do this for you"
           exit 1
         fi
+        
+        ETCD_ETCDCTL_BIN="etcdctl"
+        if [ -x "$(command -v etcdutl)" ]; then
+          echo "found newer etcdutl, using that instead of etcdctl"
+          ETCD_ETCDCTL_BIN="etcdutl"
+        fi      
 
         # check if we have backup file to be restored
         # if the file exist, check if it has not changed size in last 5 seconds
@@ -1073,15 +1106,22 @@ spec:
             exit 1
           fi
         fi
-
+        
+        BUMP_ARGS=""
+        if [[ "${ETCD_ETCDCTL_RESTORE_ENABLE_BUMP}" == "true" ]]; then
+          echo "enabling restore bump"
+          BUMP_ARGS="--bump-revision 1000000000 --mark-compacted"
+        fi
+                
         UUID=$(uuidgen)
         echo "restoring to a single node cluster"
-        ETCDCTL_API=3 /usr/bin/etcdctl snapshot restore /var/lib/etcd-backup/snapshot.db \
+        ${ETCD_ETCDCTL_BIN} snapshot restore /var/lib/etcd-backup/snapshot.db \
          --name  $ETCD_NAME \
          --initial-cluster=$ETCD_INITIAL_CLUSTER \
          --initial-cluster-token "openshift-etcd-${UUID}" \
          --initial-advertise-peer-urls $ETCD_NODE_PEER_URL \
-         --data-dir="/var/lib/etcd/restore-${UUID}"
+         --data-dir="/var/lib/etcd/restore-${UUID}" \
+         ${BUMP_ARGS}
 
         mv /var/lib/etcd/restore-${UUID}/* /var/lib/etcd/
 


### PR DESCRIPTION
This PR will:
* use etcdutl when available, to ease the eventual transition towards 3.6 
* add a rev bump by 1 billion and mark compacted to test the feature in our CI restore job, flagged off by default


