### PR TITLE
dump all goroutines, not the current stack

### DIFF
--- a/pkg/operator/health/aliveness_checker.go
+++ b/pkg/operator/health/aliveness_checker.go
@@ -1,7 +1,7 @@
 package health
 
 import (
-	"runtime/debug"
+	"runtime"
 	"sync"
 
 	"k8s.io/klog/v2"
@@ -31,7 +31,11 @@ func (r *MultiAlivenessChecker) Alive() bool {
 	for s, checker := range r.checkerMap {
 		if !checker.Alive() {
 			klog.Warningf("Controller [%s] didn't sync for a long time, declaring unhealthy and dumping stack", s)
-			debug.PrintStack()
+			// 12 mb should be enough for a full goroutine dump
+			buf := make([]byte, 1024*1024*12)
+			n := runtime.Stack(buf, true)
+			klog.Warningf("%s", buf[:n])
+
 			return false
 		}
 	}


### PR DESCRIPTION
Turns out that debug.PrintStack only outputs the current stack, which is kubelet scraping the /healthz endpoint. Not exactly helpful when trying to figure out where something is stuck on. 

There's another utility to dump all goroutines in the runtime package, which has a boolean parameter "all". 