### PR TITLE
OCPBUGS-16889: machine api check: rely on status more than baseline

### DIFF
--- a/pkg/operator/ceohelpers/machine_api.go
+++ b/pkg/operator/ceohelpers/machine_api.go
@@ -122,9 +122,9 @@ func (m *MachineAPI) IsEnabled() (bool, error) {
 		return false, err
 	}
 
-	// this is a special case introduced from 4.14 on, where MachineAPI can be optional with clusters installed using capabilities.baselineCapabilitySet=None
+	// this is a special case introduced from 4.14 on, where MachineAPI can be optional.
 	// on upgrades from prior versions of OpenShift the status should have MachineAPI listed as an EnabledCapabilities
-	if clusterVersion != nil && clusterVersion.Spec.Capabilities != nil && string(clusterVersion.Spec.Capabilities.BaselineCapabilitySet) == "None" {
+	if clusterVersion != nil {
 		machineAPIEnabled := false
 		for _, capability := range clusterVersion.Status.Capabilities.EnabledCapabilities {
 			if capability == configv1.ClusterVersionCapabilityMachineAPI {

--- a/pkg/operator/ceohelpers/machine_api_test.go
+++ b/pkg/operator/ceohelpers/machine_api_test.go
@@ -28,6 +28,13 @@ func TestIsMachineAPIFunctionalWrapper(t *testing.T) {
 	clusterVersion := &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{Name: "version"},
 		Spec:       configv1.ClusterVersionSpec{},
+		Status: configv1.ClusterVersionStatus{
+			Capabilities: configv1.ClusterVersionCapabilitiesStatus{
+				EnabledCapabilities: []configv1.ClusterVersionCapability{
+					configv1.ClusterVersionCapabilityMachineAPI,
+				},
+			},
+		},
 	}
 
 	scenarios := []struct {


### PR DESCRIPTION
turns out "None" is not easy to depend on, when running an installation with the flags customized you can set different baselines:

```
spec:
  capabilities:
    baselineCapabilitySet: v4.13
  channel: stable-4.14
status:
  availableUpdates: null
  capabilities:
    enabledCapabilities:
    - CSISnapshot
    - Console
    - Insights
    - NodeTuning
    - Storage
    - baremetal
    - marketplace
    - openshift-samples
```

This PR removes the None check entirely and relies on the status fields.