### PR TITLE
OCPBUGS-18357: prepend authfile to podman create

### DIFF
--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -24,7 +24,7 @@ function dl_etcdctl {
   fi
 
   local etcdimg=${ETCD_IMAGE}
-  local etcdctr=$(podman create ${etcdimg} --authfile=/var/lib/kubelet/config.json)
+  local etcdctr=$(podman create --authfile=/var/lib/kubelet/config.json ${etcdimg})
   local etcdmnt=$(podman mount "${etcdctr}")
   [ ! -d ${ETCDCTL_BIN_DIR} ] && mkdir -p ${ETCDCTL_BIN_DIR}
   cp ${etcdmnt}/bin/etcdctl ${ETCDCTL_BIN_DIR}/

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -831,7 +831,7 @@ function dl_etcdctl {
   fi
 
   local etcdimg=${ETCD_IMAGE}
-  local etcdctr=$(podman create ${etcdimg} --authfile=/var/lib/kubelet/config.json)
+  local etcdctr=$(podman create --authfile=/var/lib/kubelet/config.json ${etcdimg})
   local etcdmnt=$(podman mount "${etcdctr}")
   [ ! -d ${ETCDCTL_BIN_DIR} ] && mkdir -p ${ETCDCTL_BIN_DIR}
   cp ${etcdmnt}/bin/etcdctl ${ETCDCTL_BIN_DIR}/


### PR DESCRIPTION
the auth file seems used as a command argument to the container creation instead of a podman option.