### PR TITLE
[release-4.14] OCPBUGS-19553: Update static pod manifests perms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openshift/api v0.0.0-20230816181854-a7ca92db022a
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20230718103934-90d8d813cf54
-	github.com/openshift/library-go v0.0.0-20230724150037-c515269de16e
+	github.com/openshift/library-go v0.0.0-20230922122527-75af1bc5cb98
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/common v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230718103934-90d8d813cf54 h1:eC0E7f19a0z7qGinEF7IYWQcPu4ucITI8m2Y3rpb8DQ=
 github.com/openshift/client-go v0.0.0-20230718103934-90d8d813cf54/go.mod h1:wg7MAQ5/PCTdt+OcgPEY3E8VbffYmNa6bqrMO2cG6sY=
-github.com/openshift/library-go v0.0.0-20230724150037-c515269de16e h1:E8KSHPb3c68Bjf7I7+A6B5M3j7q3qB1r4or94P8Hqd8=
-github.com/openshift/library-go v0.0.0-20230724150037-c515269de16e/go.mod h1:jPcIZk2ReAozFTDX2s9peO5at1Hs1BS6JvoASSk6NqQ=
+github.com/openshift/library-go v0.0.0-20230922122527-75af1bc5cb98 h1:1B7m0/J2CJgZ+Cq4kCAtxqeaNhclV2Haw5GeWlr9q1Q=
+github.com/openshift/library-go v0.0.0-20230922122527-75af1bc5cb98/go.mod h1:ZFwNwC3opc/7aOvzUbU95zp33Lbxet48h80ryH3p6DY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -605,7 +605,7 @@ func (o *InstallOptions) writePod(rawPodBytes []byte, manifestFileName, resource
 	// Write secrets, config maps and pod to disk
 	// This does not need timeout, instead we should fail hard when we are not able to write.
 	klog.Infof("Writing pod manifest %q ...", path.Join(resourceDir, manifestFileName))
-	if err := ioutil.WriteFile(path.Join(resourceDir, manifestFileName), []byte(finalPodBytes), 0644); err != nil {
+	if err := ioutil.WriteFile(path.Join(resourceDir, manifestFileName), []byte(finalPodBytes), 0600); err != nil {
 		return err
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -323,7 +323,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20230724150037-c515269de16e
+# github.com/openshift/library-go v0.0.0-20230922122527-75af1bc5cb98
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
This PR bumps library-go to get the latest static pod permissions(more specifically https://github.com/openshift/library-go/pull/1576).