### PR TITLE
add ownership for etcd-ca-bundle that I don't think is updated

### DIFF
--- a/bindata/bootkube/manifests/etcd-ca-bundle-configmap.yaml
+++ b/bindata/bootkube/manifests/etcd-ca-bundle-configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: etcd-ca-bundle
   namespace: openshift-config
+  annotations:
+    openshift.io/owning-component: Etcd
 data:
   ca-bundle.crt: |
     {{ .EtcdCaBundle | indent 4 }}


### PR DESCRIPTION
This is input from the installer, but its not user provided so it is logically owned by the component