### PR TITLE
Revert "[release-4.13] OCPBUGS-23044: remove revision stability check from bootstrap complet…"

### DIFF
--- a/pkg/operator/ceohelpers/bootstrap.go
+++ b/pkg/operator/ceohelpers/bootstrap.go
@@ -182,13 +182,19 @@ func IsBootstrapComplete(configMapClient corev1listers.ConfigMapLister, staticPo
 		return false, nil
 	}
 
+	// now run check to stability of revisions
 	_, status, _, err := staticPodClient.GetStaticPodOperatorState()
 	if err != nil {
 		return false, fmt.Errorf("failed to get static pod operator state: %w", err)
 	}
-
 	if status.LatestAvailableRevision == 0 {
 		return false, nil
+	}
+	for _, curr := range status.NodeStatuses {
+		if curr.CurrentRevision != status.LatestAvailableRevision {
+			klog.V(4).Infof("bootstrap considered incomplete because revision %d is still in progress", status.LatestAvailableRevision)
+			return false, nil
+		}
 	}
 
 	// check if etcd-bootstrap member is still present within the etcd cluster membership

--- a/pkg/operator/ceohelpers/bootstrap_test.go
+++ b/pkg/operator/ceohelpers/bootstrap_test.go
@@ -197,6 +197,13 @@ func Test_IsBootstrapComplete(t *testing.T) {
 			expectComplete:     true,
 			expectError:        nil,
 		},
+		"bootstrap complete, node progressing": {
+			bootstrapConfigMap: bootstrapComplete,
+			nodes:              twoNodesProgressingTowardsCurrentRevision,
+			etcdMembers:        u.DefaultEtcdMembers(),
+			expectComplete:     false,
+			expectError:        nil,
+		},
 		"bootstrap complete, etcd-bootstrap removed": {
 			bootstrapConfigMap: bootstrapComplete,
 			nodes:              twoNodesAtCurrentRevision,

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
@@ -136,6 +136,37 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 			},
 		},
 		{
+			// The configmap should remain intact because although bootstrapping
+			// reports complete, the nodes are still progressing towards a revision.
+			name: "NewClusterBootstrapNodesProgressing",
+			objects: []runtime.Object{
+				u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
+				u.EndpointsConfigMap(
+					u.WithBootstrapIP("192.0.2.1"),
+					u.WithEndpoint(etcdMembers[0].ID, etcdMembers[0].PeerURLs[0]),
+					u.WithEndpoint(etcdMembers[1].ID, etcdMembers[1].PeerURLs[0]),
+					u.WithEndpoint(etcdMembers[2].ID, etcdMembers[2].PeerURLs[0]),
+				),
+			},
+			staticPodStatus: u.StaticPodOperatorStatus(
+				u.WithLatestRevision(3),
+				u.WithNodeStatusAtCurrentRevision(3),
+				u.WithNodeStatusAtCurrentRevision(2),
+				u.WithNodeStatusAtCurrentRevision(3),
+			),
+			expectBootstrap: true,
+			etcdMembers:     etcdMembers,
+			validateFunc: func(ts *testing.T, endpoints []func(*corev1.ConfigMap), actions []clientgotesting.Action) {
+				for _, action := range actions {
+					if action.Matches("update", "configmaps") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						actual := updateAction.GetObject().(*corev1.ConfigMap)
+						ts.Errorf("unexpected configmap update: %#v", actual)
+					}
+				}
+			},
+		},
+		{
 			// The configmap should remain intact because although nodes appear
 			// to have converged on a revision, bootstrap reports incomplete.
 			name: "NewClusterBootstrapProgressing",


### PR DESCRIPTION
Reverts openshift/cluster-etcd-operator#1151

to be compared with #1165 for AI issues

/hold