### PR TITLE
OCPBUGS-17199: remove revision stability check from bootstrap completeness

### DIFF
--- a/pkg/operator/ceohelpers/bootstrap.go
+++ b/pkg/operator/ceohelpers/bootstrap.go
@@ -182,19 +182,12 @@ func IsBootstrapComplete(configMapClient corev1listers.ConfigMapLister, staticPo
 		return false, nil
 	}
 
-	// now run check to stability of revisions
 	_, status, _, err := staticPodClient.GetStaticPodOperatorState()
 	if err != nil {
 		return false, fmt.Errorf("failed to get static pod operator state: %w", err)
 	}
 	if status.LatestAvailableRevision == 0 {
 		return false, nil
-	}
-	for _, curr := range status.NodeStatuses {
-		if curr.CurrentRevision != status.LatestAvailableRevision {
-			klog.V(4).Infof("bootstrap considered incomplete because revision %d is still in progress", status.LatestAvailableRevision)
-			return false, nil
-		}
 	}
 
 	// check if etcd-bootstrap member is still present within the etcd cluster membership

--- a/pkg/operator/ceohelpers/bootstrap_test.go
+++ b/pkg/operator/ceohelpers/bootstrap_test.go
@@ -197,13 +197,6 @@ func Test_IsBootstrapComplete(t *testing.T) {
 			expectComplete:     true,
 			expectError:        nil,
 		},
-		"bootstrap complete, node progressing": {
-			bootstrapConfigMap: bootstrapComplete,
-			nodes:              twoNodesProgressingTowardsCurrentRevision,
-			etcdMembers:        u.DefaultEtcdMembers(),
-			expectComplete:     false,
-			expectError:        nil,
-		},
 		"bootstrap complete, etcd-bootstrap removed": {
 			bootstrapConfigMap: bootstrapComplete,
 			nodes:              twoNodesAtCurrentRevision,

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -89,7 +89,7 @@ func NewClusterMemberRemovalController(
 	return factory.New().
 		WithSync(syncer.Sync).
 		WithSyncDegradedOnError(operatorClient).
-		ResyncEvery(33*time.Minute). // make it slow since nodes are updated every few minutes
+		ResyncEvery(5*time.Minute). // nodes are updated several times a minute, 5m for safety on getting stuck
 		WithBareInformers(networkInformer.Informer()).
 		WithInformers(
 			masterNodeInformer,
@@ -99,6 +99,13 @@ func NewClusterMemberRemovalController(
 }
 
 func (c *clusterMemberRemovalController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	// only attempt to scale down if the machine API is functional
+	if isFunctional, err := c.machineAPIChecker.IsFunctional(); err != nil {
+		return fmt.Errorf("failed to determine whether machine api is functional: %w", err)
+	} else if !isFunctional {
+		return nil
+	}
+
 	// skip reconciling this controller, if bootstrapping is not completed
 	bootstrapComplete, err := ceohelpers.IsBootstrapComplete(c.configMapLister, c.operatorClient, c.etcdClient)
 	if err != nil {
@@ -108,10 +115,13 @@ func (c *clusterMemberRemovalController) sync(ctx context.Context, syncCtx facto
 		return nil
 	}
 
-	// only attempt to scale down if the machine API is functional
-	if isFunctional, err := c.machineAPIChecker.IsFunctional(); err != nil {
-		return err
-	} else if !isFunctional {
+	// check for stability of revisions, by also taking the node status into account
+	// note that this is an important step for the AssistedInstallers installation procedure.
+	stable, err := c.isRevisionStable()
+	if err != nil {
+		return fmt.Errorf("isRevisionStable failed to determine revision stability: %w", err)
+	}
+	if !stable {
 		return nil
 	}
 
@@ -126,7 +136,45 @@ func (c *clusterMemberRemovalController) sync(ctx context.Context, syncCtx facto
 		errs = append(errs, err)
 	}
 	return kerrors.NewAggregate(errs)
+}
 
+func (c *clusterMemberRemovalController) isRevisionStable() (bool, error) {
+	_, status, _, err := c.operatorClient.GetStaticPodOperatorState()
+	if err != nil {
+		return false, fmt.Errorf("failed to get static pod operator state: %w", err)
+	}
+
+	masterNodes, err := c.masterNodeLister.List(c.masterNodeSelector)
+	if err != nil {
+		return false, fmt.Errorf("failed to list master nodes: %w", err)
+	}
+
+	for _, node := range masterNodes {
+		nodeReady := false
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				nodeReady = true
+			}
+		}
+
+		// There are cases where the installer can be quicker to create a new revision than it can detect a node going away.
+		// This causes the revision check below to infinite loop, waiting forever for the installation on that node.
+		// Subsequently, all healthy other nodes are barred from installing the new revision.
+		// Normally, the machine-api will detect this and replace said node, here we do not want to block the member removal
+		// that can get us out of that situation automatically.
+		if !nodeReady {
+			return true, nil
+		}
+	}
+
+	for _, curr := range status.NodeStatuses {
+		if curr.CurrentRevision != status.LatestAvailableRevision {
+			klog.V(4).Infof("pending revision %d/%d is still in progress on node %s", curr.CurrentRevision, status.LatestAvailableRevision, curr.NodeName)
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 // attemptToScaleDown attempts to remove a voting member only once we have identified that
@@ -232,7 +280,7 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 	// When at the desired control-plane size, scale down is only allowed if a member is unhealthy so that a new machine can replace it.
 	// For healthy members, deleting a machine should result in a new machine being created and member addition before scale down can occur
 	if reflect.DeepEqual(liveVotingMembers, healthyLiveVotingMembers) && len(healthyLiveVotingMembers) <= desiredControlPlaneReplicasCount {
-		klog.V(2).Infof("skip scale down: all voting, non-bootstrap members are healthy and membership does not exceed the desired cluster size of %v", desiredControlPlaneReplicasCount)
+		klog.V(2).Infof("skip scale down: all voting, non-bootstrap members are healthy and membership does not exceed the desired cluster size of %d. Current Members: %v, healthy: %v", desiredControlPlaneReplicasCount, liveVotingMembers, healthyLiveVotingMembers)
 		return nil
 	}
 
@@ -268,7 +316,7 @@ func (c *clusterMemberRemovalController) removeMemberWithoutMachine(ctx context.
 	for _, potentialMemberToRemoveIP := range etcdEndpointsConfigMap.Data {
 		memberLocator := potentialMemberToRemoveIP
 		machine, err := c.getMachineForMember(potentialMemberToRemoveIP)
-		if err != nil && err != errNotFound {
+		if err != nil && !errors.Is(err, errNotFound) {
 			return fmt.Errorf("unable to get a machine for member: %v, err: %v", memberLocator, err)
 		}
 		if machine != nil {
@@ -277,7 +325,7 @@ func (c *clusterMemberRemovalController) removeMemberWithoutMachine(ctx context.
 		}
 
 		node, err := c.getNodeForMember(potentialMemberToRemoveIP)
-		if err != nil && err != errNotFound {
+		if err != nil && !errors.Is(err, errNotFound) {
 			return fmt.Errorf("unable to get a node for member: %v, err: %v", memberLocator, err)
 		}
 		if node != nil {
@@ -370,7 +418,7 @@ func (c *clusterMemberRemovalController) attemptToRemoveLearningMember(ctx conte
 
 func (c *clusterMemberRemovalController) getMachineForMember(memberInternalIP string) (*machinev1beta1.Machine, error) {
 	node, err := c.getNodeForMember(memberInternalIP)
-	if err != nil && err != errNotFound {
+	if err != nil && !errors.Is(err, errNotFound) {
 		return nil, err
 	}
 

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
@@ -136,37 +136,6 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 			},
 		},
 		{
-			// The configmap should remain intact because although bootstrapping
-			// reports complete, the nodes are still progressing towards a revision.
-			name: "NewClusterBootstrapNodesProgressing",
-			objects: []runtime.Object{
-				u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
-				u.EndpointsConfigMap(
-					u.WithBootstrapIP("192.0.2.1"),
-					u.WithEndpoint(etcdMembers[0].ID, etcdMembers[0].PeerURLs[0]),
-					u.WithEndpoint(etcdMembers[1].ID, etcdMembers[1].PeerURLs[0]),
-					u.WithEndpoint(etcdMembers[2].ID, etcdMembers[2].PeerURLs[0]),
-				),
-			},
-			staticPodStatus: u.StaticPodOperatorStatus(
-				u.WithLatestRevision(3),
-				u.WithNodeStatusAtCurrentRevision(3),
-				u.WithNodeStatusAtCurrentRevision(2),
-				u.WithNodeStatusAtCurrentRevision(3),
-			),
-			expectBootstrap: true,
-			etcdMembers:     etcdMembers,
-			validateFunc: func(ts *testing.T, endpoints []func(*corev1.ConfigMap), actions []clientgotesting.Action) {
-				for _, action := range actions {
-					if action.Matches("update", "configmaps") {
-						updateAction := action.(clientgotesting.UpdateAction)
-						actual := updateAction.GetObject().(*corev1.ConfigMap)
-						ts.Errorf("unexpected configmap update: %#v", actual)
-					}
-				}
-			},
-		},
-		{
 			// The configmap should remain intact because although nodes appear
 			// to have converged on a revision, bootstrap reports incomplete.
 			name: "NewClusterBootstrapProgressing",


### PR DESCRIPTION
slightly more involved checking against actual node status now, requires further testing against assisted installer and some refactoring.