### PR TITLE
OCPBUGS-26214: fix device busy errors

### DIFF
--- a/bindata/etcd/cluster-backup-pod.yaml
+++ b/bindata/etcd/cluster-backup-pod.yaml
@@ -37,8 +37,7 @@ spec:
         
         if [ -n "${DELETE_BACKUP_DIR}" ]; then
           echo "removing all backups in ${DELETE_BACKUP_DIR}" 
-          rm -rf "${DELETE_BACKUP_DIR}"
-          mkdir -p "${DELETE_BACKUP_DIR}"
+          rm -rf "${DELETE_BACKUP_DIR}/*"
         fi
 
         /usr/local/bin/cluster-backup.sh --force ${CLUSTER_BACKUP_PATH}

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -385,8 +385,7 @@ spec:
         
         if [ -n "${DELETE_BACKUP_DIR}" ]; then
           echo "removing all backups in ${DELETE_BACKUP_DIR}" 
-          rm -rf "${DELETE_BACKUP_DIR}"
-          mkdir -p "${DELETE_BACKUP_DIR}"
+          rm -rf "${DELETE_BACKUP_DIR}/*"
         fi
 
         /usr/local/bin/cluster-backup.sh --force ${CLUSTER_BACKUP_PATH}


### PR DESCRIPTION
In some file system implementations the root dir can't be removed itself when mounted. This fix will only delete all contents of the directory.