### PR TITLE
ETCD-512: refactoring the cert signer controller

### DIFF
--- a/docs/etcd-tls-assets.md
+++ b/docs/etcd-tls-assets.md
@@ -772,3 +772,53 @@ Eventually, when `cluster-etcd-operator` is installed, running, and
 reporting the `EtcdRunningInCluster = True` condition. This is usually
 when the etcd cluster has scaled to 4, and it is safe to remove the
 bootstrap member.
+
+# The Big CA Cert Rotation
+
+With 4.16 we want to take an initial stab at the rotation of the signer certificates.
+
+The whole process can be split into a two-step migration:
+1. Operator must manage all etcd certificates [CEO#1177](https://github.com/openshift/cluster-etcd-operator/pull/1177) 
+   1. Operator should create new signers, in addition to the current ones in openshift-config. Both bundled and distributed.  
+      This allows us to stop the "death clock" on any existing signer expiration and allowing manual rotation immediately.
+   2. Having the rotation code already in place also enables easier offline rotation [ETCD-510](https://issues.redhat.com/browse/ETCD-510)
+2. Operator must orchestrate an automated signer rotation process
+   1. A new signer needs to be generated, distributed via bundle and static pod rollout
+   2. All certificates must be re-generated using the new signer
+   3. All consumers of client certs (Prometheus, CEO, KAS) need to be notified or must react correctly to a rotated certificate secret
+
+With step (1), we want to move the source-of-truth for etcd certificates into the `openshift-etcd` namespace. This should 
+help in future backup and restore stories, allowing us to more easily collect all certificates required for etcd and guard 
+them better by RBAC.
+
+The above cert summary tables become as follows:
+
+## etcd CA summary
+
+"Old" etcd CAs and their CA bundles remain stored in the `openshift-config` namespace. 
+The new CAs and their bundles are moved to `openshift-etcd`, bundles always contain the old CAs from `openshift-config`. 
+
+| CA (secret)                                      | CA bundle (configmap)                                         |
+|--------------------------------------------------|---------------------------------------------------------------|
+| openshift-config/etcd-signer (deprecated)        | openshift-config/etcd-ca-bundle                               |
+|                                                  | openshift-etcd/etcd-ca-bundle                                 |
+| openshift-etcd/etcd-signer (NEW)                 | openshift-etcd/etcd-ca-bundle                                 |
+| openshift-config/etcd-metric-signer (deprecated) | openshift-config/etcd-metric-serving-ca                       |
+|                                                  | openshift-etcd/etcd-metrics-ca-bundle                         |
+| openshift-etcd/etcd-metric-signer (NEW)          | openshift-config/etcd-metric-serving-ca (to be removed later) |
+|                                                  | openshift-etcd/etcd-metrics-ca-bundle                         |
+
+The new bundles are then distributed using the `ResourceSyncController` to all consumers, e.g. `openshift-etcd-operator`.
+
+## etcd cert summary
+
+All etcd certificates are stored in secrets, bundles are always found in configmaps.
+
+| CA                                               | Certificate                               | Purpose                          | Certificate copied to                      |
+|--------------------------------------------------|-------------------------------------------|----------------------------------|--------------------------------------------|
+| openshift-config/etcd-signer (deprecated)        | openshift-etcd/etcd-client                | authn KAS to etcd                | openshift-config                           |
+|                                                  |                                           | authn CEO to etcd                | openshift-etcd-operator                    |
+|                                                  | openshift-etcd/etcd-peer-$node            | etcd peer communication          | collected in openshift-etcd/etcd-all-certs |
+|                                                  | openshift-etcd/etcd-serving-$node         | etcd member serving              | collected in openshift-etcd/etcd-all-certs |
+| openshift-config/etcd-metric-signer (deprecated) | openshift-etcd/etcd-metric-client         | authn prometheus to etcd metrics | openshift-etcd-operator/etcd-metric-client |
+|                                                  | openshift-etcd/etcd-serving-metrics-$node | etcd member metrics serving      | collected in openshift-etcd/etcd-all-certs |

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openshift/api v0.0.0-20231218131639-7a5aa77cc72d
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20231218140158-47f6d749b9d9
-	github.com/openshift/library-go v0.0.0-20240112145826-26e0d27811cb
+	github.com/openshift/library-go v0.0.0-20240124134907-4dfbf6bc7b11
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/common v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20231218140158-47f6d749b9d9 h1:kjgW3luAkf9NWu+8u+jqNNbexDG+CY82/INw8hGbG14=
 github.com/openshift/client-go v0.0.0-20231218140158-47f6d749b9d9/go.mod h1:kKmxYRXTMutfF7XzGppFdbLhNGX1brXkRsZx5ID8c7U=
-github.com/openshift/library-go v0.0.0-20240112145826-26e0d27811cb h1:RCD3ceA43lALxTwi6ChwphRkreCJtuixJeWpHRDXxh8=
-github.com/openshift/library-go v0.0.0-20240112145826-26e0d27811cb/go.mod h1:82B0gt8XawdXWRtKMrm3jSMTeRsiOSYKCi4F0fvPjG0=
+github.com/openshift/library-go v0.0.0-20240124134907-4dfbf6bc7b11 h1:9alPFotg+mC+HjDM1CgF7jmfpOr4lBgUQK+/5WKYKME=
+github.com/openshift/library-go v0.0.0-20240124134907-4dfbf6bc7b11/go.mod h1:dccfc6I7w8HDcCYFgAzyL8xHyzcDra+n8tuSizvsySQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -1,92 +1,76 @@
 package etcdcertsigner
 
 import (
-	"bytes"
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"strings"
 	"time"
 
+	apiannotations "github.com/openshift/api/annotations"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/health"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/certrotation"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	corev1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/klog/v2"
 
-	apiannotations "github.com/openshift/api/annotations"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
-	"github.com/openshift/cluster-etcd-operator/pkg/dnshelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-etcd-operator/pkg/tlshelpers"
 )
 
-const (
-	// Annotation key used to associate a cert secret with a node uid. This allows
-	// cert regeneration if a node was deleted and added with the same name.
-	nodeUIDAnnotation = "etcd-operator.alpha.openshift.io/cert-secret-node-uid"
+type certConfig struct {
+	// configmap name: "etcd-ca-bundle"
+	signerCaBundle certrotation.CABundleConfigMap
+	// secret name: "etcd-signer"
+	signerCert certrotation.RotatedSigningCASecret
 
-	// The minimum percentage duration of a certificate. If a cert has less than
-	// this percentage of its duration remaining, it will be regenerated.
-	defaultMinDurationPercent = 0.20
-)
+	// configmap name: "etcd-metric-ca-bundle"
+	metricsSignerCaBundle certrotation.CABundleConfigMap
+	// secret name: "etcd-metric-signer"
+	metricsSignerCert certrotation.RotatedSigningCASecret
 
-// etcdCertConfig defines the configuration required to maintain a cert secret for an etcd member.
-type etcdCertConfig struct {
-	// Name of the secret in namespace openshift-config that contains the CA used to issue the cert
-	caSecretName string
-	// Function that derives the name of the cert secret from the node name
-	secretNameFunc func(nodeName string) string
-	// Function that creates the key material for a new cert
-	newCertFunc func(caCert, caKey []byte, ipAddresses []string) (*bytes.Buffer, *bytes.Buffer, error)
+	// secret name: "etcd-metric-client"
+	metricsClientCert certrotation.RotatedSelfSignedCertKeySecret
+	// secret name: "etcd-client"
+	etcdClientCert certrotation.RotatedSelfSignedCertKeySecret
 }
 
-// Define configuration for creating etcd cert secrets.
-var certConfigs = map[string]etcdCertConfig{
-	"peer": {
-		caSecretName:   "etcd-signer",
-		secretNameFunc: tlshelpers.GetPeerClientSecretNameForNode,
-		newCertFunc:    tlshelpers.CreatePeerCertKey,
-	},
-	"serving": {
-		caSecretName:   "etcd-signer",
-		secretNameFunc: tlshelpers.GetServingSecretNameForNode,
-		newCertFunc:    tlshelpers.CreateServerCertKey,
-	},
-	"serving-metrics": {
-		caSecretName:   "etcd-metric-signer",
-		secretNameFunc: tlshelpers.GetServingMetricsSecretNameForNode,
-		newCertFunc:    tlshelpers.CreateMetricCertKey,
-	},
+// nodeCertConfigs contains all certificates generated per node
+type nodeCertConfigs struct {
+	node *corev1.Node
+
+	peerCert    *certrotation.RotatedSelfSignedCertKeySecret
+	servingCert *certrotation.RotatedSelfSignedCertKeySecret
+	metricsCert *certrotation.RotatedSelfSignedCertKeySecret
 }
 
 type EtcdCertSignerController struct {
+	eventRecorder  events.Recorder
 	kubeClient     kubernetes.Interface
 	operatorClient v1helpers.StaticPodOperatorClient
 	nodeLister     corev1listers.NodeLister
+	secretInformer corev1informers.SecretInformer
 	secretLister   corev1listers.SecretLister
 	secretClient   corev1client.SecretsGetter
 	quorumChecker  ceohelpers.QuorumChecker
+
+	certConfig *certConfig
 }
 
 // NewEtcdCertSignerController watches master nodes and maintains secrets for each master node, placing them in a single secret (NOT a tls secret)
 // so that the revision controller only has to watch a single secret.  This isn't ideal because it's possible to have a
 // revision that is missing the content of a secret, but the actual static pod will fail if that happens and the later
 // revision will pick it up.
-// This control loop is considerably less robust than the actual cert rotation controller, but I don't have time at the moment
-// to make the cert rotation controller dynamic.
 func NewEtcdCertSignerController(
 	livenessChecker *health.MultiAlivenessChecker,
 	kubeClient kubernetes.Interface,
@@ -95,13 +79,54 @@ func NewEtcdCertSignerController(
 	eventRecorder events.Recorder,
 	quorumChecker ceohelpers.QuorumChecker,
 ) factory.Controller {
+	eventRecorder = eventRecorder.WithComponentSuffix("etcd-cert-signer-controller")
+	cmInformer := kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps()
+	cmLister := cmInformer.Lister()
+	cmGetter := v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformers)
+	signerCaBundle := tlshelpers.CreateSignerCertRotationBundleConfigMap(
+		cmInformer,
+		cmLister,
+		cmGetter,
+		eventRecorder,
+	)
+
+	metricsSignerCaBundle := tlshelpers.CreateMetricsSignerCertRotationBundleConfigMap(
+		cmInformer,
+		cmLister,
+		cmGetter,
+		eventRecorder,
+	)
+
+	secretInformer := kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets()
+	secretLister := secretInformer.Lister()
+	secretClient := v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformers)
+
+	signerCert := tlshelpers.CreateSignerCert(secretInformer, secretLister, secretClient, eventRecorder)
+	etcdClientCert := tlshelpers.CreateEtcdClientCert(secretInformer, secretLister, secretClient, eventRecorder)
+
+	metricsSignerCert := tlshelpers.CreateMetricsSignerCert(secretInformer, secretLister, secretClient, eventRecorder)
+	metricsClientCert := tlshelpers.CreateMetricsClientCert(secretInformer, secretLister, secretClient, eventRecorder)
+
+	certCfg := &certConfig{
+		signerCaBundle: signerCaBundle,
+		signerCert:     signerCert,
+		etcdClientCert: etcdClientCert,
+
+		metricsSignerCaBundle: metricsSignerCaBundle,
+		metricsSignerCert:     metricsSignerCert,
+		metricsClientCert:     metricsClientCert,
+	}
+
 	c := &EtcdCertSignerController{
+		eventRecorder:  eventRecorder,
 		kubeClient:     kubeClient,
 		operatorClient: operatorClient,
 		nodeLister:     kubeInformers.InformersFor("").Core().V1().Nodes().Lister(),
-		secretLister:   kubeInformers.SecretLister(),
-		secretClient:   v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformers),
+		secretInformer: secretInformer,
+		secretLister:   secretLister,
+		secretClient:   secretClient,
 		quorumChecker:  quorumChecker,
+		certConfig:     certCfg,
 	}
 
 	syncer := health.NewDefaultCheckingSyncWrapper(c.sync)
@@ -109,10 +134,11 @@ func NewEtcdCertSignerController(
 
 	return factory.New().ResyncEvery(time.Minute).WithInformers(
 		kubeInformers.InformersFor("").Core().V1().Nodes().Informer(),
-		kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Informer(),
 		kubeInformers.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace).Core().V1().Secrets().Informer(),
+		cmInformer.Informer(),
+		secretInformer.Informer(),
 		operatorClient.Informer(),
-	).WithSync(syncer.Sync).ToController("EtcdCertSignerController", eventRecorder.WithComponentSuffix("etcd-cert-signer-controller"))
+	).WithSync(syncer.Sync).ToController("EtcdCertSignerController", c.eventRecorder)
 }
 
 func (c *EtcdCertSignerController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
@@ -125,8 +151,7 @@ func (c *EtcdCertSignerController) sync(ctx context.Context, syncCtx factory.Syn
 		return fmt.Errorf("skipping EtcdCertSignerController reconciliation due to insufficient quorum")
 	}
 
-	err = c.syncAllMasters(ctx, syncCtx.Recorder())
-	if err != nil {
+	if err := c.syncAllMasterCertificates(ctx, syncCtx.Recorder()); err != nil {
 		_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    "EtcdCertSignerControllerDegraded",
 			Status:  operatorv1.ConditionTrue,
@@ -146,13 +171,95 @@ func (c *EtcdCertSignerController) sync(ctx context.Context, syncCtx factory.Syn
 			Reason: "AsExpected",
 		}))
 	return updateErr
-
 }
 
-func (c *EtcdCertSignerController) syncAllMasters(ctx context.Context, recorder events.Recorder) error {
-	certs, err := c.ensureCerts(ctx, recorder)
+func (c *EtcdCertSignerController) syncAllMasterCertificates(ctx context.Context, recorder events.Recorder) error {
+	// TODO(thomas): it is of utmost importance to keep the existing signer certs for now
+	// when we just create a new signer cert, the new revision does not allow the peer to join the existing two-node
+	// cluster based on the old CA. Any newly rotated additions will come for free through the signerCaBundle and will work out of the box.
+	// Unfortunately, we can't make use of the certrotation.RotatedSigningCASecret here because it would immediately try to rotate the existing signer.
+	signerCaPair, err := tlshelpers.ReadConfigSignerCert(ctx, c.secretClient)
 	if err != nil {
 		return err
+	}
+
+	// EnsureConfigMapCABundle is stateful w.r.t to the configmap it manages, so we can simply add it to the bundle before the new one
+	_, err = c.certConfig.signerCaBundle.EnsureConfigMapCABundle(ctx, signerCaPair)
+	if err != nil {
+		return fmt.Errorf("error on ensuring signer bundle for existing pair: %w", err)
+	}
+
+	// TODO(thomas): we need to transition that new signer as a replacement for the above - today we only bundle it
+	newSignerCaPair, err := c.certConfig.signerCert.EnsureSigningCertKeyPair(ctx)
+	if err != nil {
+		return fmt.Errorf("error on ensuring etcd-signer cert: %w", err)
+	}
+
+	signerBundle, err := c.certConfig.signerCaBundle.EnsureConfigMapCABundle(ctx, newSignerCaPair)
+	if err != nil {
+		return fmt.Errorf("error on ensuring signer bundle for new pair: %w", err)
+	}
+
+	_, err = c.certConfig.etcdClientCert.EnsureTargetCertKeyPair(ctx, signerCaPair, signerBundle)
+	if err != nil {
+		return fmt.Errorf("error on ensuring etcd client cert: %w", err)
+	}
+
+	metricsSignerCaPair, err := tlshelpers.ReadConfigMetricsSignerCert(ctx, c.secretClient)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.certConfig.metricsSignerCaBundle.EnsureConfigMapCABundle(ctx, metricsSignerCaPair)
+	if err != nil {
+		return fmt.Errorf("error on ensuring metrics signer bundle for existing pair: %w", err)
+	}
+
+	// TODO(thomas): we need to transition that new signer as a replacement for the above - today we only bundle it
+	newMetricsSignerCaPair, err := c.certConfig.metricsSignerCert.EnsureSigningCertKeyPair(ctx)
+	if err != nil {
+		return fmt.Errorf("error on ensuring metrics-signer cert: %w", err)
+	}
+
+	metricsSignerBundle, err := c.certConfig.metricsSignerCaBundle.EnsureConfigMapCABundle(ctx, newMetricsSignerCaPair)
+	if err != nil {
+		return fmt.Errorf("error on ensuring metrics signer bundle: %w", err)
+	}
+
+	_, err = c.certConfig.metricsClientCert.EnsureTargetCertKeyPair(ctx, metricsSignerCaPair, metricsSignerBundle)
+	if err != nil {
+		return fmt.Errorf("error on ensuring metrics client cert: %w", err)
+	}
+
+	nodeCfgs, err := c.createNodeCertConfigs()
+	if err != nil {
+		return fmt.Errorf("error while creating cert configs for nodes: %w", err)
+	}
+
+	allCerts := map[string][]byte{}
+	var errs []error
+	for _, cfg := range nodeCfgs {
+		secret, err := cfg.peerCert.EnsureTargetCertKeyPair(ctx, signerCaPair, signerBundle)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error on peer cert sync: %w", err))
+		}
+		allCerts = addCertSecretToMap(allCerts, secret)
+
+		secret, err = cfg.servingCert.EnsureTargetCertKeyPair(ctx, signerCaPair, signerBundle)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error on serving cert sync: %w", err))
+		}
+		allCerts = addCertSecretToMap(allCerts, secret)
+
+		secret, err = cfg.metricsCert.EnsureTargetCertKeyPair(ctx, metricsSignerCaPair, metricsSignerBundle)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error on serving metrics cert sync: %w", err))
+		}
+		allCerts = addCertSecretToMap(allCerts, secret)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("encountered errors while syncing some certificates: %w", utilerrors.NewAggregate(errs))
 	}
 
 	// Write a secret that aggregates all certs for all nodes for the static
@@ -169,206 +276,69 @@ func (c *EtcdCertSignerController) syncAllMasters(ctx context.Context, recorder 
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
-		Data: certs,
+		Data: allCerts,
 	}
 	_, _, err = resourceapply.ApplySecret(ctx, c.secretClient, recorder, secret)
-	return err
+
+	return nil
 }
 
-// ensureCerts attempts to ensure the existence of valid etcd cert secrets for
-// all master nodes and if successful returns a map of all cert pairs.
-//
-// Example output:
-//
-//	{
-//	  "etcd-peer-master-0.crt":    []byte{...},
-//	  "etcd-peer-master-0.key":    []byte{...},
-//	  "etcd-serving-master-0.crt": []byte{...},
-//	  "etcd-serving-master-0.key": []byte{...},
-//	  ...
-//	}
-func (c *EtcdCertSignerController) ensureCerts(ctx context.Context, recorder events.Recorder) (map[string][]byte, error) {
+// Nodes change internally the whole time (e.g. due to IPs changing), we thus re-create the cert configs every sync loop.
+// This works, because initialization is cheap and all state is kept in secrets, configmaps and their annotations.
+func (c *EtcdCertSignerController) createNodeCertConfigs() ([]*nodeCertConfigs, error) {
+	var cfgs []*nodeCertConfigs
 	nodes, err := c.nodeLister.List(labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector())
 	if err != nil {
-		return nil, err
+		return cfgs, err
 	}
 
-	errs := []error{}
-	certs := map[string][]byte{}
 	for _, node := range nodes {
-		certsForNode, certErrs := c.ensureCertsForNode(ctx, node, recorder)
-		if certErrs != nil {
-			errs = append(errs, certErrs...)
-		}
-		if len(errs) > 0 {
-			// Any error precludes further cert collection
-			continue
-		}
-		for key, value := range certsForNode {
-			// Each key is guaranteed to be unique by virtue of embedding the
-			// cert type and node name.
-			certs[key] = value
-		}
-	}
-	if len(errs) > 0 {
-		return nil, utilerrors.NewAggregate(errs)
-	}
-	return certs, nil
-}
-
-// ensureCertsForNode attempts to ensure the existence of secrets containing the
-// etcd cert (cert+key) pairs needed for an etcd member.
-func (c *EtcdCertSignerController) ensureCertsForNode(ctx context.Context, node *corev1.Node, recorder events.Recorder) (map[string][]byte, []error) {
-	ipAddresses, err := dnshelpers.GetInternalIPAddressesForNodeName(node)
-	if err != nil {
-		return nil, []error{err}
-	}
-
-	errs := []error{}
-	certs := map[string][]byte{}
-	for _, certConfig := range certConfigs {
-		secretName := certConfig.secretNameFunc(node.Name)
-		cert, key, err := c.ensureCertSecret(ctx, secretName, string(node.UID), ipAddresses, certConfig, recorder)
+		peerCert, err := tlshelpers.CreatePeerCertificate(node,
+			c.secretInformer,
+			c.secretLister,
+			c.secretClient,
+			c.eventRecorder)
 		if err != nil {
-			errs = append(errs, err)
-			continue
+			return cfgs, fmt.Errorf("error creating peer cert for node [%s]: %w", node.Name, err)
 		}
-		certs[fmt.Sprintf("%s.crt", secretName)] = cert
-		certs[fmt.Sprintf("%s.key", secretName)] = key
-	}
-	if len(errs) > 0 {
-		return nil, errs
-	}
-	return certs, nil
-}
 
-// ensureCertSecret attempts to ensure the existence of a secret containing an
-// etcd cert (cert+key) pair. The secret will be created if it does not
-// exist. If the secret exists but contains an invalid cert pair, it will be
-// updated with a new cert pair. If the secret is ensured to have a valid
-// cert pair, the bytes of the cert and key will be returned.
-func (c *EtcdCertSignerController) ensureCertSecret(ctx context.Context, secretName, nodeUID string, ipAddresses []string, certConfig etcdCertConfig, recorder events.Recorder) ([]byte, []byte, error) {
-	secret, err := c.secretLister.Secrets(operatorclient.TargetNamespace).Get(secretName)
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, nil, err
-	}
-
-	storedUID := ""
-	if secret != nil {
-		storedUID := secret.Annotations[nodeUIDAnnotation]
-		invalidMsg, err := checkCertValidity(secret.Data["tls.crt"], secret.Data["tls.key"], ipAddresses, nodeUID, storedUID)
+		servingCert, err := tlshelpers.CreateServingCertificate(node,
+			c.secretInformer,
+			c.secretLister,
+			c.secretClient,
+			c.eventRecorder)
 		if err != nil {
-			return nil, nil, err
+			return cfgs, fmt.Errorf("error creating serving cert for node [%s]: %w", node.Name, err)
 		}
-		if len(invalidMsg) > 0 {
-			klog.V(4).Infof("TLS cert %s is invalid and will be regenerated: %v", secretName, invalidMsg)
-			// A nil secret will prompt creation of a new keypair
-			secret = nil
-		}
-	}
 
-	var cert []byte
-	var key []byte
-	if secret != nil {
-		cert = secret.Data["tls.crt"]
-		key = secret.Data["tls.key"]
-		if storedUID == nodeUID {
-			// Nothing to do: Cert pair is valid, node uid is current
-			return cert, key, nil
-		}
-	} else {
-		// Generate a new cert pair. The secret is missing or its contents are invalid.
-		caSecret, err := c.secretLister.Secrets(operatorclient.GlobalUserSpecifiedConfigNamespace).Get(certConfig.caSecretName)
+		metricsCert, err := tlshelpers.CreateMetricsServingCertificate(node,
+			c.secretInformer,
+			c.secretLister,
+			c.secretClient,
+			c.eventRecorder)
 		if err != nil {
-			return nil, nil, err
+			return cfgs, fmt.Errorf("error creating metrics cert for node [%s]: %w", node.Name, err)
 		}
-		certBuffer, keyBuffer, err := certConfig.newCertFunc(caSecret.Data["tls.crt"], caSecret.Data["tls.key"], ipAddresses)
-		if err != nil {
-			return nil, nil, err
-		}
-		cert = certBuffer.Bytes()
-		key = keyBuffer.Bytes()
+
+		cfgs = append(cfgs, &nodeCertConfigs{
+			node:        node.DeepCopy(),
+			peerCert:    peerCert,
+			servingCert: servingCert,
+			metricsCert: metricsCert,
+		})
 	}
 
-	//TODO: Update annotations Not Before and Not After for Cert Rotation
-	newSecret := newCertSecret(secretName, nodeUID, cert, key)
-	_, _, err = resourceapply.ApplySecret(ctx, c.secretClient, recorder, newSecret)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return cert, key, nil
+	return cfgs, nil
 }
 
-// newCertSecret ensures consistency of secret creation between the controller
-// and its tests.
-func newCertSecret(secretName, nodeUID string, cert, key []byte) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: operatorclient.TargetNamespace,
-			Annotations: map[string]string{
-				nodeUIDAnnotation:                 nodeUID,
-				apiannotations.OpenShiftComponent: "Etcd",
-			},
-		},
-		Type: corev1.SecretTypeTLS,
-		Data: map[string][]byte{
-			"tls.crt": cert,
-			"tls.key": key,
-		},
-	}
-}
-
-// checkCertValidity validates the provided cert bytes. If the cert needs to be
-// regenerated, a message will be returned indicating why. An empty message
-// indicates a valid cert. An error will be returned if the cert is not valid
-// and should not be regenerated.
-func checkCertValidity(certBytes, keyBytes []byte, ipAddresses []string, nodeUID, storedUID string) (string, error) {
-	// Loading the keypair without error indicates the key material is valid and
-	// the cert and private key are related.
-	keyPair, err := tls.X509KeyPair(certBytes, keyBytes)
-	if err != nil {
-		// Invalid keypair - regen required
-		return fmt.Sprintf("%v", err), nil
-	}
-	leafCert, err := x509.ParseCertificate(keyPair.Certificate[0])
-	if err != nil {
-		// Should never happen once x509KeyPair() succeeds
-		return fmt.Sprintf("%v", err), nil
-	}
-
-	// Check that the cert is valid for the provided ip addresses
-	var errs []error
-	for _, ipAddress := range ipAddresses {
-		if err := leafCert.VerifyHostname(ipAddress); err != nil {
-			errs = append(errs, err)
+func addCertSecretToMap(allCerts map[string][]byte, secret *corev1.Secret) map[string][]byte {
+	for k, v := range secret.Data {
+		// in library-go the certs are stored as tls.crt and tls.key - which we trim away to stay backward compatible
+		ext, found := strings.CutPrefix(k, "tls")
+		if found {
+			k = ext
 		}
+		allCerts[fmt.Sprintf("%s%s", secret.Name, k)] = v
 	}
-	if len(errs) > 0 {
-		var msgs []string
-		for _, err := range errs {
-			msgs = append(msgs, fmt.Sprintf("%v", err))
-		}
-		return strings.Join(msgs, ", "), nil
-	}
-
-	if ok := lessThanMinimumDuration(leafCert.NotBefore, leafCert.NotAfter, defaultMinDurationPercent); ok {
-		return fmt.Sprintf("less than %d%% duration remaining", int64(defaultMinDurationPercent*100)), nil
-	}
-
-	// TODO(marun) Check that the certificate was issued by the CA
-
-	// Cert is valid
-	return "", nil
-}
-
-// lessThanMinimumDuration indicates whether the provided cert has less
-// than the provided minimum percentage of its duration remaining.
-func lessThanMinimumDuration(notBefore, notAfter time.Time, minDurationPercent float64) bool {
-	expiry := notAfter
-	duration := expiry.Sub(notBefore)
-	minDuration := time.Duration(float64(duration.Nanoseconds()) * minDurationPercent)
-	replacementTime := expiry.Add(-minDuration)
-	return time.Now().After(replacementTime)
+	return allCerts
 }

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -2,15 +2,13 @@ package etcdcertsigner
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/x509"
 	"fmt"
-	"testing"
-	"time"
-
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/cluster-etcd-operator/pkg/dnshelpers"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/health"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"github.com/stretchr/testify/assert"
@@ -19,12 +17,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
-	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"testing"
 
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -36,195 +32,10 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/tlshelpers"
 )
 
-func TestCheckCertValidity(t *testing.T) {
-	ipAddresses := []string{"127.0.0.1"}
-	differentIpAddresses := []string{"127.0.0.2"}
-
-	nodeUID := "foo-bar"
-	differentNodeUID := "bar-foo"
-
-	expireDays := 100
-
-	caConfig, err := crypto.MakeSelfSignedCAConfig("foo", expireDays)
-	if err != nil {
-		t.Fatalf("Failed to create ca config: %v", err)
-	}
-	ca := &crypto.CA{
-		Config:          caConfig,
-		SerialGenerator: &crypto.RandomSerialGenerator{},
-	}
-
-	testCases := map[string]struct {
-		invalidCertPair     bool
-		lessThanMinDuration bool
-		certIPAddresses     []string
-		nodeIPAddresses     []string
-		storedNodeUID       string
-		expectedRegenMsg    bool
-		expectedErr         bool
-	}{
-		"invalid bytes": {
-			invalidCertPair:  true,
-			expectedRegenMsg: true,
-		},
-		"missing ip address; node uid changed": {
-			certIPAddresses:  ipAddresses,
-			nodeIPAddresses:  differentIpAddresses,
-			storedNodeUID:    differentNodeUID,
-			expectedRegenMsg: true,
-		},
-		"less than minimum duration remaining": {
-			certIPAddresses:     ipAddresses,
-			nodeIPAddresses:     ipAddresses,
-			storedNodeUID:       nodeUID,
-			lessThanMinDuration: true,
-			expectedRegenMsg:    true,
-		},
-		"valid": {
-			certIPAddresses: ipAddresses,
-			nodeIPAddresses: ipAddresses,
-			storedNodeUID:   nodeUID,
-		},
-	}
-	for testName, tc := range testCases {
-		t.Run(testName, func(t *testing.T) {
-			certBytes := []byte{}
-			keyBytes := []byte{}
-			if !tc.invalidCertPair {
-				// Generate a valid cert for the cert ip addresses
-				certConfig, err := ca.MakeServerCert(sets.NewString(tc.certIPAddresses...), expireDays)
-				if err != nil {
-					t.Fatalf("Error generating cert: %v", err)
-				}
-				if tc.lessThanMinDuration {
-					certConfig = ensureLessThanMinDuration(t, certConfig)
-				}
-				certBytes, keyBytes, err = certConfig.GetPEMBytes()
-				if err != nil {
-					t.Fatalf("Error converting cert to bytes: %v", err)
-				}
-			}
-			msg, err := checkCertValidity(certBytes, keyBytes, tc.nodeIPAddresses, nodeUID, tc.storedNodeUID)
-			if tc.expectedRegenMsg && len(msg) == 0 {
-				t.Fatalf("Expected a regen message")
-			}
-			if !tc.expectedRegenMsg && len(msg) > 0 {
-				t.Fatalf("Unexpected regen message: %s", msg)
-			}
-			if tc.expectedErr && err == nil {
-				t.Fatalf("Expected an error")
-			}
-			if !tc.expectedErr && err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-		})
-	}
-}
-
-func TestEnsureCertForNode(t *testing.T) {
-	// Any one of the cert configs will be representative
-	certConfig := certConfigs["peer"]
-
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "master-0",
-			UID:  uuid.NewUUID(),
-		},
-	}
-
-	secretName := certConfig.secretNameFunc(node.Name)
-	testCases := map[string]struct {
-		certSecret     *corev1.Secret
-		createExpected bool
-		updateExpected bool
-		ipAddresses    []string
-	}{
-		"missing cert secret is created": {
-			createExpected: true,
-			ipAddresses:    []string{"127.0.0.1"},
-		},
-		"invalid cert secret is regenerated": {
-			certSecret:     newCertSecret(secretName, "", nil, nil),
-			ipAddresses:    []string{"127.0.0.1"},
-			updateExpected: true,
-		},
-		// this is a very common case when adding NICs on day2 operations
-		"cert secret is regenerated when ip addresses change": {
-			certSecret:     newCertSecretForIPs(t, secretName, []string{"127.0.0.1"}),
-			ipAddresses:    []string{"127.0.0.1", "127.0.0.2"},
-			createExpected: true,
-			updateExpected: true,
-		},
-		// The test for a valid cert secret is performed after a successful
-		// cert creation to simplify test setup.
-	}
-	for testName, tc := range testCases {
-		t.Run(testName, func(t *testing.T) {
-			objects := []runtime.Object{}
-			if tc.certSecret != nil {
-				objects = append(objects, tc.certSecret)
-			}
-
-			fakeKubeClient, controller, recorder := setupController(t, objects)
-			secretName := certConfig.secretNameFunc(node.Name)
-			nodeUID := string(node.UID)
-			_, _, err := controller.ensureCertSecret(context.TODO(), secretName, nodeUID, tc.ipAddresses, certConfig, recorder)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			var updatedSecret *corev1.Secret
-			var createdSecret *corev1.Secret
-			for _, action := range fakeKubeClient.Actions() {
-				if action.Matches("update", "secrets") {
-					updateAction := action.(clientgotesting.UpdateAction)
-					updatedSecret = updateAction.GetObject().(*corev1.Secret)
-					break
-				}
-				if action.Matches("create", "secrets") {
-					createAction := action.(clientgotesting.CreateAction)
-					createdSecret = createAction.GetObject().(*corev1.Secret)
-					break
-				}
-			}
-			if !tc.updateExpected && updatedSecret != nil {
-				t.Fatalf("Secret unexpectedly updated")
-			}
-			if updatedSecret != nil {
-				validateTestSecret(t, "updated", updatedSecret, tc.ipAddresses)
-			}
-			if !tc.createExpected && createdSecret != nil {
-				t.Fatalf("Secret unexpectedly created")
-			}
-			if createdSecret != nil {
-				validateTestSecret(t, "created", createdSecret, tc.ipAddresses)
-
-				// Verify that a cert secret created by ensureCertSecret will
-				// not be updated when immediately round-tripped.
-				objects := []runtime.Object{createdSecret}
-				fakeKubeClient, controller, recorder := setupController(t, objects)
-				_, _, err := controller.ensureCertSecret(context.TODO(), secretName, nodeUID,
-					tc.ipAddresses, certConfig, recorder)
-				if err != nil {
-					t.Fatal(err)
-				}
-				for _, action := range fakeKubeClient.Actions() {
-					if action.Matches("update", "secrets") {
-						t.Fatal("Valid secret unexpectedly updated")
-					}
-					if action.Matches("create", "secrets") {
-						t.Fatal("Valid secret unexpectedly updated")
-					}
-				}
-			}
-		})
-	}
-}
-
 func TestSyncSkipsOnInsufficientQuorum(t *testing.T) {
 	_, controller, recorder := setupController(t, []runtime.Object{})
 
-	err := controller.sync(context.TODO(), factory.NewSyncContext("test", recorder))
+	err := controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder))
 	require.NoError(t, err)
 
 	etcdMembers := []*etcdserverpb.Member{
@@ -234,7 +45,7 @@ func TestSyncSkipsOnInsufficientQuorum(t *testing.T) {
 	_, controller, recorder = setupControllerWithEtcd(t, []runtime.Object{
 		u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
 	}, etcdMembers)
-	err = controller.sync(context.TODO(), factory.NewSyncContext("test", recorder))
+	err = controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder))
 	assert.Equal(t, "EtcdCertSignerController can't evaluate whether quorum is safe: etcd cluster has quorum of 2 which is not fault tolerant: [{Member:name:\"etcd-0\" peerURLs:\"https://10.0.0.1:2380\" clientURLs:\"https://10.0.0.1:2907\"  Healthy:true Took: Error:<nil>} {Member:ID:1 name:\"etcd-1\" peerURLs:\"https://10.0.0.2:2380\" clientURLs:\"https://10.0.0.2:2907\"  Healthy:true Took: Error:<nil>}]",
 		err.Error())
 }
@@ -243,46 +54,125 @@ func TestSyncSkipsOnInsufficientQuorum(t *testing.T) {
 // cert type per node and an aggregated secret per cert type.
 func TestSyncAllMasters(t *testing.T) {
 	fakeKubeClient, controller, recorder := setupController(t, []runtime.Object{})
-	err := controller.syncAllMasters(context.TODO(), recorder)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder)))
+
+	nodes, secretMap := allNodesAndSecrets(t, fakeKubeClient)
+	require.Equal(t, 3, len(nodes.Items))
+	assertNodeCerts(t, nodes, secretMap)
+	assertStaticPodAllCerts(t, nodes, secretMap)
+	assertClientCerts(t, secretMap)
+}
+
+func TestNewNodeAdded(t *testing.T) {
+	fakeKubeClient, controller, recorder := setupController(t, []runtime.Object{})
+
+	require.NoError(t, controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder)))
+
+	nodes, secretMap := allNodesAndSecrets(t, fakeKubeClient)
+	require.Equal(t, 3, len(nodes.Items))
+	assertNodeCerts(t, nodes, secretMap)
+	assertStaticPodAllCerts(t, nodes, secretMap)
+	assertClientCerts(t, secretMap)
+
+	_, err := fakeKubeClient.CoreV1().Nodes().Create(context.TODO(), u.FakeNode("master-3", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.4")), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder)))
+
+	nodes, secretMap = allNodesAndSecrets(t, fakeKubeClient)
+	require.Equal(t, 4, len(nodes.Items))
+	assertNodeCerts(t, nodes, secretMap)
+	assertStaticPodAllCerts(t, nodes, secretMap)
+	assertClientCerts(t, secretMap)
+}
+
+func TestNodeChangingIPs(t *testing.T) {
+	fakeKubeClient, controller, recorder := setupController(t, []runtime.Object{})
+
+	require.NoError(t, controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder)))
+
+	nodes, secretMap := allNodesAndSecrets(t, fakeKubeClient)
+	require.Equal(t, 3, len(nodes.Items))
+	assertNodeCerts(t, nodes, secretMap)
+	assertStaticPodAllCerts(t, nodes, secretMap)
+	assertClientCerts(t, secretMap)
+
+	n, err := fakeKubeClient.CoreV1().Nodes().Get(context.TODO(), "master-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	// change its IP to a completely different subnet
+	n.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.100.100.1"}}
+	_, err = fakeKubeClient.CoreV1().Nodes().Update(context.TODO(), n, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder)))
+
+	nodes, secretMap = allNodesAndSecrets(t, fakeKubeClient)
+	require.Equal(t, 3, len(nodes.Items))
+	assertNodeCerts(t, nodes, secretMap)
+	assertStaticPodAllCerts(t, nodes, secretMap)
+	assertClientCerts(t, secretMap)
+}
+
+func TestClientCertsRemoval(t *testing.T) {
+	fakeKubeClient, controller, recorder := setupController(t, []runtime.Object{})
+
+	require.NoError(t, controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder)))
+
+	nodes, secretMap := allNodesAndSecrets(t, fakeKubeClient)
+	require.Equal(t, 3, len(nodes.Items))
+	assertNodeCerts(t, nodes, secretMap)
+	assertStaticPodAllCerts(t, nodes, secretMap)
+	assertClientCerts(t, secretMap)
+
+	oldClientCert, err := fakeKubeClient.CoreV1().Secrets(operatorclient.TargetNamespace).Get(context.TODO(), tlshelpers.EtcdClientCertSecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	err = fakeKubeClient.CoreV1().Secrets(operatorclient.TargetNamespace).Delete(context.TODO(), tlshelpers.EtcdClientCertSecretName, metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	oldMetricClientCert, err := fakeKubeClient.CoreV1().Secrets(operatorclient.TargetNamespace).Get(context.TODO(), tlshelpers.EtcdMetricsClientCertSecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	err = fakeKubeClient.CoreV1().Secrets(operatorclient.TargetNamespace).Delete(context.TODO(), tlshelpers.EtcdMetricsClientCertSecretName, metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	// this should regenerate the certificates
+	require.NoError(t, controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder)))
+
+	nodes, secretMap = allNodesAndSecrets(t, fakeKubeClient)
+	require.Equal(t, 3, len(nodes.Items))
+	assertNodeCerts(t, nodes, secretMap)
+	assertStaticPodAllCerts(t, nodes, secretMap)
+	assertClientCerts(t, secretMap)
+	// test that the secrets actually differ and the cert was regenerated
+	require.NotEqual(t, oldClientCert.Data, secretMap[tlshelpers.EtcdClientCertSecretName])
+	require.NotEqual(t, oldMetricClientCert.Data, secretMap[tlshelpers.EtcdMetricsClientCertSecretName])
+}
+
+func allNodesAndSecrets(t *testing.T, fakeKubeClient *fake.Clientset) (*corev1.NodeList, map[string]corev1.Secret) {
 	nodes, err := fakeKubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	secrets, err := fakeKubeClient.CoreV1().Secrets(operatorclient.TargetNamespace).List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	secretMap := map[string]corev1.Secret{}
 	for _, secret := range secrets.Items {
 		secretMap[secret.Name] = secret
 	}
-	for _, certConfig := range certConfigs {
-		// Cert secret per type per node
-		for _, node := range nodes.Items {
-			secretName := certConfig.secretNameFunc(node.Name)
-			t.Run(secretName, func(t *testing.T) {
-				secret, ok := secretMap[secretName]
-				if !ok {
-					t.Fatalf("secret %s is missing", secretName)
-				}
-				checkCertPairSecret(t, secretName, "tls.crt", "tls.key", secret.Data)
-			})
-		}
-	}
+	return nodes, secretMap
+}
+
+func assertStaticPodAllCerts(t *testing.T, nodes *corev1.NodeList, secretMap map[string]corev1.Secret) {
 	// A single aggregated secret
 	secretName := tlshelpers.EtcdAllCertsSecretName
 	t.Run(secretName, func(t *testing.T) {
 		allSecret, ok := secretMap[secretName]
-		if !ok {
-			t.Fatalf("secret %s is missing", secretName)
-		}
+		require.Truef(t, ok, "expected secret/%s to exist", secretName)
 		// Cert pair per type per node
-		for _, certConfig := range certConfigs {
-			for _, node := range nodes.Items {
-				secretName := certConfig.secretNameFunc(node.Name)
+		for _, node := range nodes.Items {
+			for _, secretName := range []string{
+				tlshelpers.GetPeerClientSecretNameForNode(node.Name),
+				tlshelpers.GetServingSecretNameForNode(node.Name),
+				tlshelpers.GetServingMetricsSecretNameForNode(node.Name),
+			} {
 				certName := fmt.Sprintf("%s.crt", secretName)
 				keyName := fmt.Sprintf("%s.key", secretName)
 				checkCertPairSecret(t, secretName, certName, keyName, allSecret.Data)
@@ -291,15 +181,57 @@ func TestSyncAllMasters(t *testing.T) {
 	})
 }
 
+func assertNodeCerts(t *testing.T, nodes *corev1.NodeList, secretMap map[string]corev1.Secret) {
+	// Cert secret per type per node
+	for _, node := range nodes.Items {
+		for _, secretName := range []string{
+			tlshelpers.GetPeerClientSecretNameForNode(node.Name),
+			tlshelpers.GetServingSecretNameForNode(node.Name),
+			tlshelpers.GetServingMetricsSecretNameForNode(node.Name),
+		} {
+			t.Run(secretName, func(t *testing.T) {
+				secret, ok := secretMap[secretName]
+				require.Truef(t, ok, "expected secret/%s to exist", secretName)
+				checkCertPairSecret(t, secretName, "tls.crt", "tls.key", secret.Data)
+				checkCertNodeValidity(t, node, "tls.crt", "tls.key", secret.Data)
+			})
+		}
+	}
+}
+
+func assertClientCerts(t *testing.T, secretMap map[string]corev1.Secret) {
+	require.Containsf(t, secretMap, tlshelpers.EtcdClientCertSecretName, "expected secret/%s to exist", tlshelpers.EtcdClientCertSecretName)
+	require.Containsf(t, secretMap, tlshelpers.EtcdMetricsClientCertSecretName, "expected secret/%s to exist", tlshelpers.EtcdMetricsClientCertSecretName)
+}
+
+func checkCertNodeValidity(t *testing.T, node corev1.Node, certName, keyName string, secretData map[string][]byte) {
+	cfg, err := crypto.GetTLSCertificateConfigFromBytes(secretData[certName], secretData[keyName])
+	require.NoError(t, err)
+
+	names, err := dnshelpers.GetInternalIPAddressesForNodeName(&node)
+	require.NoError(t, err)
+
+	expectedUsages := []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+	// all internal names should be in any of the certs
+	for _, name := range names {
+		for _, cert := range cfg.Certs {
+			if len(cert.ExtKeyUsage) > 0 {
+				require.Equal(t, expectedUsages, cert.ExtKeyUsage)
+				require.Containsf(t, cert.DNSNames, name, "expected node %s to have DNS name %s, but only had: %v", node.Name, name, cert.DNSNames)
+			}
+		}
+	}
+}
+
 func checkCertPairSecret(t *testing.T, secretName, certName, keyName string, secretData map[string][]byte) {
 	for _, key := range []string{certName, keyName} {
-		if _, ok := secretData[certName]; !ok {
+		if _, ok := secretData[key]; !ok {
 			t.Fatalf("secret %s is missing %s", secretName, key)
 		}
 	}
 }
 
-func setupController(t *testing.T, objects []runtime.Object) (*fake.Clientset, *EtcdCertSignerController, events.Recorder) {
+func setupController(t *testing.T, objects []runtime.Object) (*fake.Clientset, factory.Controller, events.Recorder) {
 	etcdMembers := []*etcdserverpb.Member{
 		u.FakeEtcdMemberWithoutServer(0),
 		u.FakeEtcdMemberWithoutServer(1),
@@ -309,41 +241,36 @@ func setupController(t *testing.T, objects []runtime.Object) (*fake.Clientset, *
 }
 
 // setupController configures EtcdCertSignerController for testing with etcd members.
-func setupControllerWithEtcd(t *testing.T, objects []runtime.Object, etcdMembers []*etcdserverpb.Member) (*fake.Clientset, *EtcdCertSignerController, events.Recorder) {
+func setupControllerWithEtcd(t *testing.T, objects []runtime.Object, etcdMembers []*etcdserverpb.Member) (*fake.Clientset, factory.Controller, events.Recorder) {
 	// Add nodes and CAs
 	objects = append(objects,
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: operatorclient.TargetNamespace},
+		},
 		u.FakeNode("master-0", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.1")),
 		u.FakeNode("master-1", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.2")),
 		u.FakeNode("master-2", u.WithMasterLabel(), u.WithNodeInternalIP("10.0.0.3")),
 	)
-	signerNames := sets.NewString()
-	for _, certConfig := range certConfigs {
-		name := certConfig.caSecretName
-		if signerNames.Has(name) {
-			continue
-		}
-		signerNames.Insert(name)
-		objects = append(objects, newCASecret(t, name))
-	}
 
-	fakeKubeClient := fake.NewSimpleClientset(objects...)
+	objects = append(objects, newCASecret(t, tlshelpers.EtcdSignerCertSecretName), newCASecret(t, tlshelpers.EtcdMetricsSignerCertSecretName))
+
 	indexer := cache.NewIndexer(
 		cache.MetaNamespaceKeyFunc,
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 
-	objects = append(objects,
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: operatorclient.TargetNamespace},
+	fakeKubeClient := fake.NewSimpleClientset(objects...)
+	kubeInformerForNamespace := v1helpers.NewKubeInformersForNamespaces(fakeKubeClient, "",
+		operatorclient.TargetNamespace, operatorclient.OperatorNamespace, operatorclient.GlobalUserSpecifiedConfigNamespace)
+
+	objects = append(objects, &configv1.Infrastructure{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ceohelpers.InfrastructureClusterName,
 		},
-		&configv1.Infrastructure{
-			TypeMeta: metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ceohelpers.InfrastructureClusterName,
-			},
-			Status: configv1.InfrastructureStatus{
-				ControlPlaneTopology: configv1.HighlyAvailableTopologyMode},
-		})
+		Status: configv1.InfrastructureStatus{
+			ControlPlaneTopology: configv1.HighlyAvailableTopologyMode},
+	})
 	for _, obj := range objects {
 		require.NoError(t, indexer.Add(obj))
 	}
@@ -364,9 +291,7 @@ func setupControllerWithEtcd(t *testing.T, objects []runtime.Object, etcdMembers
 	)
 
 	fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(etcdMembers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	quorumChecker := ceohelpers.NewQuorumChecker(
 		corev1listers.NewConfigMapLister(indexer),
@@ -375,19 +300,29 @@ func setupControllerWithEtcd(t *testing.T, objects []runtime.Object, etcdMembers
 		fakeOperatorClient,
 		fakeEtcdClient)
 
-	controller := &EtcdCertSignerController{
-		kubeClient:     fakeKubeClient,
-		operatorClient: fakeOperatorClient,
-		nodeLister:     corev1listers.NewNodeLister(indexer),
-		secretLister:   corev1listers.NewSecretLister(indexer),
-		secretClient:   fakeKubeClient.CoreV1(),
-		quorumChecker:  quorumChecker,
-	}
 	recorder := events.NewRecorder(
 		fakeKubeClient.CoreV1().Events(operatorclient.TargetNamespace),
 		"test-cert-signer",
 		&corev1.ObjectReference{},
 	)
+	controller := NewEtcdCertSignerController(
+		health.NewMultiAlivenessChecker(),
+		fakeKubeClient,
+		fakeOperatorClient,
+		kubeInformerForNamespace,
+		recorder,
+		quorumChecker)
+
+	stopChan := make(chan struct{})
+	t.Cleanup(func() {
+		close(stopChan)
+	})
+
+	kubeInformerForNamespace.Start(stopChan)
+	for ns := range kubeInformerForNamespace.Namespaces() {
+		kubeInformerForNamespace.InformersFor(ns).WaitForCacheSync(stopChan)
+	}
+
 	return fakeKubeClient, controller, recorder
 }
 
@@ -409,77 +344,5 @@ func newCASecret(t *testing.T, secretName string) *corev1.Secret {
 			"tls.crt": caCertBytes,
 			"tls.key": caKeyBytes,
 		},
-	}
-}
-
-func newCertSecretForIPs(t *testing.T, secretName string, ips []string) *corev1.Secret {
-	expireDays := 100
-
-	caConfig, err := crypto.MakeSelfSignedCAConfig("foo", expireDays)
-	if err != nil {
-		t.Fatalf("Failed to create ca config: %v", err)
-	}
-	ca := &crypto.CA{
-		Config:          caConfig,
-		SerialGenerator: &crypto.RandomSerialGenerator{},
-	}
-
-	certConfig, err := ca.MakeServerCert(sets.NewString(ips...), expireDays)
-	if err != nil {
-		t.Fatalf("Error generating cert: %v", err)
-	}
-
-	certBytes, keyBytes, err := certConfig.GetPEMBytes()
-	if err != nil {
-		t.Fatalf("Error converting cert to bytes: %v", err)
-	}
-
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: operatorclient.TargetNamespace,
-			Name:      secretName,
-		},
-		Data: map[string][]byte{
-			"tls.crt": certBytes,
-			"tls.key": keyBytes,
-		},
-	}
-}
-
-// validateTestSecret checks that a secret created or updated by
-// ensureCertSecret is valid acording to checkCertValidity.
-func validateTestSecret(t *testing.T, action string, secret *corev1.Secret, ipAddresses []string) {
-	if secret.Data == nil {
-		t.Fatalf("%s secret is empty", action)
-	}
-	storedNodeUID := secret.Annotations[nodeUIDAnnotation]
-	msg, err := checkCertValidity(secret.Data["tls.crt"], secret.Data["tls.key"], ipAddresses, storedNodeUID, storedNodeUID)
-	if len(msg) > 0 {
-		t.Fatalf("%s secret is invalid with message: %s", action, msg)
-	}
-	if err != nil {
-		t.Fatalf("%s secret is invalid with error: %v", action, err)
-	}
-}
-
-func ensureLessThanMinDuration(t *testing.T, caConfig *crypto.TLSCertificateConfig) *crypto.TLSCertificateConfig {
-	caCert := caConfig.Certs[0]
-
-	// Issued 9 hours ago, 1 hour remaining: < 20% duration remaining
-	caCert.NotBefore = time.Now().Add(-9 * time.Hour)
-	caCert.NotAfter = time.Now().Add(time.Hour)
-
-	rawCert, err := x509.CreateCertificate(rand.Reader, caCert, caCert, caCert.PublicKey, caConfig.Key)
-	if err != nil {
-		t.Fatalf("error creating certificate: %v", err)
-	}
-	parsedCerts, err := x509.ParseCertificates(rawCert)
-	if err != nil {
-		t.Fatalf("error parsing certificate: %v", err)
-	}
-
-	return &crypto.TLSCertificateConfig{
-		Certs: []*x509.Certificate{parsedCerts[0]},
-		Key:   caConfig.Key,
 	}
 }

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -1,11 +1,14 @@
 package resourcesynccontroller
 
 import (
-	"k8s.io/client-go/kubernetes"
-
+	"context"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 )
@@ -16,79 +19,17 @@ func NewResourceSyncController(
 	kubeClient kubernetes.Interface,
 	eventRecorder events.Recorder) (*resourcesynccontroller.ResourceSyncController, error) {
 
+	secretClient := v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformersForNamespaces)
+	configMapClient := v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformersForNamespaces)
+
 	resourceSyncController := resourcesynccontroller.NewResourceSyncController(
 		operatorConfigClient,
 		kubeInformersForNamespaces,
-		v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
-		v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
+		secretClient,
+		configMapClient,
 		eventRecorder,
 	)
 
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "etcd-ca-bundle"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-ca-bundle"},
-	); err != nil {
-		return nil, err
-	}
-
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-ca-bundle"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-ca-bundle"},
-	); err != nil {
-		return nil, err
-	}
-
-	if err := resourceSyncController.SyncSecret(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "etcd-client"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-client"},
-	); err != nil {
-		return nil, err
-	}
-
-	if err := resourceSyncController.SyncSecret(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-client"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-client"},
-	); err != nil {
-		return nil, err
-	}
-
-	if err := resourceSyncController.SyncSecret(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "etcd-metric-client"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-metric-client"},
-	); err != nil {
-		return nil, err
-	}
-
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-peer-client-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-ca-bundle"},
-	); err != nil {
-		return nil, err
-	}
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metrics-proxy-client-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-metric-serving-ca"},
-	); err != nil {
-		return nil, err
-	}
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "etcd-metric-serving-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-metric-serving-ca"},
-	); err != nil {
-		return nil, err
-	}
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-serving-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-serving-ca"},
-	); err != nil {
-		return nil, err
-	}
-	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metrics-proxy-serving-ca"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-metric-serving-ca"},
-	); err != nil {
-		return nil, err
-	}
 	if err := resourceSyncController.SyncConfigMap(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "cluster-config-v1"},
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.KubeSystemNamespace, Name: "cluster-config-v1"},
@@ -96,5 +37,134 @@ func NewResourceSyncController(
 		return nil, err
 	}
 
+	// serving ca
+	caBundleExistsFunc := func() (bool, error) {
+		return configMapExistsPrecondition(configMapClient, resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-ca-bundle"})
+	}
+	if err := resourceSyncController.SyncConfigMapConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "etcd-ca-bundle"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-ca-bundle"},
+		caBundleExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+
+	if err := resourceSyncController.SyncConfigMapConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-peer-client-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-ca-bundle"},
+		caBundleExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+
+	// "etcd-serving-ca" is replaced by the "etcd-ca-bundle"
+	if err := resourceSyncController.SyncConfigMapConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-serving-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-ca-bundle"},
+		caBundleExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+
+	if err := resourceSyncController.SyncConfigMapConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-serving-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-ca-bundle"},
+		caBundleExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+
+	// metrics serving
+	metricsBundleExistsFunc := func() (bool, error) {
+		return configMapExistsPrecondition(configMapClient, resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metrics-ca-bundle"})
+	}
+	// TODO(thomas): copying the metrics ca-bundle back to openshift-config should not be necessary anymore
+	// this buys us some more transition time, but the source of truth stays in openshift-etcd
+	if err := resourceSyncController.SyncConfigMapConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-metric-serving-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metrics-ca-bundle"},
+		metricsBundleExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+	if err := resourceSyncController.SyncConfigMapConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metrics-proxy-client-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metrics-ca-bundle"},
+		metricsBundleExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+	if err := resourceSyncController.SyncConfigMapConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "etcd-metric-serving-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metrics-ca-bundle"},
+		metricsBundleExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+	if err := resourceSyncController.SyncConfigMapConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metrics-proxy-serving-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metrics-ca-bundle"},
+		metricsBundleExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+
+	// client certs
+	metricsClientExistsFunc := func() (bool, error) {
+		return secretExistsPrecondition(secretClient, resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metric-client"})
+	}
+	if err := resourceSyncController.SyncSecretConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "etcd-metric-client"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-metric-client"},
+		metricsClientExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+
+	etcdClientExistsFunc := func() (bool, error) {
+		return secretExistsPrecondition(secretClient, resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-client"})
+	}
+	if err := resourceSyncController.SyncSecretConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "etcd-client"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-client"},
+		etcdClientExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+
+	if err := resourceSyncController.SyncSecretConditionally(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "etcd-client"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "etcd-client"},
+		etcdClientExistsFunc,
+	); err != nil {
+		return nil, err
+	}
+
 	return resourceSyncController, nil
+}
+
+// configMapExistsPrecondition will check whether the given resourcesynccontroller.ResourceLocation already exists.
+// This is to ensure that the destination is not removed in case we're switching locations, or they are accidentally deleted.
+func configMapExistsPrecondition(configMapsGetter corev1client.ConfigMapsGetter, loc resourcesynccontroller.ResourceLocation) (bool, error) {
+	_, err := configMapsGetter.ConfigMaps(loc.Namespace).Get(context.Background(), loc.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// secretExistsPrecondition will check whether the given resourcesynccontroller.ResourceLocation already exists.
+// This is to ensure that the destination is not removed in case we're switching locations, or they are accidentally deleted.
+func secretExistsPrecondition(secretsGetter corev1client.SecretsGetter, loc resourcesynccontroller.ResourceLocation) (bool, error) {
+	_, err := secretsGetter.Secrets(loc.Namespace).Get(context.Background(), loc.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }

--- a/pkg/tlshelpers/tlshelpers.go
+++ b/pkg/tlshelpers/tlshelpers.go
@@ -2,9 +2,20 @@ package tlshelpers
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
+	"github.com/openshift/cluster-etcd-operator/pkg/dnshelpers"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/operator/certrotation"
+	"github.com/openshift/library-go/pkg/operator/events"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"strings"
 	"time"
 
@@ -15,7 +26,10 @@ import (
 )
 
 const (
-	etcdCertValidity = 3 * 365 * 24 * time.Hour
+	etcdCertValidity          = 3 * 365 * 24 * time.Hour
+	etcdCertValidityRefresh   = 2.5 * 365 * 24 * time.Hour
+	etcdCaCertValidity        = 5 * 365 * 24 * time.Hour
+	etcdCaCertValidityRefresh = 4.5 * 365 * 24 * time.Hour
 
 	peerOrg   = "system:etcd-peers"
 	serverOrg = "system:etcd-servers"
@@ -24,7 +38,14 @@ const (
 	// TODO debt left for @hexfusion or @sanchezl
 	fakePodFQDN = "etcd-client"
 
-	EtcdAllCertsSecretName = "etcd-all-certs"
+	EtcdJiraComponentName                  = "etcd"
+	EtcdSignerCertSecretName               = "etcd-signer"
+	EtcdSignerCaBundleConfigMapName        = "etcd-ca-bundle"
+	EtcdMetricsSignerCertSecretName        = "etcd-metric-signer"
+	EtcdMetricsSignerCaBundleConfigMapName = "etcd-metrics-ca-bundle"
+	EtcdAllCertsSecretName                 = "etcd-all-certs"
+	EtcdClientCertSecretName               = "etcd-client"
+	EtcdMetricsClientCertSecretName        = "etcd-metric-client"
 )
 
 func GetPeerClientSecretNameForNode(nodeName string) string {
@@ -50,8 +71,233 @@ func getServerHostNames(nodeInternalIPs []string) []string {
 		"etcd.openshift-etcd.svc.cluster.local",
 		"127.0.0.1",
 		"::1",
-		"0:0:0:0:0:0:0:1",
+		// "0:0:0:0:0:0:0:1" will be automatically collapsed to "::1", so we don't have to add it on top
 	}, nodeInternalIPs...)
+}
+
+func CreateSignerCertRotationBundleConfigMap(
+	cmInformer corev1informers.ConfigMapInformer,
+	cmLister corev1listers.ConfigMapLister,
+	cmGetter corev1client.ConfigMapsGetter,
+	recorder events.Recorder) certrotation.CABundleConfigMap {
+
+	return certrotation.CABundleConfigMap{
+		Name:          EtcdSignerCaBundleConfigMapName,
+		Namespace:     operatorclient.TargetNamespace,
+		JiraComponent: EtcdJiraComponentName,
+		Description:   "bundle for etcd signer certificate authorities",
+		Informer:      cmInformer,
+		Lister:        cmLister,
+		Client:        cmGetter,
+		EventRecorder: recorder,
+	}
+}
+
+func CreateMetricsSignerCertRotationBundleConfigMap(
+	cmInformer corev1informers.ConfigMapInformer,
+	cmLister corev1listers.ConfigMapLister,
+	cmGetter corev1client.ConfigMapsGetter,
+	recorder events.Recorder) certrotation.CABundleConfigMap {
+
+	return certrotation.CABundleConfigMap{
+		Name:          EtcdMetricsSignerCaBundleConfigMapName,
+		Namespace:     operatorclient.TargetNamespace,
+		JiraComponent: EtcdJiraComponentName,
+		Description:   "bundle for etcd metrics signer certificate authorities",
+		Informer:      cmInformer,
+		Lister:        cmLister,
+		Client:        cmGetter,
+		EventRecorder: recorder,
+	}
+}
+
+func CreateSignerCert(
+	secretInformer corev1informers.SecretInformer,
+	secretLister corev1listers.SecretLister,
+	secretGetter corev1client.SecretsGetter,
+	recorder events.Recorder) certrotation.RotatedSigningCASecret {
+
+	return certrotation.RotatedSigningCASecret{
+		Namespace:     operatorclient.TargetNamespace,
+		Name:          EtcdSignerCertSecretName,
+		JiraComponent: EtcdJiraComponentName,
+		Description:   "etcd signer certificate authorities",
+		Validity:      etcdCaCertValidity,
+		Refresh:       etcdCaCertValidityRefresh,
+
+		Informer:      secretInformer,
+		Lister:        secretLister,
+		Client:        secretGetter,
+		EventRecorder: recorder,
+	}
+}
+
+func CreateMetricsSignerCert(
+	secretInformer corev1informers.SecretInformer,
+	secretLister corev1listers.SecretLister,
+	secretGetter corev1client.SecretsGetter,
+	recorder events.Recorder) certrotation.RotatedSigningCASecret {
+
+	return certrotation.RotatedSigningCASecret{
+		Namespace:     operatorclient.TargetNamespace,
+		Name:          EtcdMetricsSignerCertSecretName,
+		JiraComponent: EtcdJiraComponentName,
+		Description:   "etcd metrics signer certificate authorities",
+		Validity:      etcdCaCertValidity,
+		Refresh:       etcdCaCertValidityRefresh,
+
+		Informer:      secretInformer,
+		Lister:        secretLister,
+		Client:        secretGetter,
+		EventRecorder: recorder,
+	}
+}
+
+func CreatePeerCertificate(node *corev1.Node,
+	secretInformer corev1informers.SecretInformer,
+	secretLister corev1listers.SecretLister,
+	secretGetter corev1client.SecretsGetter,
+	recorder events.Recorder) (*certrotation.RotatedSelfSignedCertKeySecret, error) {
+	return createCertForNode(
+		fmt.Sprintf("Peer Cert for node %s", node.Name),
+		GetPeerClientSecretNameForNode(node.Name),
+		node, secretInformer, secretLister, secretGetter, recorder)
+}
+
+func CreateServingCertificate(node *corev1.Node,
+	secretInformer corev1informers.SecretInformer,
+	secretLister corev1listers.SecretLister,
+	secretGetter corev1client.SecretsGetter,
+	recorder events.Recorder) (*certrotation.RotatedSelfSignedCertKeySecret, error) {
+	return createCertForNode(
+		fmt.Sprintf("Serving Cert for node %s", node.Name),
+		GetServingSecretNameForNode(node.Name),
+		node, secretInformer, secretLister, secretGetter, recorder)
+}
+
+func CreateMetricsServingCertificate(node *corev1.Node,
+	secretInformer corev1informers.SecretInformer,
+	secretLister corev1listers.SecretLister,
+	secretGetter corev1client.SecretsGetter,
+	recorder events.Recorder) (*certrotation.RotatedSelfSignedCertKeySecret, error) {
+	return createCertForNode(
+		fmt.Sprintf("Metric Serving Cert for node %s", node.Name),
+		GetServingMetricsSecretNameForNode(node.Name),
+		node, secretInformer, secretLister, secretGetter, recorder)
+}
+
+func createCertForNode(description, secretName string, node *corev1.Node,
+	secretInformer corev1informers.SecretInformer,
+	secretLister corev1listers.SecretLister,
+	secretGetter corev1client.SecretsGetter,
+	recorder events.Recorder) (*certrotation.RotatedSelfSignedCertKeySecret, error) {
+
+	ipAddresses, err := dnshelpers.GetInternalIPAddressesForNodeName(node)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve internal IP addresses for node: %w", err)
+	}
+	hostNames := getServerHostNames(ipAddresses)
+
+	creator := &certrotation.ServingRotation{
+		Hostnames: func() []string {
+			return hostNames
+		},
+		CertificateExtensionFn: []crypto.CertificateExtensionFunc{
+			func(certificate *x509.Certificate) error {
+				certificate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+				return nil
+			},
+		},
+	}
+
+	return &certrotation.RotatedSelfSignedCertKeySecret{
+		Namespace:     operatorclient.TargetNamespace,
+		Name:          secretName,
+		JiraComponent: EtcdJiraComponentName,
+		Description:   description,
+		Validity:      etcdCertValidity,
+		Refresh:       etcdCertValidityRefresh,
+		CertCreator:   creator,
+
+		Informer:      secretInformer,
+		Lister:        secretLister,
+		Client:        secretGetter,
+		EventRecorder: recorder,
+	}, nil
+}
+
+func CreateMetricsClientCert(
+	secretInformer corev1informers.SecretInformer,
+	secretLister corev1listers.SecretLister,
+	secretGetter corev1client.SecretsGetter,
+	recorder events.Recorder) certrotation.RotatedSelfSignedCertKeySecret {
+	creator := &certrotation.ClientRotation{
+		UserInfo: &user.DefaultInfo{
+			Name:   "etcd-metric",
+			Groups: []string{"system:etcd", "etcd-metric"},
+		},
+	}
+
+	return certrotation.RotatedSelfSignedCertKeySecret{
+		Namespace:     operatorclient.TargetNamespace,
+		Name:          EtcdMetricsClientCertSecretName,
+		JiraComponent: EtcdJiraComponentName,
+		Description:   "etcd metrics client certificate",
+		Validity:      etcdCertValidity,
+		Refresh:       etcdCertValidityRefresh,
+		CertCreator:   creator,
+
+		Informer:      secretInformer,
+		Lister:        secretLister,
+		Client:        secretGetter,
+		EventRecorder: recorder,
+	}
+}
+
+func CreateEtcdClientCert(
+	secretInformer corev1informers.SecretInformer,
+	secretLister corev1listers.SecretLister,
+	secretGetter corev1client.SecretsGetter,
+	recorder events.Recorder) certrotation.RotatedSelfSignedCertKeySecret {
+	creator := &certrotation.ClientRotation{
+		UserInfo: &user.DefaultInfo{
+			Name:   "etcd-client",
+			Groups: []string{"system:etcd", "etcd-client"},
+		},
+	}
+
+	return certrotation.RotatedSelfSignedCertKeySecret{
+		Namespace:     operatorclient.TargetNamespace,
+		Name:          EtcdClientCertSecretName,
+		JiraComponent: EtcdJiraComponentName,
+		Description:   "etcd client certificate",
+		Validity:      etcdCertValidity,
+		Refresh:       etcdCertValidityRefresh,
+		CertCreator:   creator,
+
+		Informer:      secretInformer,
+		Lister:        secretLister,
+		Client:        secretGetter,
+		EventRecorder: recorder,
+	}
+}
+
+func ReadConfigSignerCert(ctx context.Context, secretClient corev1client.SecretsGetter) (*crypto.CA, error) {
+	signingCertKeyPairSecret, err := secretClient.Secrets(operatorclient.GlobalUserSpecifiedConfigNamespace).Get(ctx, EtcdSignerCertSecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting %s/%s: %w", operatorclient.GlobalUserSpecifiedConfigNamespace, EtcdSignerCertSecretName, err)
+	}
+
+	return crypto.GetCAFromBytes(signingCertKeyPairSecret.Data["tls.crt"], signingCertKeyPairSecret.Data["tls.key"])
+}
+
+func ReadConfigMetricsSignerCert(ctx context.Context, secretClient corev1client.SecretsGetter) (*crypto.CA, error) {
+	metricsSigningCertKeyPairSecret, err := secretClient.Secrets(operatorclient.GlobalUserSpecifiedConfigNamespace).Get(ctx, EtcdMetricsSignerCertSecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting %s/%s: %w", operatorclient.GlobalUserSpecifiedConfigNamespace, EtcdMetricsSignerCertSecretName, err)
+	}
+
+	return crypto.GetCAFromBytes(metricsSigningCertKeyPairSecret.Data["tls.crt"], metricsSigningCertKeyPairSecret.Data["tls.key"])
 }
 
 func CreatePeerCertKey(caCert, caKey []byte, nodeInternalIPs []string) (*bytes.Buffer, *bytes.Buffer, error) {

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -124,7 +124,7 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 		}
 	}
 
-	if reason := needNewTargetCertKeyPair(targetCertKeyPairSecret.Annotations, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired); len(reason) > 0 {
+	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret.Annotations, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired); len(reason) > 0 {
 		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair: %v", c.Name, c.Namespace, reason)
 		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.CertCreator, c.JiraComponent, c.Description); err != nil {
 			return nil, err

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,11 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
-
-	"github.com/ghodss/yaml"
-
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/klog/v2"
 )
 
 // SetOperandVersion sets the new version and returns the previous value.
@@ -160,6 +160,7 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 	updated := false
 	var updatedOperatorStatus *operatorv1.OperatorStatus
 	numberOfAttempts := 0
+	previousResourceVersion := ""
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		defer func() {
 			numberOfAttempts++
@@ -168,15 +169,21 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 		var resourceVersion string
 		var err error
 
-		if numberOfAttempts < 1 { // prefer lister if we haven't already failed.
-			_, oldStatus, resourceVersion, err = client.GetOperatorState()
-
-		} else { // if we have failed enough times (chose 1 as a starting point, do a live GET
-			_, oldStatus, resourceVersion, err = client.GetOperatorStateWithQuorum(ctx)
-		}
+		// prefer lister if we haven't already failed.
+		_, oldStatus, resourceVersion, err = client.GetOperatorState()
 		if err != nil {
 			return err
 		}
+		if resourceVersion == previousResourceVersion {
+			listerResourceVersion := resourceVersion
+			// this indicates that we've had a conflict and the lister has not caught up, so do a live GET
+			_, oldStatus, resourceVersion, err = client.GetOperatorStateWithQuorum(ctx)
+			if err != nil {
+				return err
+			}
+			klog.V(2).Infof("lister was stale at resourceVersion=%v, live get showed resourceVersion=%v", listerResourceVersion, resourceVersion)
+		}
+		previousResourceVersion = resourceVersion
 
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
@@ -190,6 +197,9 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 			updatedOperatorStatus = newStatus
 			return nil
 		}
+		if klog.V(2).Enabled() {
+			klog.Infof("Operator status changed: %v", operatorStatusJSONPatchNoError(oldStatus, newStatus))
+		}
 
 		updatedOperatorStatus, err = client.UpdateOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
@@ -197,6 +207,17 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 	})
 
 	return updatedOperatorStatus, updated, err
+}
+
+func operatorStatusJSONPatchNoError(original, modified *operatorv1.OperatorStatus) string {
+	if original == nil {
+		return "original object is nil"
+	}
+	if modified == nil {
+		return "modified object is nil"
+	}
+
+	return cmp.Diff(original, modified)
 }
 
 // UpdateConditionFn returns a func to update a condition.
@@ -215,6 +236,7 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 	updated := false
 	var updatedOperatorStatus *operatorv1.StaticPodOperatorStatus
 	numberOfAttempts := 0
+	previousResourceVersion := ""
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		defer func() {
 			numberOfAttempts++
@@ -223,15 +245,21 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 		var resourceVersion string
 		var err error
 
-		if numberOfAttempts < 1 { // prefer lister if we haven't already failed.
-			_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorState()
-
-		} else { // if we have failed enough times (chose 1 as a starting point, do a live GET
-			_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorStateWithQuorum(ctx)
-		}
+		// prefer lister if we haven't already failed.
+		_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorState()
 		if err != nil {
 			return err
 		}
+		if resourceVersion == previousResourceVersion {
+			listerResourceVersion := resourceVersion
+			// this indicates that we've had a conflict and the lister has not caught up, so do a live GET
+			_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorStateWithQuorum(ctx)
+			if err != nil {
+				return err
+			}
+			klog.V(2).Infof("lister was stale at resourceVersion=%v, live get showed resourceVersion=%v", listerResourceVersion, resourceVersion)
+		}
+		previousResourceVersion = resourceVersion
 
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
@@ -245,6 +273,9 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 			updatedOperatorStatus = newStatus
 			return nil
 		}
+		if klog.V(2).Enabled() {
+			klog.Infof("Operator status changed: %v", staticPodOperatorStatusJSONPatchNoError(oldStatus, newStatus))
+		}
 
 		updatedOperatorStatus, err = client.UpdateStaticPodOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
@@ -252,6 +283,16 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 	})
 
 	return updatedOperatorStatus, updated, err
+}
+
+func staticPodOperatorStatusJSONPatchNoError(original, modified *operatorv1.StaticPodOperatorStatus) string {
+	if original == nil {
+		return "original object is nil"
+	}
+	if modified == nil {
+		return "modified object is nil"
+	}
+	return cmp.Diff(original, modified)
 }
 
 // UpdateStaticPodConditionFn returns a func to update a condition.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -327,7 +327,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20240112145826-26e0d27811cb
+# github.com/openshift/library-go v0.0.0-20240124134907-4dfbf6bc7b11
 ## explicit; go 1.21
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
Second try, containing a fix for the client secret deletion described in:
https://issues.redhat.com/browse/TRT-1485?focusedId=24060763&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24060763


----
This PR will
* replace the existing cert rotation logic with more battle tested ones from library-go
* create new signer certificates (metrics + serving) in openshift-etcd namespace, in addition to existing ones in openshift-config
* create new server certificates (peer, serving, serving-metrics)
* create new client certificates (etcd-client, etcd-metrics)
* bundle existing signer certificates with newly created CAs (to stay backward compatible)

The consequence of merging this PR is:
* an additional static pod rollout during installation and upgrades (slightly longer install/upgrade time expected)
* all existing certs are rotated with existing old and new signers, which are distributed to all nodes for actual signer rotation later on