### PR TITLE
Revert "OCPBUGS-22969: Use v1 for flowcontrol API"

### DIFF
--- a/manifests/0000_20_etcd-operator_10_flowschema.yaml
+++ b/manifests/0000_20_etcd-operator_10_flowschema.yaml
@@ -1,4 +1,4 @@
-apiVersion: flowcontrol.apiserver.k8s.io/v1
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
 kind: FlowSchema
 metadata:
   name: openshift-etcd-operator


### PR DESCRIPTION
Reverts openshift/cluster-etcd-operator#1149

This is to unblock issues with another PR on SNO #1194 

more info https://redhat-internal.slack.com/archives/CEGKQ43CP/p1707207498634039