### PR TITLE
OCPBUGS-29417: fix condition name type

### DIFF
--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
@@ -168,7 +168,7 @@ func (c *BootstrapTeardownController) removeBootstrap(ctx context.Context, safeT
 
 func setSuccessfulBoostrapRemovalStatus(ctx context.Context, client v1helpers.StaticPodOperatorClient) error {
 	_, _, updateErr := v1helpers.UpdateStatus(ctx, client, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-		Type:    "EtcdBoostrapMemberRemoved",
+		Type:    "EtcdBootstrapMemberRemoved",
 		Status:  operatorv1.ConditionTrue,
 		Reason:  "BootstrapMemberRemoved",
 		Message: "etcd bootstrap member is removed",

--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller_test.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller_test.go
@@ -28,7 +28,7 @@ var (
 	}
 
 	conditionBootstrapMemberRemoved = operatorv1.OperatorCondition{
-		Type:    "EtcdBoostrapMemberRemoved",
+		Type:    "EtcdBootstrapMemberRemoved",
 		Status:  "True",
 		Reason:  "BootstrapMemberRemoved",
 		Message: "etcd bootstrap member is removed",
@@ -49,7 +49,7 @@ var (
 	}
 
 	conditionEtcdMemberRemoved = operatorv1.OperatorCondition{
-		Type:    "EtcdBoostrapMemberRemoved",
+		Type:    "EtcdBootstrapMemberRemoved",
 		Status:  "True",
 		Reason:  "BootstrapMemberRemoved",
 		Message: "etcd bootstrap member is removed",
@@ -75,7 +75,7 @@ func TestCanRemoveEtcdBootstrap(t *testing.T) {
 			bootstrapId:     uint64(0),
 		},
 		"HA happy path with bootstrap": {
-			etcdMembers:     append(u.DefaultEtcdMembers(), u.FakeEtcdBoostrapMember(0)),
+			etcdMembers:     append(u.DefaultEtcdMembers(), u.FakeEtcdBootstrapMember(0)),
 			scalingStrategy: ceohelpers.HAScalingStrategy,
 			safeToRemove:    true,
 			hasBootstrap:    true,
@@ -83,7 +83,7 @@ func TestCanRemoveEtcdBootstrap(t *testing.T) {
 		},
 		"HA happy path with bootstrap and not enough members": {
 			etcdMembers: []*etcdserverpb.Member{
-				u.FakeEtcdBoostrapMember(0),
+				u.FakeEtcdBootstrapMember(0),
 				u.FakeEtcdMemberWithoutServer(1),
 				u.FakeEtcdMemberWithoutServer(2),
 			},
@@ -93,7 +93,7 @@ func TestCanRemoveEtcdBootstrap(t *testing.T) {
 			bootstrapId:     uint64(0),
 		},
 		"HA with unhealthy member": {
-			etcdMembers:     append(u.DefaultEtcdMembers(), u.FakeEtcdBoostrapMember(0)),
+			etcdMembers:     append(u.DefaultEtcdMembers(), u.FakeEtcdBootstrapMember(0)),
 			clientFakeOpts:  etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Unhealthy: 1, Healthy: 3}),
 			scalingStrategy: ceohelpers.HAScalingStrategy,
 			safeToRemove:    false,
@@ -102,7 +102,7 @@ func TestCanRemoveEtcdBootstrap(t *testing.T) {
 		},
 		"HA with unhealthy bootstrap": {
 			etcdMembers: []*etcdserverpb.Member{
-				u.FakeEtcdBoostrapMember(0),
+				u.FakeEtcdBootstrapMember(0),
 				u.FakeEtcdMemberWithoutServer(1),
 				u.FakeEtcdMemberWithoutServer(2),
 				u.FakeEtcdMemberWithoutServer(3),
@@ -121,7 +121,7 @@ func TestCanRemoveEtcdBootstrap(t *testing.T) {
 			bootstrapId:     uint64(0),
 		},
 		"DelayedScaling happy path with bootstrap": {
-			etcdMembers:     append(u.DefaultEtcdMembers(), u.FakeEtcdBoostrapMember(0)),
+			etcdMembers:     append(u.DefaultEtcdMembers(), u.FakeEtcdBootstrapMember(0)),
 			scalingStrategy: ceohelpers.DelayedHAScalingStrategy,
 			safeToRemove:    true,
 			hasBootstrap:    true,
@@ -129,7 +129,7 @@ func TestCanRemoveEtcdBootstrap(t *testing.T) {
 		},
 		"DelayedScaling happy path with bootstrap and just enough members": {
 			etcdMembers: []*etcdserverpb.Member{
-				u.FakeEtcdBoostrapMember(0),
+				u.FakeEtcdBootstrapMember(0),
 				u.FakeEtcdMemberWithoutServer(1),
 				u.FakeEtcdMemberWithoutServer(2),
 			},
@@ -140,7 +140,7 @@ func TestCanRemoveEtcdBootstrap(t *testing.T) {
 		},
 		"DelayedScaling happy path with bootstrap and not enough members": {
 			etcdMembers: []*etcdserverpb.Member{
-				u.FakeEtcdBoostrapMember(0),
+				u.FakeEtcdBootstrapMember(0),
 				u.FakeEtcdMemberWithoutServer(1),
 			},
 			scalingStrategy: ceohelpers.DelayedHAScalingStrategy,
@@ -150,7 +150,7 @@ func TestCanRemoveEtcdBootstrap(t *testing.T) {
 		},
 		"UnsafeScaling happy path with bootstrap and enough members": {
 			etcdMembers: []*etcdserverpb.Member{
-				u.FakeEtcdBoostrapMember(0),
+				u.FakeEtcdBootstrapMember(0),
 				u.FakeEtcdMemberWithoutServer(1),
 			},
 			scalingStrategy: ceohelpers.UnsafeScalingStrategy,
@@ -274,7 +274,7 @@ func TestRemoveBootstrap(t *testing.T) {
 			fakeConfigmapLister := corev1listers.NewConfigMapLister(indexer)
 			fakeInfraLister := configv1listers.NewInfrastructureLister(indexer)
 			fakeStaticPodClient := v1helpers.NewFakeStaticPodOperatorClient(&operatorv1.StaticPodOperatorSpec{}, &operatorv1.StaticPodOperatorStatus{}, nil, nil)
-			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient([]*etcdserverpb.Member{u.FakeEtcdBoostrapMember(1)})
+			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient([]*etcdserverpb.Member{u.FakeEtcdBootstrapMember(1)})
 			require.NoError(t, err)
 
 			c := &BootstrapTeardownController{

--- a/pkg/operator/ceohelpers/bootstrap_test.go
+++ b/pkg/operator/ceohelpers/bootstrap_test.go
@@ -214,7 +214,7 @@ func Test_IsBootstrapComplete(t *testing.T) {
 		"bootstrap complete, etcd-bootstrap exists": {
 			bootstrapConfigMap: bootstrapComplete,
 			nodes:              twoNodesAtCurrentRevision,
-			etcdMembers:        append(u.DefaultEtcdMembers(), u.FakeEtcdBoostrapMember(0)),
+			etcdMembers:        append(u.DefaultEtcdMembers(), u.FakeEtcdBootstrapMember(0)),
 			expectComplete:     false,
 			expectError:        nil,
 		},

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -262,7 +262,7 @@ func FakeEtcdMemberWithoutServer(member int) *etcdserverpb.Member {
 	}
 }
 
-func FakeEtcdBoostrapMember(member int) *etcdserverpb.Member {
+func FakeEtcdBootstrapMember(member int) *etcdserverpb.Member {
 	return &etcdserverpb.Member{
 		Name:       "etcd-bootstrap",
 		ClientURLs: []string{fmt.Sprintf("https://10.0.0.%d:2907", member+1)},


### PR DESCRIPTION
Fixing a small misspell for the `/EtcdBoostrapMemberRemoved/EtcdBootstrapMemberRemoved/` condition type, this update condition will be used by openshift/installer#8004 to resolve a race condition for SNO deployments.