### PR TITLE
OCPBUGS-30245: [4.13] Replace nodelister with master nodelister everywhere

### DIFF
--- a/pkg/etcdenvvar/envvarcontroller_test.go
+++ b/pkg/etcdenvvar/envvarcontroller_test.go
@@ -157,7 +157,7 @@ func TestEnvVarController(t *testing.T) {
 				eventRecorder:        eventRecorder,
 				configmapLister:      corev1listers.NewConfigMapLister(indexer),
 				infrastructureLister: configv1listers.NewInfrastructureLister(indexer),
-				nodeLister:           corev1listers.NewNodeLister(indexer),
+				masterNodeLister:     corev1listers.NewNodeLister(indexer),
 				networkLister:        configv1listers.NewNetworkLister(networkIndexer),
 			}
 

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"k8s.io/client-go/tools/cache"
 	"strings"
 	"time"
 
@@ -71,12 +72,13 @@ var certConfigs = map[string]etcdCertConfig{
 }
 
 type EtcdCertSignerController struct {
-	kubeClient     kubernetes.Interface
-	operatorClient v1helpers.StaticPodOperatorClient
-	nodeLister     corev1listers.NodeLister
-	secretLister   corev1listers.SecretLister
-	secretClient   corev1client.SecretsGetter
-	quorumChecker  ceohelpers.QuorumChecker
+	kubeClient         kubernetes.Interface
+	operatorClient     v1helpers.StaticPodOperatorClient
+	masterNodeLister   corev1listers.NodeLister
+	masterNodeSelector labels.Selector
+	secretLister       corev1listers.SecretLister
+	secretClient       corev1client.SecretsGetter
+	quorumChecker      ceohelpers.QuorumChecker
 }
 
 // NewEtcdCertSignerController watches master nodes and maintains secrets for each master node, placing them in a single secret (NOT a tls secret)
@@ -89,19 +91,23 @@ func NewEtcdCertSignerController(
 	kubeClient kubernetes.Interface,
 	operatorClient v1helpers.StaticPodOperatorClient,
 	kubeInformers v1helpers.KubeInformersForNamespaces,
+	masterNodeInformer cache.SharedIndexInformer,
+	masterNodeLister corev1listers.NodeLister,
+	masterNodeSelector labels.Selector,
 	eventRecorder events.Recorder,
 	quorumChecker ceohelpers.QuorumChecker,
 ) factory.Controller {
 	c := &EtcdCertSignerController{
-		kubeClient:     kubeClient,
-		operatorClient: operatorClient,
-		nodeLister:     kubeInformers.InformersFor("").Core().V1().Nodes().Lister(),
-		secretLister:   kubeInformers.SecretLister(),
-		secretClient:   v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformers),
-		quorumChecker:  quorumChecker,
+		kubeClient:         kubeClient,
+		operatorClient:     operatorClient,
+		masterNodeLister:   masterNodeLister,
+		masterNodeSelector: masterNodeSelector,
+		secretLister:       kubeInformers.SecretLister(),
+		secretClient:       v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformers),
+		quorumChecker:      quorumChecker,
 	}
 	return factory.New().ResyncEvery(time.Minute).WithInformers(
-		kubeInformers.InformersFor("").Core().V1().Nodes().Informer(),
+		masterNodeInformer,
 		kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Informer(),
 		kubeInformers.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace).Core().V1().Secrets().Informer(),
 		operatorClient.Informer(),
@@ -178,7 +184,7 @@ func (c *EtcdCertSignerController) syncAllMasters(ctx context.Context, recorder 
 //	  ...
 //	}
 func (c *EtcdCertSignerController) ensureCerts(ctx context.Context, recorder events.Recorder) (map[string][]byte, error) {
-	nodes, err := c.nodeLister.List(labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector())
+	nodes, err := c.masterNodeLister.List(c.masterNodeSelector)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
 	"testing"
 	"time"
 
@@ -375,13 +376,17 @@ func setupControllerWithEtcd(t *testing.T, objects []runtime.Object, etcdMembers
 		fakeOperatorClient,
 		fakeEtcdClient)
 
+	nodeSelector, err := labels.Parse("node-role.kubernetes.io/master")
+	require.NoError(t, err)
+
 	controller := &EtcdCertSignerController{
-		kubeClient:     fakeKubeClient,
-		operatorClient: fakeOperatorClient,
-		nodeLister:     corev1listers.NewNodeLister(indexer),
-		secretLister:   corev1listers.NewSecretLister(indexer),
-		secretClient:   fakeKubeClient.CoreV1(),
-		quorumChecker:  quorumChecker,
+		kubeClient:         fakeKubeClient,
+		operatorClient:     fakeOperatorClient,
+		masterNodeLister:   corev1listers.NewNodeLister(indexer),
+		masterNodeSelector: nodeSelector,
+		secretLister:       corev1listers.NewSecretLister(indexer),
+		secretClient:       fakeKubeClient.CoreV1(),
+		quorumChecker:      quorumChecker,
 	}
 	recorder := events.NewRecorder(
 		fakeKubeClient.CoreV1().Events(operatorclient.TargetNamespace),

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -48,6 +48,7 @@ func NewTargetConfigController(
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	infrastructureInformer configv1informers.InfrastructureInformer,
 	networkInformer configv1informers.NetworkInformer,
+	masterNodeInformer cache.SharedIndexInformer,
 	kubeClient kubernetes.Interface,
 	envVarGetter etcdenvvar.EnvVar,
 	eventRecorder events.Recorder,
@@ -74,7 +75,7 @@ func NewTargetConfigController(
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Informer(),
 		kubeInformersForOpenshiftEtcdNamespace.Core().V1().ConfigMaps().Informer(),
 		kubeInformersForOpenshiftEtcdNamespace.Core().V1().Secrets().Informer(),
-		kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes().Informer(),
+		masterNodeInformer,
 		infrastructureInformer.Informer(),
 		networkInformer.Informer(),
 	).WithSync(c.sync).ToController("TargetConfigController", syncCtx.Recorder())


### PR DESCRIPTION
From profiling on cert rotation we know that the node informer is called every couple of seconds on node heartbeats. This PR will ensure that all our node listers only ever listen/inform on the master node updates to reduce the frequency of unnecessary sync calls.