### PR TITLE
first try for auto-recert

### DIFF
--- a/pkg/cmd/render/certs.go
+++ b/pkg/cmd/render/certs.go
@@ -76,7 +76,8 @@ func createCertSecrets(nodes []*corev1.Node) ([]corev1.Secret, []corev1.ConfigMa
 		kubeInformers.InformersFor("").Core().V1().Nodes().Lister(),
 		nodeSelector,
 		recorder,
-		&ceohelpers.AlwaysSafeQuorumChecker{})
+		&ceohelpers.AlwaysSafeQuorumChecker{},
+		true)
 
 	stopChan := make(chan struct{})
 	defer close(stopChan)

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -379,7 +379,9 @@ func setupControllerWithEtcd(
 		kubeInformerForNamespace.InformersFor("").Core().V1().Nodes().Lister(),
 		nodeSelector,
 		recorder,
-		quorumChecker)
+		quorumChecker,
+		// TODO(thomas): we need to test the revision gating now too :-)
+		true)
 
 	stopChan := make(chan struct{})
 	t.Cleanup(func() {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -365,6 +365,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		masterNodeLabelSelector,
 		controllerContext.EventRecorder,
 		quorumChecker,
+		false,
 	)
 
 	etcdCertCleanerController := etcdcertcleaner.NewEtcdCertCleanerController(


### PR DESCRIPTION
This PR adds:
* deprecation path for openshift-config certificates
* fully managed auto-rotation of signers and their leafs