### PR TITLE
API-1800: manifests: convert SecretTypeTLS secrets to kubernetes.io/tls

### DIFF
--- a/manifests/0000_20_etcd-operator_03_secret.yaml
+++ b/manifests/0000_20_etcd-operator_03_secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Secret
-type: SecretTypeTLS
+type: kubernetes.io/tls
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -8,3 +8,6 @@ metadata:
     release.openshift.io/create-only: "true"
   name: etcd-client
   namespace: openshift-etcd-operator
+data:
+  tls.crt: ""
+  tls.key: ""


### PR DESCRIPTION
SecretTypeTLS is a deprecated type, which gets converted to kubernetes.io/tls when controller parses. Changing this type to supported to make controller skip convertion on initial install.

Ref: https://issues.redhat.com/browse/API-1800