### PR TITLE
OCPBUGS-33495: return errors in wait-for-ceo

### DIFF
--- a/pkg/cmd/waitforceo/waitforceo.go
+++ b/pkg/cmd/waitforceo/waitforceo.go
@@ -51,9 +51,11 @@ func (w *waitForCeoOpts) Run() error {
 	config, err := clientcmd.BuildConfigFromFlags("", w.kubeconfig)
 	if err != nil {
 		klog.Errorf("error loading kubeconfig: %#v", err)
+		return err
 	}
 	if err := bootstrapteardown.WaitForEtcdBootstrap(context.TODO(), config); err != nil {
 		klog.Errorf("error waiting for cluster-etcd-operator %#v", err)
+		return err
 	}
 	return nil
 }

--- a/pkg/operator/bootstrapteardown/waitforceo.go
+++ b/pkg/operator/bootstrapteardown/waitforceo.go
@@ -23,10 +23,12 @@ func WaitForEtcdBootstrap(ctx context.Context, config *rest.Config) error {
 
 	// TODO: figure out if we can timeout after 30 mins by
 	// passing a different context here
-	if err := waitForEtcdBootstrap(ctx, operatorConfigClient.OperatorV1().RESTClient()); err != nil {
+	err = waitForEtcdBootstrap(ctx, operatorConfigClient.OperatorV1().RESTClient())
+	if err != nil {
 		klog.Errorf("error watching etcd: %#v", err)
+		return err
 	}
-	return err
+	return nil
 }
 
 func waitForEtcdBootstrap(ctx context.Context, operatorRestClient rest.Interface) error {


### PR DESCRIPTION
Fixes [OCPBUGS-33495](https://issues.redhat.com/browse/OCPBUGS-33495) as we were swallowing errors in the wait-for-ceo cmd

/cc @dusk125 @tjungblu 