### PR TITLE
NO-JIRA:check the cluster is healthy or not after getting env var, to ensure it is safe to rollout

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -105,6 +105,15 @@ func (c TargetConfigController) sync(ctx context.Context, syncCtx factory.SyncCo
 	if err != nil {
 		return err
 	}
+	// check the cluster is healthy or not after get env var, to ensure it is safe to rollout
+	safe, err = c.quorumChecker.IsSafeToUpdateRevision()
+	if err != nil {
+		return fmt.Errorf("TargetConfigController can't evaluate whether quorum is safe: %w", err)
+	}
+
+	if !safe {
+		return fmt.Errorf("skipping TargetConfigController reconciliation due to insufficient quorum")
+	}
 	requeue, err := createTargetConfig(ctx, c, syncCtx.Recorder(), operatorSpec, envVars)
 	if err != nil {
 		return err


### PR DESCRIPTION
1. similar to the https://github.com/openshift/cluster-etcd-operator/pull/1239, I found the ceo could also rollout when remove one master node
2. the targetconfigcontroller  should check the cluster is safe or not when get env vars, in case the env vas have changed, but the cluster is not healthy yet

