### PR TITLE
ETCD-603: add revision helpers

### DIFF
--- a/pkg/operator/ceohelpers/common_test.go
+++ b/pkg/operator/ceohelpers/common_test.go
@@ -1,6 +1,8 @@
 package ceohelpers
 
 import (
+	"errors"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -72,6 +74,155 @@ func TestReadDesiredControlPlaneReplicaCount(t *testing.T) {
 			if actualReplicaCount != scenario.expectedControlPlaneReplicaCount {
 				t.Fatalf("unexpected control plance replicat count: %d, expected: %d", actualReplicaCount, scenario.expectedControlPlaneReplicaCount)
 			}
+		})
+	}
+}
+
+func TestRevisionRolloutInProgress(t *testing.T) {
+	scenarios := []struct {
+		name     string
+		status   operatorv1.StaticPodOperatorStatus
+		expected bool
+	}{
+		{
+			name: "revs equal single node",
+			status: operatorv1.StaticPodOperatorStatus{
+				LatestAvailableRevision: 1,
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 1, TargetRevision: 1},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "revs not equal single node",
+			status: operatorv1.StaticPodOperatorStatus{
+				LatestAvailableRevision: 3,
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 1, TargetRevision: 3},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "revs not equal multi node",
+			status: operatorv1.StaticPodOperatorStatus{
+				LatestAvailableRevision: 3,
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 3, TargetRevision: 3},
+					{NodeName: "node-2", CurrentRevision: 1, TargetRevision: 3},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "revs equal multi node",
+			status: operatorv1.StaticPodOperatorStatus{
+				LatestAvailableRevision: 3,
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 3, TargetRevision: 3},
+					{NodeName: "node-2", CurrentRevision: 3, TargetRevision: 3},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			require.Equal(t, scenario.expected, RevisionRolloutInProgress(scenario.status))
+		})
+	}
+}
+
+func TestCurrentRevision(t *testing.T) {
+	scenarios := []struct {
+		name        string
+		status      operatorv1.StaticPodOperatorStatus
+		expected    int32
+		expectedErr error
+	}{
+		{
+			name: "revs equal single node",
+			status: operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{},
+			},
+			expectedErr: errors.New("no node status"),
+		},
+		{
+			name: "revs equal single node",
+			status: operatorv1.StaticPodOperatorStatus{
+				LatestAvailableRevision: 22,
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 22, TargetRevision: 22},
+				},
+			},
+			expected: 22,
+		},
+		{
+			name: "revs not equal single node",
+			status: operatorv1.StaticPodOperatorStatus{
+				LatestAvailableRevision: 3,
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 1, TargetRevision: 3},
+				},
+			},
+			expected:    0,
+			expectedErr: RevisionRolloutInProgressErr,
+		},
+		{
+			name: "target revs not equal multi node",
+			status: operatorv1.StaticPodOperatorStatus{
+				LatestAvailableRevision: 3,
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 3, TargetRevision: 3},
+					{NodeName: "node-2", CurrentRevision: 1, TargetRevision: 3},
+				},
+			},
+			expected:    0,
+			expectedErr: RevisionRolloutInProgressErr,
+		},
+		{
+			name: "revs equal multi node",
+			status: operatorv1.StaticPodOperatorStatus{
+				LatestAvailableRevision: 3,
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 3, TargetRevision: 0},
+					{NodeName: "node-2", CurrentRevision: 3, TargetRevision: 0},
+				},
+			},
+			expected: 3,
+		},
+		{
+			name: "revs differ multi node",
+			status: operatorv1.StaticPodOperatorStatus{
+				LatestAvailableRevision: 3,
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 3, TargetRevision: 3},
+					{NodeName: "node-2", CurrentRevision: 2, TargetRevision: 2},
+				},
+			},
+			expected:    0,
+			expectedErr: errors.New("revision rollout in progress, can't establish current revision"),
+		},
+		{
+			name: "latest rev far ahead",
+			status: operatorv1.StaticPodOperatorStatus{
+				LatestAvailableRevision: 25,
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 3, TargetRevision: 3},
+				},
+			},
+			expected:    0,
+			expectedErr: errors.New("revision rollout in progress, can't establish current revision"),
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			revision, err := CurrentRevision(scenario.status)
+			require.Equal(t, scenario.expectedErr, err)
+			require.Equal(t, scenario.expected, revision)
 		})
 	}
 }


### PR DESCRIPTION
Salvage from the previous reverted PR we had in 4.16. Note that some of those helpers are not actively used yet, but it's used in a follow-up PR.