### PR TITLE
TRT-1687: Revert #1268 "ETCD-606: Batch bundle revision rollout"

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -145,7 +145,7 @@ ${COMPUTED_ENV_VARS}
         # this has a non-zero return code if the command is non-zero.  If you use an export first, it doesn't and you
         # will succeed when you should fail.
         ETCD_INITIAL_CLUSTER=$(discover-etcd-initial-cluster \
-          --cacert=/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
+          --cacert=/etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt \
           --cert=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt \
           --key=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key \
           --endpoints=${ALL_ETCD_ENDPOINTS} \
@@ -175,11 +175,11 @@ ${COMPUTED_ENV_VARS}
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \
-          --trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
+          --trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt \
           --client-cert-auth=true \
           --peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt \
           --peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key \
-          --peer-trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
+          --peer-trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-peer-client-ca/ca-bundle.crt \
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
           --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379,unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
@@ -255,8 +255,8 @@ ${COMPUTED_ENV_VARS}
           --key-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.key \
           --cert /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt \
           --cert-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.crt \
-          --cacert /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
-          --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/metrics-ca-bundle.crt \
+          --cacert /etc/kubernetes/static-pod-certs/configmaps/etcd-peer-client-ca/ca-bundle.crt \
+          --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-metrics-proxy-serving-ca/ca-bundle.crt \
           --listen-cipher-suites TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256
     env:
 ${COMPUTED_ENV_VARS}

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -89,11 +89,11 @@ spec:
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \
-          --trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
+          --trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt \
           --client-cert-auth=true \
           --peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt \
           --peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key \
-          --peer-trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
+          --peer-trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-peer-client-ca/ca-bundle.crt \
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
           --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379 \

--- a/pkg/cmd/render/certs_test.go
+++ b/pkg/cmd/render/certs_test.go
@@ -23,7 +23,7 @@ func TestCertSingleNode(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 11, len(secrets))
-	require.Equal(t, 10, len(bundles))
+	require.Equal(t, 9, len(bundles))
 
 	assertCertificateCorrectness(t, secrets)
 	assertBundleCorrectness(t, secrets, bundles)
@@ -40,7 +40,7 @@ func TestCertsMultiNode(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 17, len(secrets))
-	require.Equal(t, 10, len(bundles))
+	require.Equal(t, 9, len(bundles))
 
 	assertCertificateCorrectness(t, secrets)
 	assertBundleCorrectness(t, secrets, bundles)
@@ -116,39 +116,25 @@ func assertBundleCorrectness(t *testing.T, secrets []corev1.Secret, bundles []co
 	}
 
 	for _, bundle := range bundles {
-		if bundle.Name == tlshelpers.EtcdAllBundlesConfigMapName {
-			serverBundleCerts, err := cert.ParseCertsPEM([]byte(bundle.Data["server-ca-bundle.crt"]))
-			require.NoError(t, err)
-			assertMatchingBundles(t, signerMap[tlshelpers.EtcdSignerCertSecretName], serverBundleCerts)
+		bundleCerts, err := cert.ParseCertsPEM([]byte(bundle.Data["ca-bundle.crt"]))
+		require.NoError(t, err)
 
-			metricsBundleCerts, err := cert.ParseCertsPEM([]byte(bundle.Data["metrics-ca-bundle.crt"]))
-			require.NoError(t, err)
-			assertMatchingBundles(t, signerMap[tlshelpers.EtcdMetricsSignerCertSecretName], metricsBundleCerts)
+		var signers []*x509.Certificate
+		if strings.Contains(bundle.Name, "metric") {
+			signers = signerMap[tlshelpers.EtcdMetricsSignerCertSecretName]
 		} else {
-			bundleCerts, err := cert.ParseCertsPEM([]byte(bundle.Data["ca-bundle.crt"]))
-			require.NoError(t, err)
-
-			var signers []*x509.Certificate
-			if strings.Contains(bundle.Name, "metric") {
-				signers = signerMap[tlshelpers.EtcdMetricsSignerCertSecretName]
-			} else {
-				signers = signerMap[tlshelpers.EtcdSignerCertSecretName]
-			}
-
-			assertMatchingBundles(t, signers, bundleCerts)
+			signers = signerMap[tlshelpers.EtcdSignerCertSecretName]
 		}
+
+		sort.SliceStable(signers, func(i, j int) bool {
+			return bytes.Compare(signers[i].Raw, signers[j].Raw) < 0
+		})
+		sort.SliceStable(bundleCerts, func(i, j int) bool {
+			return bytes.Compare(bundleCerts[i].Raw, bundleCerts[j].Raw) < 0
+		})
+
+		require.Equal(t, signers, bundleCerts)
 	}
-}
-
-func assertMatchingBundles(t *testing.T, expectedBundle []*x509.Certificate, actualBundle []*x509.Certificate) {
-	sort.SliceStable(expectedBundle, func(i, j int) bool {
-		return bytes.Compare(expectedBundle[i].Raw, expectedBundle[j].Raw) < 0
-	})
-	sort.SliceStable(actualBundle, func(i, j int) bool {
-		return bytes.Compare(actualBundle[i].Raw, actualBundle[j].Raw) < 0
-	})
-
-	require.Equal(t, expectedBundle, actualBundle)
 }
 
 // we only check that all certificates were generated, the correctness is verified above

--- a/pkg/etcdenvvar/envvarcontroller_test.go
+++ b/pkg/etcdenvvar/envvarcontroller_test.go
@@ -37,7 +37,7 @@ var (
 	defaultEnvResult = map[string]string{
 		"ALL_ETCD_ENDPOINTS":                       "https://192.168.2.0:2379,https://192.168.2.1:2379,https://192.168.2.2:2379",
 		"ETCDCTL_API":                              "3",
-		"ETCDCTL_CACERT":                           "/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt",
+		"ETCDCTL_CACERT":                           "/etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt",
 		"ETCDCTL_CERT":                             "/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt",
 		"ETCDCTL_ENDPOINTS":                        "https://192.168.2.0:2379,https://192.168.2.1:2379,https://192.168.2.2:2379",
 		"ETCDCTL_KEY":                              "/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key",

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -126,7 +126,7 @@ func getEtcdctlEnvVars(envVarContext envVarContext) (map[string]string, error) {
 	}
 	return map[string]string{
 		"ETCDCTL_API":       "3",
-		"ETCDCTL_CACERT":    "/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt",
+		"ETCDCTL_CACERT":    "/etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt",
 		"ETCDCTL_CERT":      "/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt",
 		"ETCDCTL_KEY":       "/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key",
 		"ETCDCTL_ENDPOINTS": endpoints,

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1061,7 +1061,7 @@ ${COMPUTED_ENV_VARS}
         # this has a non-zero return code if the command is non-zero.  If you use an export first, it doesn't and you
         # will succeed when you should fail.
         ETCD_INITIAL_CLUSTER=$(discover-etcd-initial-cluster \
-          --cacert=/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
+          --cacert=/etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt \
           --cert=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt \
           --key=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key \
           --endpoints=${ALL_ETCD_ENDPOINTS} \
@@ -1091,11 +1091,11 @@ ${COMPUTED_ENV_VARS}
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \
-          --trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
+          --trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt \
           --client-cert-auth=true \
           --peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt \
           --peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key \
-          --peer-trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
+          --peer-trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-peer-client-ca/ca-bundle.crt \
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
           --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379,unixs://${NODE_NODE_ENVVAR_NAME_IP}:0 \
@@ -1171,8 +1171,8 @@ ${COMPUTED_ENV_VARS}
           --key-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.key \
           --cert /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt \
           --cert-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.crt \
-          --cacert /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
-          --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/metrics-ca-bundle.crt \
+          --cacert /etc/kubernetes/static-pod-certs/configmaps/etcd-peer-client-ca/ca-bundle.crt \
+          --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-metrics-proxy-serving-ca/ca-bundle.crt \
           --listen-cipher-suites TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256
     env:
 ${COMPUTED_ENV_VARS}
@@ -1462,11 +1462,11 @@ spec:
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \
-          --trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
+          --trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt \
           --client-cert-auth=true \
           --peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.crt \
           --peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-peer-NODE_NAME.key \
-          --peer-trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
+          --peer-trusted-ca-file=/etc/kubernetes/static-pod-certs/configmaps/etcd-peer-client-ca/ca-bundle.crt \
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
           --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379 \

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -69,7 +69,6 @@ type EtcdCertSignerController struct {
 	secretInformer     corev1informers.SecretInformer
 	secretLister       corev1listers.SecretLister
 	secretClient       corev1client.SecretsGetter
-	configMapClient    corev1client.ConfigMapsGetter
 	quorumChecker      ceohelpers.QuorumChecker
 
 	certConfig *certConfig
@@ -152,7 +151,6 @@ func NewEtcdCertSignerController(
 		secretInformer:        secretInformer,
 		secretLister:          secretLister,
 		secretClient:          secretClient,
-		configMapClient:       cmGetter,
 		quorumChecker:         quorumChecker,
 		certConfig:            certCfg,
 		signerExpirationGauge: signerExpirationGauge,
@@ -233,8 +231,7 @@ func (c *EtcdCertSignerController) syncAllMasterCertificates(ctx context.Context
 		return fmt.Errorf("error on ensuring metrics-signer cert: %w", err)
 	}
 
-	signerBundle, metricsSignerBundle, err := c.ensureBundles(ctx, recorder,
-		[]*crypto.CA{signerCaPair, newSignerCaPair}, []*crypto.CA{metricsSignerCaPair, newMetricsSignerCaPair})
+	signerBundle, metricsSignerBundle, err := c.ensureBundles(ctx, []*crypto.CA{signerCaPair, newSignerCaPair}, []*crypto.CA{metricsSignerCaPair, newMetricsSignerCaPair})
 	if err != nil {
 		return fmt.Errorf("error on ensuring bundles: %w", err)
 	}
@@ -311,8 +308,8 @@ func (c *EtcdCertSignerController) syncAllMasterCertificates(ctx context.Context
 
 // ensureBundles will take the metrics and server CA certificates and ensure the bundle is updated.
 // This will cause a revision rollout if a change in the bundle was detected.
-func (c *EtcdCertSignerController) ensureBundles(ctx context.Context, recorder events.Recorder,
-	serverCA []*crypto.CA, metricsCA []*crypto.CA) (serverBundle []*x509.Certificate, metricsBundle []*x509.Certificate, err error) {
+// TODO(thomas): that bundle rollout is not transactional: it's very likely the first update will already trigger a new revision, the metrics could come in a follow-up
+func (c *EtcdCertSignerController) ensureBundles(ctx context.Context, serverCA []*crypto.CA, metricsCA []*crypto.CA) (serverBundle []*x509.Certificate, metricsBundle []*x509.Certificate, err error) {
 	for _, ca := range serverCA {
 		serverBundle, err = c.certConfig.signerCaBundle.EnsureConfigMapCABundle(ctx, ca)
 		if err != nil {
@@ -320,58 +317,11 @@ func (c *EtcdCertSignerController) ensureBundles(ctx context.Context, recorder e
 		}
 	}
 
-	serverCaBytes, err := crypto.EncodeCertificates(serverBundle...)
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not encode server bundle: %w", err)
-	}
-
 	for _, ca := range metricsCA {
 		metricsBundle, err = c.certConfig.metricsSignerCaBundle.EnsureConfigMapCABundle(ctx, ca)
 		if err != nil {
 			return
 		}
-	}
-
-	metricsCaBytes, err := crypto.EncodeCertificates(metricsBundle...)
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not encode metrics bundle: %w", err)
-	}
-
-	// Write a configmap that aggregates all certs for all nodes for the static
-	// pod controller to watch. A single configmap ensures that a bundle change
-	// (e.g. node addition or cert rotation) triggers at most one static pod
-	// rollout. If multiple configmaps were written, the static pod controller
-	// might initiate rollout before all configmaps had been updated.
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: operatorclient.TargetNamespace,
-			Name:      tlshelpers.EtcdAllBundlesConfigMapName,
-			Annotations: map[string]string{
-				apiannotations.OpenShiftComponent: "Etcd",
-			},
-		},
-		Data: map[string]string{
-			"server-ca-bundle.crt":  string(serverCaBytes),
-			"metrics-ca-bundle.crt": string(metricsCaBytes),
-		},
-	}
-
-	safe, err := c.quorumChecker.IsSafeToUpdateRevision()
-	if err != nil {
-		return nil, nil, fmt.Errorf("EtcdCertSignerController.ensureBundles can't evaluate whether quorum is safe: %w", err)
-	}
-
-	if !safe {
-		return nil, nil, fmt.Errorf("skipping EtcdCertSignerController.ensureBundles reconciliation due to insufficient quorum")
-	}
-	_, changed, err := resourceapply.ApplyConfigMap(ctx, c.configMapClient, recorder, configMap)
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not apply bundle configmap: %w", err)
-	}
-
-	if changed {
-		// TODO(thomas): set the rollout bundle revision in the CEO status
-		// TODO(thomas): we need to notify the outside caller that it's not safe to rotate the leafs just yet
 	}
 
 	return

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -615,8 +615,12 @@ func getEnabledDisabledFeatures(features featuregates.FeatureGate) ([]string, []
 // the first element should be the configmap that contains the static pod manifest
 var RevisionConfigMaps = []revision.RevisionResource{
 	{Name: "etcd-pod"},
+
+	{Name: "etcd-serving-ca"},
+	{Name: "etcd-peer-client-ca"},
+	{Name: "etcd-metrics-proxy-serving-ca"},
+	{Name: "etcd-metrics-proxy-client-ca"},
 	{Name: "etcd-endpoints"},
-	{Name: "etcd-all-bundles"},
 }
 
 // RevisionSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.
@@ -627,7 +631,10 @@ var RevisionSecrets = []revision.RevisionResource{
 var CertConfigMaps = []installer.UnrevisionedResource{
 	{Name: "restore-etcd-pod"},
 	{Name: "etcd-scripts"},
-	{Name: "etcd-all-bundles"},
+	{Name: "etcd-serving-ca"},
+	{Name: "etcd-peer-client-ca"},
+	{Name: "etcd-metrics-proxy-serving-ca"},
+	{Name: "etcd-metrics-proxy-client-ca"},
 }
 
 var CertSecrets = []installer.UnrevisionedResource{

--- a/pkg/tlshelpers/tlshelpers.go
+++ b/pkg/tlshelpers/tlshelpers.go
@@ -37,7 +37,6 @@ const (
 	EtcdMetricsSignerCertSecretName        = "etcd-metric-signer"
 	EtcdMetricsSignerCaBundleConfigMapName = "etcd-metrics-ca-bundle"
 	EtcdAllCertsSecretName                 = "etcd-all-certs"
-	EtcdAllBundlesConfigMapName            = "etcd-all-bundles"
 	EtcdClientCertSecretName               = "etcd-client"
 	EtcdMetricsClientCertSecretName        = "etcd-metric-client"
 )


### PR DESCRIPTION

Reverts #1268 ; tracked by https://issues.redhat.com/browse/TRT-1687

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Appear to be intermittently failing a pathological event test enough to take out 4.17 CI payloads

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-aggregate periodic-ci-openshift-release-master-ci-4.17-upgrade-from-stable-4.16-e2e-aws-ovn-upgrade 10
```

CC: @tjungblu

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
