### PR TITLE
ETCD-593: Enable experimental-stop-grpc-service-on-defrag

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -49,6 +49,7 @@ spec:
       exec etcd \
         --logger=zap \
         --experimental-initial-corrupt-check=true \
+        --experimental-stop-grpc-service-on-defrag \
         --initial-advertise-peer-urls=https://{{ .EtcdAddress.EscapedBootstrapIP }}:2380 \
         --cert-file=/etc/ssl/etcd/etcd-all-certs/etcd-serving-{{ .Hostname }}.crt \
         --key-file=/etc/ssl/etcd/etcd-all-certs/etcd-serving-{{ .Hostname }}.key \

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -171,6 +171,7 @@ ${COMPUTED_ENV_VARS}
           --logger=zap \
           --log-level=${VERBOSITY} \
           --experimental-initial-corrupt-check=true \
+          --experimental-stop-grpc-service-on-defrag \
           --snapshot-count=10000 \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1087,6 +1087,7 @@ ${COMPUTED_ENV_VARS}
           --logger=zap \
           --log-level=${VERBOSITY} \
           --experimental-initial-corrupt-check=true \
+          --experimental-stop-grpc-service-on-defrag \
           --snapshot-count=10000 \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \


### PR DESCRIPTION
This PR enable `--experimental-stop-grpc-service-on-defrag` on OCP/Etcd. 

cc @openshift/openshift-team-etcd 
