### PR TITLE
OCPBUGS-36621: add etcd-all-bundles to cvo create-only

### DIFF
--- a/manifests/0000_20_etcd-operator_03_configmap.yaml
+++ b/manifests/0000_20_etcd-operator_03_configmap.yaml
@@ -31,3 +31,13 @@ metadata:
     service.beta.openshift.io/inject-cabundle: "true"
   name: etcd-service-ca-bundle
   namespace: openshift-etcd-operator
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  name: etcd-all-bundles
+  namespace: openshift-etcd


### PR DESCRIPTION
This should avoid cases where the static pod installer controller races with the cert controller and they would block each other on that resource.
