### PR TITLE
ETCD-635: add backup server sidecar

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -311,6 +311,26 @@ ${COMPUTED_ENV_VARS}
         name: log-dir
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
+  - name: etcd-backup-server
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: [cluster-etcd-operator]
+    args:
+${COMPUTED_BACKUP_VARS}
+    securityContext:
+      privileged: true
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
+    env:
+${COMPUTED_ENV_VARS}
+    volumeMounts:
+      - mountPath: /var/lib/etcd
+        name: data-dir
+      - mountPath: /var/log/etcd
+        name: log-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/cmd/cluster-etcd-operator/main.go
+++ b/cmd/cluster-etcd-operator/main.go
@@ -75,6 +75,7 @@ func NewSSCSCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(readyz.NewReadyzCommand())
 	cmd.AddCommand(prune_backups.NewPruneCommand())
 	cmd.AddCommand(requestbackup.NewRequestBackupCommand(ctx))
+	cmd.AddCommand(backuprestore.NewBackupServer(ctx))
 
 	return cmd
 }

--- a/pkg/backuphelpers/backupvars.go
+++ b/pkg/backuphelpers/backupvars.go
@@ -1,0 +1,73 @@
+package backuphelpers
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	backupv1alpha1 "github.com/openshift/api/config/v1alpha1"
+)
+
+type Enqueueable interface {
+	Enqueue()
+}
+
+type BackupVar interface {
+	AddListener(listener Enqueueable)
+	SetBackupSpec(spec backupv1alpha1.EtcdBackupSpec)
+	ArgString() string
+}
+
+type BackupConfig struct {
+	enabled   bool
+	spec      backupv1alpha1.EtcdBackupSpec
+	listeners []Enqueueable
+	mux       sync.Mutex
+}
+
+func NewDisabledBackupConfig() *BackupConfig {
+	return &BackupConfig{
+		enabled: false,
+		mux:     sync.Mutex{},
+	}
+}
+
+func (b *BackupConfig) SetBackupSpec(spec backupv1alpha1.EtcdBackupSpec) {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	if reflect.DeepEqual(b.spec, spec) {
+		return
+	}
+
+	b.spec = spec
+	for _, l := range b.listeners {
+		l.Enqueue()
+	}
+}
+
+func (b *BackupConfig) ArgString() string {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	args := []string{"    - backup-server"}
+	args = append(args, fmt.Sprintf("- --%s=%v", "enabled", b.enabled))
+
+	if b.spec.TimeZone != "" {
+		args = append(args, fmt.Sprintf("- --%s=%s", "timezone", b.spec.TimeZone))
+	}
+
+	if b.spec.Schedule != "" {
+		args = append(args, fmt.Sprintf("- --%s=%s", "schedule", b.spec.Schedule))
+	}
+
+	return strings.Join(args, "\n    ")
+}
+
+func (b *BackupConfig) AddListener(listener Enqueueable) {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	b.listeners = append(b.listeners, listener)
+}

--- a/pkg/backuphelpers/backupvars_test.go
+++ b/pkg/backuphelpers/backupvars_test.go
@@ -1,0 +1,96 @@
+package backuphelpers
+
+import (
+	"testing"
+
+	backupv1alpha1 "github.com/openshift/api/config/v1alpha1"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	schedule = "0 */2 * * *"
+	timezone = "GMT"
+)
+
+func TestBackupConfig_ToArgs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		cr       backupv1alpha1.EtcdBackupSpec
+		enabled  bool
+		expected string
+	}{
+		{
+			"enabled",
+			createEtcdBackupSpec(timezone, schedule),
+			true,
+			"    - backup-server\n    - --enabled=true\n    - --timezone=GMT\n    - --schedule=0 */2 * * *",
+		},
+		{
+			"disabled",
+			createEtcdBackupSpec(timezone, schedule),
+			false,
+			"    - backup-server\n    - --enabled=false\n    - --timezone=GMT\n    - --schedule=0 */2 * * *",
+		},
+		{
+			"empty schedule disabled",
+			createEtcdBackupSpec(timezone, ""),
+			false,
+			"    - backup-server\n    - --enabled=false\n    - --timezone=GMT",
+		},
+		{
+			"empty schedule enabled",
+			createEtcdBackupSpec(timezone, ""),
+			true,
+			"    - backup-server\n    - --enabled=true\n    - --timezone=GMT",
+		},
+
+		{
+			"empty timezone disabled",
+			createEtcdBackupSpec("", schedule),
+			false,
+			"    - backup-server\n    - --enabled=false\n    - --schedule=0 */2 * * *",
+		},
+		{
+			"empty timezone enabled",
+			createEtcdBackupSpec("", schedule),
+			true,
+			"    - backup-server\n    - --enabled=true\n    - --schedule=0 */2 * * *",
+		},
+
+		{
+			"empty timezone and schedule disabled",
+			createEtcdBackupSpec("", ""),
+			false,
+			"    - backup-server\n    - --enabled=false",
+		},
+		{
+			"empty timezone and schedule enabled",
+			createEtcdBackupSpec("", ""),
+			true,
+			"    - backup-server\n    - --enabled=true",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			c := NewDisabledBackupConfig()
+			c.SetBackupSpec(tc.cr)
+			if tc.enabled {
+				c.enabled = true
+			}
+
+			act := c.ArgString()
+
+			require.Equal(t, tc.expected, act)
+		})
+	}
+}
+
+func createEtcdBackupSpec(timezone, schedule string) backupv1alpha1.EtcdBackupSpec {
+	return backupv1alpha1.EtcdBackupSpec{
+		Schedule: schedule,
+		TimeZone: timezone,
+	}
+}

--- a/pkg/cmd/backuprestore/backupserver.go
+++ b/pkg/cmd/backuprestore/backupserver.go
@@ -1,0 +1,105 @@
+package backuprestore
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"k8s.io/klog/v2"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+
+type backupServer struct {
+	schedule string
+	timeZone string
+	enabled  bool
+	//scheduler *tasker.Tasker
+	backupOptions
+}
+
+func NewBackupServer(ctx context.Context) *cobra.Command {
+	backupSrv := &backupServer{
+		backupOptions: backupOptions{errOut: os.Stderr},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "backup-server",
+		Short: "Backs up a snapshot of etcd database and static pod resources without config",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			klog.Infof("hello from backup server :) ")
+
+			if err := backupSrv.Validate(); err != nil {
+				klog.Fatal(err)
+			}
+			if err := backupSrv.Run(ctx); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+	backupSrv.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (b *backupServer) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&b.enabled, "enabled", false, "enable backup server")
+	fs.StringVar(&b.schedule, "schedule", "", "schedule specifies the cron schedule to run the backup")
+	fs.StringVar(&b.timeZone, "timezone", "", "timezone specifies the timezone of the cron schedule to run the backup")
+	cobra.MarkFlagRequired(fs, "enabled")
+
+	//b.backupOptions.AddFlags(fs)
+}
+
+func (b *backupServer) Validate() error {
+	//return b.backupOptions.Validate()
+	return nil
+}
+
+func (b *backupServer) Run(ctx context.Context) error {
+	//b.scheduler = tasker.New(tasker.Option{
+	//	Verbose: true,
+	//	Tz:      b.timeZone,
+	//})
+
+	klog.Infof("hello from backup server Run() :) ")
+	// handle teardown
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	shutdownHandler := make(chan os.Signal, 2)
+	signal.Notify(shutdownHandler, shutdownSignals...)
+	go func() {
+		select {
+		case <-shutdownHandler:
+			klog.Infof("Received SIGTERM or SIGINT signal, shutting down.")
+			close(shutdownHandler)
+			cancel()
+		case <-ctx.Done():
+			klog.Infof("Context has been cancelled, shutting down.")
+			close(shutdownHandler)
+			cancel()
+		}
+	}()
+
+	//err := b.scheduleBackup()
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//doneCh := make(chan struct{})
+	//go func() {
+	//	b.scheduler.Run()
+	//	doneCh <- struct{}{}
+	//}()
+	//
+	//<-doneCh
+	//return nil
+
+	<-ctx.Done()
+
+	return nil
+}

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1227,6 +1227,26 @@ ${COMPUTED_ENV_VARS}
         name: log-dir
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
+  - name: etcd-backup-server
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: [cluster-etcd-operator]
+    args:
+${COMPUTED_BACKUP_VARS}
+    securityContext:
+      privileged: true
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
+    env:
+${COMPUTED_ENV_VARS}
+    volumeMounts:
+      - mountPath: /var/lib/etcd
+        name: data-dir
+      - mountPath: /var/log/etcd
+        name: log-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/pkg/operator/periodicbackupcontroller/periodicbackupcontroller.go
+++ b/pkg/operator/periodicbackupcontroller/periodicbackupcontroller.go
@@ -10,31 +10,35 @@ import (
 	backupv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1alpha1"
 	"github.com/openshift/cluster-etcd-operator/pkg/backuphelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcd_assets"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/health"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	"k8s.io/klog/v2"
-
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/health"
-	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-	"k8s.io/client-go/kubernetes"
 )
 
-const backupJobLabel = "backup-name"
+const (
+	backupJobLabel      = "backup-name"
+	defaultBackupCRName = "default"
+)
 
 type PeriodicBackupController struct {
 	operatorClient        v1helpers.OperatorClient
 	backupsClient         backupv1client.BackupsGetter
 	kubeClient            kubernetes.Interface
 	operatorImagePullSpec string
+	backupVarGetter       backuphelpers.BackupVar
 	featureGateAccessor   featuregates.FeatureGateAccess
 }
 
@@ -46,6 +50,7 @@ func NewPeriodicBackupController(
 	eventRecorder events.Recorder,
 	operatorImagePullSpec string,
 	accessor featuregates.FeatureGateAccess,
+	backupVarGetter backuphelpers.BackupVar,
 	backupsInformer factory.Informer) factory.Controller {
 
 	c := &PeriodicBackupController{
@@ -53,6 +58,7 @@ func NewPeriodicBackupController(
 		backupsClient:         backupsClient,
 		kubeClient:            kubeClient,
 		operatorImagePullSpec: operatorImagePullSpec,
+		backupVarGetter:       backupVarGetter,
 		featureGateAccessor:   accessor,
 	}
 
@@ -81,6 +87,11 @@ func (c *PeriodicBackupController) sync(ctx context.Context, _ factory.SyncConte
 	}
 
 	for _, item := range backups.Items {
+		if item.Name == defaultBackupCRName {
+			c.backupVarGetter.SetBackupSpec(item.Spec.EtcdBackupSpec)
+			continue
+		}
+
 		err := reconcileCronJob(ctx, cronJobsClient, item, c.operatorImagePullSpec)
 		if err != nil {
 			_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -248,6 +248,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorClient,
 		cachedMemberClient)
 
+	backupVar := backuphelpers.NewDisabledBackupConfig()
+
 	targetConfigReconciler := targetconfigcontroller.NewTargetConfigController(
 		AlivenessChecker,
 		os.Getenv("IMAGE"),
@@ -260,6 +262,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		masterNodeInformer,
 		kubeClient,
 		envVarController,
+		backupVar,
 		controllerContext.EventRecorder,
 		quorumChecker,
 	)
@@ -466,6 +469,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			controllerContext.EventRecorder,
 			os.Getenv("OPERATOR_IMAGE"),
 			featureGateAccessor,
+			backupVar,
 			configBackupInformer)
 
 		backupController := backupcontroller.NewBackupController(

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -8,25 +8,27 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
-	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.etcd.io/etcd/api/v3/etcdserverpb"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1listers "k8s.io/client-go/listers/core/v1"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
-
+	"github.com/openshift/cluster-etcd-operator/pkg/backuphelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdenvvar"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	u "github.com/openshift/cluster-etcd-operator/pkg/testutils"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTargetConfigController(t *testing.T) {
@@ -153,6 +155,7 @@ func TestTargetConfigController(t *testing.T) {
 				operatorClient:        fakeOperatorClient,
 				kubeClient:            fakeKubeClient,
 				envVarGetter:          envVar,
+				backupVarGetter:       backuphelpers.NewDisabledBackupConfig(),
 				enqueueFn:             func() {},
 				quorumChecker:         quorumChecker,
 			}


### PR DESCRIPTION
This PR adds backup-server sidecar template.

This is part of https://issues.redhat.com/browse/ETCD-636

cc @openshift/openshift-team-etcd


note: rebased version of https://github.com/openshift/cluster-etcd-operator/pull/1298