### PR TITLE
ETCD-659: Add `etcd-backup-server` sidecar skeleton

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -341,6 +341,27 @@ ${COMPUTED_ENV_VARS}
       name: data-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
+  - name: etcd-backup-server
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: [cluster-etcd-operator]
+${COMPUTED_BACKUP_VARS}
+    securityContext:
+      privileged: true
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
+    env:
+${COMPUTED_ENV_VARS}
+    volumeMounts:
+      - mountPath: /var/lib/etcd
+        name: data-dir
+      - mountPath: /etc/kubernetes
+        name: config-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -365,3 +386,6 @@ ${COMPUTED_ENV_VARS}
     - hostPath:
         path: /var/log/etcd
       name: log-dir
+    - hostPath:
+        path: /etc/kubernetes
+      name: config-dir

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -346,7 +346,6 @@ ${COMPUTED_ENV_VARS}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: [cluster-etcd-operator]
-${COMPUTED_BACKUP_VARS}
     securityContext:
       privileged: true
     resources:

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -345,7 +345,7 @@ ${COMPUTED_ENV_VARS}
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: [cluster-etcd-operator]
+    command: [cluster-etcd-operator, backup-server]
     securityContext:
       privileged: true
     resources:

--- a/cmd/cluster-etcd-operator/main.go
+++ b/cmd/cluster-etcd-operator/main.go
@@ -77,6 +77,7 @@ func NewSSCSCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(prune_backups.NewPruneCommand())
 	cmd.AddCommand(requestbackup.NewRequestBackupCommand(ctx))
 	cmd.AddCommand(rev.NewRevCommand(ctx))
+	cmd.AddCommand(backuprestore.NewBackupServer(ctx))
 
 	return cmd
 }

--- a/pkg/cmd/backuprestore/backupserver.go
+++ b/pkg/cmd/backuprestore/backupserver.go
@@ -57,22 +57,9 @@ func (b *backupServer) Validate() error {
 
 func (b *backupServer) Run(ctx context.Context) error {
 	// handle teardown
-	ctx, cancel := context.WithCancel(ctx)
+	cCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	shutdownHandler := make(chan os.Signal, 2)
-	signal.Notify(shutdownHandler, shutdownSignals...)
-	go func() {
-		select {
-		case <-shutdownHandler:
-			klog.Infof("Received SIGTERM or SIGINT signal, shutting down.")
-			close(shutdownHandler)
-			cancel()
-		case <-ctx.Done():
-			klog.Infof("Context has been cancelled, shutting down.")
-			close(shutdownHandler)
-			cancel()
-		}
-	}()
+	signal.NotifyContext(cCtx, shutdownSignals...)
 
 	<-ctx.Done()
 

--- a/pkg/cmd/backuprestore/backupserver.go
+++ b/pkg/cmd/backuprestore/backupserver.go
@@ -47,8 +47,6 @@ func (b *backupServer) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&b.enabled, "enabled", false, "enable backup server")
 	fs.StringVar(&b.schedule, "schedule", "", "schedule specifies the cron schedule to run the backup")
 	fs.StringVar(&b.timeZone, "timezone", "", "timezone specifies the timezone of the cron schedule to run the backup")
-
-	cobra.MarkFlagRequired(fs, "enabled")
 }
 
 func (b *backupServer) Validate() error {

--- a/pkg/cmd/backuprestore/backupserver.go
+++ b/pkg/cmd/backuprestore/backupserver.go
@@ -1,0 +1,80 @@
+package backuprestore
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"k8s.io/klog/v2"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+
+type backupServer struct {
+	schedule string
+	timeZone string
+	enabled  bool
+	backupOptions
+}
+
+func NewBackupServer(ctx context.Context) *cobra.Command {
+	backupSrv := &backupServer{
+		backupOptions: backupOptions{errOut: os.Stderr},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "backup-server",
+		Short: "Backs up a snapshot of etcd database and static pod resources without config",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			if err := backupSrv.Validate(); err != nil {
+				klog.Fatal(err)
+			}
+			if err := backupSrv.Run(ctx); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+	backupSrv.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (b *backupServer) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&b.enabled, "enabled", false, "enable backup server")
+	fs.StringVar(&b.schedule, "schedule", "", "schedule specifies the cron schedule to run the backup")
+	fs.StringVar(&b.timeZone, "timezone", "", "timezone specifies the timezone of the cron schedule to run the backup")
+
+	cobra.MarkFlagRequired(fs, "enabled")
+}
+
+func (b *backupServer) Validate() error {
+	return nil
+}
+
+func (b *backupServer) Run(ctx context.Context) error {
+	// handle teardown
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	shutdownHandler := make(chan os.Signal, 2)
+	signal.Notify(shutdownHandler, shutdownSignals...)
+	go func() {
+		select {
+		case <-shutdownHandler:
+			klog.Infof("Received SIGTERM or SIGINT signal, shutting down.")
+			close(shutdownHandler)
+			cancel()
+		case <-ctx.Done():
+			klog.Infof("Context has been cancelled, shutting down.")
+			close(shutdownHandler)
+			cancel()
+		}
+	}()
+
+	<-ctx.Done()
+
+	return nil
+}

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1261,7 +1261,7 @@ ${COMPUTED_ENV_VARS}
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: [cluster-etcd-operator]
+    command: [cluster-etcd-operator, backup-server]
     securityContext:
       privileged: true
     resources:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1262,7 +1262,6 @@ ${COMPUTED_ENV_VARS}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: [cluster-etcd-operator]
-${COMPUTED_BACKUP_VARS}
     securityContext:
       privileged: true
     resources:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1257,6 +1257,27 @@ ${COMPUTED_ENV_VARS}
       name: data-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
+  - name: etcd-backup-server
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: [cluster-etcd-operator]
+${COMPUTED_BACKUP_VARS}
+    securityContext:
+      privileged: true
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
+    env:
+${COMPUTED_ENV_VARS}
+    volumeMounts:
+      - mountPath: /var/lib/etcd
+        name: data-dir
+      - mountPath: /etc/kubernetes
+        name: config-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -1281,6 +1302,9 @@ ${COMPUTED_ENV_VARS}
     - hostPath:
         path: /var/log/etcd
       name: log-dir
+    - hostPath:
+        path: /etc/kubernetes
+      name: config-dir
 `)
 
 func etcdPodYamlBytes() ([]byte, error) {


### PR DESCRIPTION
This PR adds `etcd-backup-server` sidecar skeleton.

This is part of https://issues.redhat.com/browse/ETCD-636

cc @openshift/openshift-team-etcd