### PR TITLE
Revert #1309 "NO-JIRA: degrade targetconfigcontroller on quorum loss"

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -2,7 +2,6 @@ package targetconfigcontroller
 
 import (
 	"context"
-	errors "errors"
 	"fmt"
 	"strings"
 	"time"
@@ -76,71 +75,18 @@ func NewTargetConfigController(
 	syncer := health.NewDefaultCheckingSyncWrapper(c.sync)
 	livenessChecker.Add("TargetConfigController", syncer)
 
-	return factory.New().
-		WithSyncContext(syncCtx).
-		ResyncEvery(time.Minute).
-		WithSync(syncer.Sync).
-		WithInformers(
-			operatorClient.Informer(),
-			kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Informer(),
-			kubeInformersForOpenshiftEtcdNamespace.Core().V1().ConfigMaps().Informer(),
-			kubeInformersForOpenshiftEtcdNamespace.Core().V1().Secrets().Informer(),
-			masterNodeInformer,
-			infrastructureInformer.Informer(),
-			networkInformer.Informer(),
-		).ToController("TargetConfigController", syncCtx.Recorder())
+	return factory.New().WithSyncContext(syncCtx).ResyncEvery(time.Minute).WithInformers(
+		operatorClient.Informer(),
+		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Informer(),
+		kubeInformersForOpenshiftEtcdNamespace.Core().V1().ConfigMaps().Informer(),
+		kubeInformersForOpenshiftEtcdNamespace.Core().V1().Secrets().Informer(),
+		masterNodeInformer,
+		infrastructureInformer.Informer(),
+		networkInformer.Informer(),
+	).WithSync(syncer.Sync).ToController("TargetConfigController", syncCtx.Recorder())
 }
 
-func (c *TargetConfigController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	envVars := c.envVarGetter.GetEnvVars()
-	if len(envVars) == 0 {
-		// note this will not degrade the controller, that can happen during CEO restarts often due to cold informer caches (expected)
-		return fmt.Errorf("TargetConfigController missing env var values")
-	}
-
-	operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorState()
-	if err != nil {
-		return err
-	}
-
-	err = c.createTargetConfig(ctx, syncCtx.Recorder(), operatorSpec, envVars)
-	if err != nil {
-		condition := operatorv1.OperatorCondition{
-			Type:    "TargetConfigControllerDegraded",
-			Status:  operatorv1.ConditionTrue,
-			Reason:  "SynchronizationError",
-			Message: err.Error(),
-		}
-		if _, _, err := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(condition)); err != nil {
-			// this re-queues the sync loop to get the status updated correctly next invocation
-			c.enqueueFn()
-			return err
-		}
-
-		return err
-	}
-
-	condition := operatorv1.OperatorCondition{
-		Type:   "TargetConfigControllerDegraded",
-		Status: operatorv1.ConditionFalse,
-	}
-	if _, _, err := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(condition)); err != nil {
-		// this re-queues the sync loop to get the status updated correctly next invocation
-		c.enqueueFn()
-		return err
-	}
-
-	return nil
-}
-
-// createTargetConfig takes care of creation of valid resources in a fixed name. These are inputs to other control loops.
-func (c *TargetConfigController) createTargetConfig(
-	ctx context.Context,
-	recorder events.Recorder,
-	operatorSpec *operatorv1.StaticPodOperatorSpec,
-	envVars map[string]string) error {
-
-	// check the cluster is healthy or not after get env var, to ensure it is safe to rollout
+func (c TargetConfigController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	safe, err := c.quorumChecker.IsSafeToUpdateRevision()
 	if err != nil {
 		return fmt.Errorf("TargetConfigController can't evaluate whether quorum is safe: %w", err)
@@ -150,22 +96,77 @@ func (c *TargetConfigController) createTargetConfig(
 		return fmt.Errorf("skipping TargetConfigController reconciliation due to insufficient quorum")
 	}
 
-	var errs error
-	contentReplacer, err := c.getSubstitutionReplacer(operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, envVars)
+	envVars := c.envVarGetter.GetEnvVars()
+	if len(envVars) == 0 {
+		return fmt.Errorf("TargetConfigController missing env var values")
+	}
+
+	operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorState()
 	if err != nil {
 		return err
 	}
+	// check the cluster is healthy or not after get env var, to ensure it is safe to rollout
+	safe, err = c.quorumChecker.IsSafeToUpdateRevision()
+	if err != nil {
+		return fmt.Errorf("TargetConfigController can't evaluate whether quorum is safe: %w", err)
+	}
+
+	if !safe {
+		return fmt.Errorf("skipping TargetConfigController reconciliation due to insufficient quorum")
+	}
+	requeue, err := createTargetConfig(ctx, c, syncCtx.Recorder(), operatorSpec, envVars)
+	if err != nil {
+		return err
+	}
+	if requeue {
+		return fmt.Errorf("synthetic requeue request")
+	}
+
+	return nil
+}
+
+// createTargetConfig takes care of creation of valid resources in a fixed name.  These are inputs to other control loops.
+// returns whether to requeue and if an error happened when updating status.  Normally it updates status itself.
+func createTargetConfig(ctx context.Context, c TargetConfigController, recorder events.Recorder,
+	operatorSpec *operatorv1.StaticPodOperatorSpec, envVars map[string]string) (bool, error) {
+
+	var errors []error
+	contentReplacer, err := c.getSubstitutionReplacer(operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, envVars)
+	if err != nil {
+		return false, err
+	}
 	_, _, err = c.manageStandardPod(ctx, contentReplacer, c.kubeClient.CoreV1(), recorder, operatorSpec)
 	if err != nil {
-		errs = errors.Join(errs, fmt.Errorf("%q: %w", "configmap/etcd-pod", err))
+		errors = append(errors, fmt.Errorf("%q: %v", "configmap/etcd-pod", err))
 	}
 
 	_, _, err = c.manageRecoveryPod(ctx, contentReplacer, c.kubeClient.CoreV1(), recorder, operatorSpec)
 	if err != nil {
-		errs = errors.Join(errs, fmt.Errorf("%q: %w", "configmap/restore-etcd-pod", err))
+		errors = append(errors, fmt.Errorf("%q: %v", "configmap/restore-etcd-pod", err))
 	}
 
-	return errs
+	if len(errors) > 0 {
+		condition := operatorv1.OperatorCondition{
+			Type:    "TargetConfigControllerDegraded",
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "SynchronizationError",
+			Message: v1helpers.NewMultiLineAggregate(errors).Error(),
+		}
+		if _, _, err := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(condition)); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
+	condition := operatorv1.OperatorCondition{
+		Type:   "TargetConfigControllerDegraded",
+		Status: operatorv1.ConditionFalse,
+	}
+	if _, _, err := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(condition)); err != nil {
+		return true, err
+	}
+
+	return false, nil
 }
 
 func loglevelToZap(logLevel operatorv1.LogLevel) string {

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -3,6 +3,8 @@ package targetconfigcontroller
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
@@ -12,13 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"testing"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdenvvar"
@@ -93,112 +95,70 @@ func TestTargetConfigController(t *testing.T) {
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			eventRecorder, _, controller := getController(t, scenario.staticPodStatus, scenario.objects, scenario.etcdMembers)
-			err := controller.sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				&operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+				},
+				scenario.staticPodStatus,
+				nil,
+				nil,
+			)
+
+			fakeKubeClient := fake.NewSimpleClientset(scenario.objects...)
+			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(scenario.etcdMembers)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			defaultObjects := []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: operatorclient.TargetNamespace},
+				},
+				&configv1.Infrastructure{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ceohelpers.InfrastructureClusterName,
+					},
+					Status: configv1.InfrastructureStatus{
+						ControlPlaneTopology: configv1.HighlyAvailableTopologyMode},
+				},
+			}
+
+			eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events(operatorclient.TargetNamespace),
+				"test-targetconfigcontroller", &corev1.ObjectReference{})
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, obj := range defaultObjects {
+				require.NoError(t, indexer.Add(obj))
+			}
+			for _, obj := range scenario.objects {
+				require.NoError(t, indexer.Add(obj))
+			}
+
+			envVar := etcdenvvar.FakeEnvVar{EnvVars: map[string]string{
+				"ALL_ETCD_ENDPOINTS": scenario.etcdMembersEnvVar,
+			}}
+
+			quorumChecker := ceohelpers.NewQuorumChecker(
+				corev1listers.NewConfigMapLister(indexer),
+				corev1listers.NewNamespaceLister(indexer),
+				configv1listers.NewInfrastructureLister(indexer),
+				fakeOperatorClient,
+				fakeEtcdClient)
+
+			controller := &TargetConfigController{
+				targetImagePullSpec:   "etcd-pull-spec",
+				operatorImagePullSpec: "operator-pull-spec",
+				operatorClient:        fakeOperatorClient,
+				kubeClient:            fakeKubeClient,
+				envVarGetter:          envVar,
+				enqueueFn:             func() {},
+				quorumChecker:         quorumChecker,
+			}
+
+			err = controller.sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
 			assert.Equal(t, scenario.expectedErr, err)
 		})
 	}
-}
-
-func TestControllerDegradesOnQuorumLoss(t *testing.T) {
-	objects := []runtime.Object{
-		u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
-	}
-
-	staticPodStatus := u.StaticPodOperatorStatus(
-		u.WithLatestRevision(3),
-		u.WithNodeStatusAtCurrentRevision(3),
-		u.WithNodeStatusAtCurrentRevision(3),
-		u.WithNodeStatusAtCurrentRevision(3),
-	)
-	etcdMembers := []*etcdserverpb.Member{
-		u.FakeEtcdMemberWithoutServer(0),
-		u.FakeEtcdMemberWithoutServer(2),
-	}
-
-	eventRecorder, fakeOperatorClient, controller := getController(t, staticPodStatus, objects, etcdMembers)
-	syncContext := factory.NewSyncContext("test", eventRecorder)
-
-	foundDegraded := false
-	for i := 0; i < 100; i++ {
-		require.Error(t, controller.sync(context.TODO(), syncContext))
-		// check that the controller eventually degrades
-		_, status, _, err := fakeOperatorClient.GetOperatorState()
-		require.NoError(t, err)
-
-		// we only expect one condition to be set here
-		if len(status.Conditions) > 0 {
-			require.Equal(t, "TargetConfigControllerDegraded", status.Conditions[0].Type)
-			require.Equal(t, "SynchronizationError", status.Conditions[0].Reason)
-			require.Contains(t, status.Conditions[0].Message, "TargetConfigController can't evaluate whether quorum is safe: etcd cluster has quorum of 2 which is not fault tolerant")
-			foundDegraded = true
-			break
-		}
-	}
-
-	require.Truef(t, foundDegraded, "could not find degraded status in operator client")
-}
-
-func getController(t *testing.T, staticPodStatus *operatorv1.StaticPodOperatorStatus, objects []runtime.Object, etcdMembers []*etcdserverpb.Member) (events.Recorder, v1helpers.StaticPodOperatorClient, *TargetConfigController) {
-	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
-		&operatorv1.StaticPodOperatorSpec{
-			OperatorSpec: operatorv1.OperatorSpec{
-				ManagementState: operatorv1.Managed,
-			},
-		},
-		staticPodStatus,
-		nil,
-		nil,
-	)
-
-	fakeKubeClient := fake.NewSimpleClientset(objects...)
-	fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(etcdMembers)
-	require.NoError(t, err)
-
-	defaultObjects := []runtime.Object{
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: operatorclient.TargetNamespace},
-		},
-		&configv1.Infrastructure{
-			TypeMeta: metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ceohelpers.InfrastructureClusterName,
-			},
-			Status: configv1.InfrastructureStatus{
-				ControlPlaneTopology: configv1.HighlyAvailableTopologyMode},
-		},
-	}
-
-	eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events(operatorclient.TargetNamespace),
-		"test-targetconfigcontroller", &corev1.ObjectReference{})
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	for _, obj := range defaultObjects {
-		require.NoError(t, indexer.Add(obj))
-	}
-	for _, obj := range objects {
-		require.NoError(t, indexer.Add(obj))
-	}
-
-	envVar := etcdenvvar.FakeEnvVar{EnvVars: map[string]string{
-		"ALL_ETCD_ENDPOINTS": "1,3",
-	}}
-
-	quorumChecker := ceohelpers.NewQuorumChecker(
-		corev1listers.NewConfigMapLister(indexer),
-		corev1listers.NewNamespaceLister(indexer),
-		configv1listers.NewInfrastructureLister(indexer),
-		fakeOperatorClient,
-		fakeEtcdClient)
-
-	controller := &TargetConfigController{
-		targetImagePullSpec:   "etcd-pull-spec",
-		operatorImagePullSpec: "operator-pull-spec",
-		operatorClient:        fakeOperatorClient,
-		kubeClient:            fakeKubeClient,
-		envVarGetter:          envVar,
-		enqueueFn:             func() {},
-		quorumChecker:         quorumChecker,
-	}
-
-	return eventRecorder, fakeOperatorClient, controller
 }


### PR DESCRIPTION

Reverts #1309 ; tracked by https://issues.redhat.com/browse/OCPBUGS-37964

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Azure etcd should not log excessive took too long failures 

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-aggregate periodic-ci-openshift-release-master-ci-4.17-e2e-azure-ovn-upgrade 10
```

CC: @tjungblu

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
