### PR TITLE
OCPBUGS-38341: prefer env var over hardcoding ciphers

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -257,7 +257,7 @@ ${COMPUTED_ENV_VARS}
           --cert-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.crt \
           --cacert /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
           --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/metrics-ca-bundle.crt \
-          --listen-cipher-suites TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256
+          --listen-cipher-suites ${ETCD_CIPHER_SUITES}
     env:
 ${COMPUTED_ENV_VARS}
       - name: "ETCD_STATIC_POD_VERSION"
@@ -293,7 +293,8 @@ ${COMPUTED_ENV_VARS}
           --serving-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \
           --client-cert-file=$(ETCDCTL_CERT) \
           --client-key-file=$(ETCDCTL_KEY) \
-          --client-cacert-file=$(ETCDCTL_CACERT)
+          --client-cacert-file=$(ETCDCTL_CACERT) \
+          --listen-cipher-suites=$(ETCD_CIPHER_SUITES)
     securityContext:
       privileged: true
     ports:

--- a/pkg/cmd/readyz/readyz.go
+++ b/pkg/cmd/readyz/readyz.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	goflag "flag"
 	"fmt"
+	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
 	"net"
 	"net/http"
 	"syscall"
@@ -41,6 +42,7 @@ type readyzOpts struct {
 	clientCertFile   string
 	clientKeyFile    string
 	clientCACertFile string
+	cipherSuites     []string
 
 	clientPool *etcdcli.EtcdClientPool
 }
@@ -50,6 +52,15 @@ func newReadyzOpts() *readyzOpts {
 		listenPort:     defaultListenPort,
 		dialTimeout:    defaultHTTPDialTimeout,
 		targetEndpoint: defaultEndpoint,
+		cipherSuites: []string{
+			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			"TLS_AES_128_GCM_SHA256",
+			"TLS_AES_256_GCM_SHA384",
+			"TLS_CHACHA20_POLY1305_SHA256",
+		},
 	}
 }
 
@@ -78,6 +89,7 @@ func NewReadyzCommand() *cobra.Command {
 func (r *readyzOpts) AddFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.Uint16Var(&r.listenPort, "listen-port", r.listenPort, "Listen on this port. Default 9980")
+	fs.StringSliceVar(&r.cipherSuites, "listen-cipher-suites", r.cipherSuites, "readyZ server TLS cipher suites.")
 	fs.DurationVar(&r.dialTimeout, "dial-timeout", r.dialTimeout, "Dial timeout for the client. Default 2s")
 	fs.StringVar(&r.targetEndpoint, "target", r.targetEndpoint, "Target endpoint to perform health check against. Default https://localhost:2379")
 	fs.StringVar(&r.servingCertFile, "serving-cert-file", r.servingCertFile, "Health probe server TLS client certificate file. (required)")
@@ -110,6 +122,11 @@ func (r *readyzOpts) Validate() error {
 	}
 	if len(r.clientCACertFile) == 0 {
 		return errors.New("missing required flag: --client-cacert-file")
+	}
+
+	_, err := tlsutil.GetCipherSuites(r.cipherSuites)
+	if err != nil {
+		return fmt.Errorf("invalid TLS cipher suites passed via --listen-cipher-suites: %v, err=%w", r.cipherSuites, err)
 	}
 
 	return nil
@@ -154,24 +171,17 @@ func (r *readyzOpts) Run() error {
 	addr := fmt.Sprintf("0.0.0.0:%d", r.listenPort)
 	klog.Infof("Listening on %s", addr)
 
+	suites, err := tlsutil.GetCipherSuites(r.cipherSuites)
+	if err != nil {
+		cancel()
+		return err
+	}
+
 	httpServer := &http.Server{
 		Addr:        addr,
 		Handler:     mux,
 		BaseContext: func(_ net.Listener) context.Context { return shutdownCtx },
-		TLSConfig: &tls.Config{
-			CipherSuites: []uint16{
-				// 1.2
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-
-				// 1.3
-				tls.TLS_AES_128_GCM_SHA256,
-				tls.TLS_AES_256_GCM_SHA384,
-				tls.TLS_CHACHA20_POLY1305_SHA256,
-			},
-		},
+		TLSConfig:   &tls.Config{CipherSuites: suites},
 	}
 	go func() {
 		defer cancel()

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1173,7 +1173,7 @@ ${COMPUTED_ENV_VARS}
           --cert-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.crt \
           --cacert /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
           --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/metrics-ca-bundle.crt \
-          --listen-cipher-suites TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256
+          --listen-cipher-suites ${ETCD_CIPHER_SUITES}
     env:
 ${COMPUTED_ENV_VARS}
       - name: "ETCD_STATIC_POD_VERSION"
@@ -1209,7 +1209,8 @@ ${COMPUTED_ENV_VARS}
           --serving-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \
           --client-cert-file=$(ETCDCTL_CERT) \
           --client-key-file=$(ETCDCTL_KEY) \
-          --client-cacert-file=$(ETCDCTL_CACERT)
+          --client-cacert-file=$(ETCDCTL_CACERT) \
+          --listen-cipher-suites=$(ETCD_CIPHER_SUITES)
     securityContext:
       privileged: true
     ports:


### PR DESCRIPTION
This rectifies the hardcoding of the ciphers that I've introduced in #970, which is shadowing the ciphers set through the etcd cluster CRD.