### PR TITLE
OCPBUGS-38573: use pooled client for etcd single member health checks

### DIFF
--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -339,7 +339,7 @@ func (g *etcdClientGetter) UnhealthyMembers(ctx context.Context) ([]*etcdserverp
 		return nil, fmt.Errorf("could not get member list %v", err)
 	}
 
-	memberHealth := GetMemberHealth(ctx, etcdCluster.Members)
+	memberHealth := GetMemberHealth(ctx, cli, etcdCluster.Members)
 
 	unstartedMemberNames := GetUnstartedMemberNames(memberHealth)
 	if len(unstartedMemberNames) > 0 {
@@ -379,7 +379,7 @@ func (g *etcdClientGetter) HealthyMembers(ctx context.Context) ([]*etcdserverpb.
 		return nil, err
 	}
 
-	healthyMembers := GetMemberHealth(ctx, etcdCluster.Members).GetHealthyMembers()
+	healthyMembers := GetMemberHealth(ctx, cli, etcdCluster.Members).GetHealthyMembers()
 	if len(healthyMembers) == 0 {
 		return nil, fmt.Errorf("no healthy etcd members found")
 	}
@@ -409,16 +409,25 @@ func (g *etcdClientGetter) MemberHealth(ctx context.Context) (memberHealth, erro
 	if err != nil {
 		return nil, err
 	}
-	return GetMemberHealth(ctx, etcdCluster.Members), nil
+	return GetMemberHealth(ctx, cli, etcdCluster.Members), nil
 }
 
 func (g *etcdClientGetter) IsMemberHealthy(ctx context.Context, member *etcdserverpb.Member) (bool, error) {
 	if member == nil {
 		return false, fmt.Errorf("member can not be nil")
 	}
+
+	cli, err := g.clientPool.Get()
+	if err != nil {
+		klog.Errorf("error getting etcd client: %#v", err)
+		return false, err
+	}
+	defer g.clientPool.Return(cli)
+
 	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
 	defer cancel()
-	memberHealth := GetMemberHealth(ctx, []*etcdserverpb.Member{member})
+
+	memberHealth := GetMemberHealth(ctx, cli, []*etcdserverpb.Member{member})
 	if len(memberHealth) == 0 {
 		return false, fmt.Errorf("member health check failed")
 	}

--- a/pkg/etcdcli/health.go
+++ b/pkg/etcdcli/health.go
@@ -41,7 +41,7 @@ type healthCheck struct {
 
 type memberHealth []healthCheck
 
-func GetMemberHealth(ctx context.Context, etcdMembers []*etcdserverpb.Member) memberHealth {
+func GetMemberHealth(ctx context.Context, cli *clientv3.Client, etcdMembers []*etcdserverpb.Member) memberHealth {
 	// while we don't explicitly mention that the returned ordering has to be the same as etcdMembers,
 	// we try to keep it that way for backward compatibility reasons
 	memberHealth := make([]healthCheck, len(etcdMembers))
@@ -54,7 +54,7 @@ func GetMemberHealth(ctx context.Context, etcdMembers []*etcdserverpb.Member) me
 
 		wg.Add(1)
 		go func(i int) {
-			memberHealth[i] = checkSingleMemberHealth(ctx, member)
+			memberHealth[i] = checkSingleMemberHealth(ctx, cli, member)
 			wg.Done()
 		}(i)
 	}
@@ -80,30 +80,17 @@ func GetMemberHealth(ctx context.Context, etcdMembers []*etcdserverpb.Member) me
 	return memberHealth
 }
 
-func checkSingleMemberHealth(ctx context.Context, member *etcdserverpb.Member) healthCheck {
-	// If the endpoint is for a learner member then we should skip testing the connection
-	// via the member list call as learners don't support that.
-	// The learner's connection would get tested in the health check below
-	skipConnectionTest := false
-	if member.IsLearner {
-		skipConnectionTest = true
-	}
-	cli, err := newEtcdClientWithClientOpts([]string{member.ClientURLs[0]}, skipConnectionTest)
-	if err != nil {
-		return healthCheck{
-			Member:  member,
-			Healthy: false,
-			Error:   fmt.Errorf("create client failure: %w", err)}
-	}
+func checkSingleMemberHealth(ctx context.Context, cli *clientv3.Client, member *etcdserverpb.Member) healthCheck {
+	originalEndpoints := cli.Endpoints()
+	defer func(eps []string) {
+		cli.SetEndpoints(eps...)
+	}(originalEndpoints)
 
-	defer func() {
-		if err := cli.Close(); err != nil {
-			klog.Errorf("error closing etcd client for GetMemberHealth: %v", err)
-		}
-	}()
+	// we only want to check that one member that was passed, we're restoring the original client endpoints at the end
+	cli.SetEndpoints(member.ClientURLs...)
 
 	st := time.Now()
-
+	var err error
 	var resp *clientv3.GetResponse
 	if member.IsLearner {
 		// Learner members only support serializable (without consensus) read requests


### PR DESCRIPTION
This should reduce CPU consumption because of less TLS handshakes and makes it usable from other places too.