### PR TITLE
Revert "OCPBUGS-38573: use pooled client for etcd single member health checks"

### DIFF
--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -339,7 +339,7 @@ func (g *etcdClientGetter) UnhealthyMembers(ctx context.Context) ([]*etcdserverp
 		return nil, fmt.Errorf("could not get member list %v", err)
 	}
 
-	memberHealth := GetMemberHealth(ctx, cli, etcdCluster.Members)
+	memberHealth := GetMemberHealth(ctx, etcdCluster.Members)
 
 	unstartedMemberNames := GetUnstartedMemberNames(memberHealth)
 	if len(unstartedMemberNames) > 0 {
@@ -379,7 +379,7 @@ func (g *etcdClientGetter) HealthyMembers(ctx context.Context) ([]*etcdserverpb.
 		return nil, err
 	}
 
-	healthyMembers := GetMemberHealth(ctx, cli, etcdCluster.Members).GetHealthyMembers()
+	healthyMembers := GetMemberHealth(ctx, etcdCluster.Members).GetHealthyMembers()
 	if len(healthyMembers) == 0 {
 		return nil, fmt.Errorf("no healthy etcd members found")
 	}
@@ -409,25 +409,16 @@ func (g *etcdClientGetter) MemberHealth(ctx context.Context) (memberHealth, erro
 	if err != nil {
 		return nil, err
 	}
-	return GetMemberHealth(ctx, cli, etcdCluster.Members), nil
+	return GetMemberHealth(ctx, etcdCluster.Members), nil
 }
 
 func (g *etcdClientGetter) IsMemberHealthy(ctx context.Context, member *etcdserverpb.Member) (bool, error) {
 	if member == nil {
 		return false, fmt.Errorf("member can not be nil")
 	}
-
-	cli, err := g.clientPool.Get()
-	if err != nil {
-		klog.Errorf("error getting etcd client: %#v", err)
-		return false, err
-	}
-	defer g.clientPool.Return(cli)
-
 	ctx, cancel := context.WithTimeout(ctx, DefaultClientTimeout)
 	defer cancel()
-
-	memberHealth := GetMemberHealth(ctx, cli, []*etcdserverpb.Member{member})
+	memberHealth := GetMemberHealth(ctx, []*etcdserverpb.Member{member})
 	if len(memberHealth) == 0 {
 		return false, fmt.Errorf("member health check failed")
 	}

--- a/pkg/etcdcli/health.go
+++ b/pkg/etcdcli/health.go
@@ -41,7 +41,7 @@ type healthCheck struct {
 
 type memberHealth []healthCheck
 
-func GetMemberHealth(ctx context.Context, cli *clientv3.Client, etcdMembers []*etcdserverpb.Member) memberHealth {
+func GetMemberHealth(ctx context.Context, etcdMembers []*etcdserverpb.Member) memberHealth {
 	// while we don't explicitly mention that the returned ordering has to be the same as etcdMembers,
 	// we try to keep it that way for backward compatibility reasons
 	memberHealth := make([]healthCheck, len(etcdMembers))
@@ -54,7 +54,7 @@ func GetMemberHealth(ctx context.Context, cli *clientv3.Client, etcdMembers []*e
 
 		wg.Add(1)
 		go func(i int) {
-			memberHealth[i] = checkSingleMemberHealth(ctx, cli, member)
+			memberHealth[i] = checkSingleMemberHealth(ctx, member)
 			wg.Done()
 		}(i)
 	}
@@ -80,17 +80,30 @@ func GetMemberHealth(ctx context.Context, cli *clientv3.Client, etcdMembers []*e
 	return memberHealth
 }
 
-func checkSingleMemberHealth(ctx context.Context, cli *clientv3.Client, member *etcdserverpb.Member) healthCheck {
-	originalEndpoints := cli.Endpoints()
-	defer func(eps []string) {
-		cli.SetEndpoints(eps...)
-	}(originalEndpoints)
+func checkSingleMemberHealth(ctx context.Context, member *etcdserverpb.Member) healthCheck {
+	// If the endpoint is for a learner member then we should skip testing the connection
+	// via the member list call as learners don't support that.
+	// The learner's connection would get tested in the health check below
+	skipConnectionTest := false
+	if member.IsLearner {
+		skipConnectionTest = true
+	}
+	cli, err := newEtcdClientWithClientOpts([]string{member.ClientURLs[0]}, skipConnectionTest)
+	if err != nil {
+		return healthCheck{
+			Member:  member,
+			Healthy: false,
+			Error:   fmt.Errorf("create client failure: %w", err)}
+	}
 
-	// we only want to check that one member that was passed, we're restoring the original client endpoints at the end
-	cli.SetEndpoints(member.ClientURLs...)
+	defer func() {
+		if err := cli.Close(); err != nil {
+			klog.Errorf("error closing etcd client for GetMemberHealth: %v", err)
+		}
+	}()
 
 	st := time.Now()
-	var err error
+
 	var resp *clientv3.GetResponse
 	if member.IsLearner {
 		// Learner members only support serializable (without consensus) read requests


### PR DESCRIPTION
Reverts openshift/cluster-etcd-operator#1319

not sure this is working as expected, I see many logs like this now:

> [etcd-operator-78ddbd8998-r7f4t] W0821 08:54:24.113978       1 etcdcli_pool.go:87] cached client detected change in endpoints [[https://10.0.0.5:2379]] vs. [[https://10.0.0.3:2379 https://10.0.0.4:2379 https://10.0.0.5:2379]]

and then subsequently the controllers picking up the client is not using the right endpoints anymore:

> [etcd-operator-78ddbd8998-r7f4t] E0821 09:05:44.532054       1 base_controller.go:268] DefragController reconciliation failed: failed to dial endpoint https://10.0.0.4:2379 with maintenance client: context deadline exceeded


/hold