### PR TITLE
ETCD-653: Update restore-pod to use locally stored revision

### DIFF
--- a/bindata/etcd/cluster-restore.sh
+++ b/bindata/etcd/cluster-restore.sh
@@ -8,10 +8,10 @@ set -o errtrace
 
 # example
 # ./cluster-restore.sh $path-to-backup
-# There are several customization switches based on env variables:
-# ETCD_RESTORE_SKIP_MOVE_CP_STATIC_PODS - when set this script will not move the other (non-etcd) static pod yamls
-# ETCD_ETCDCTL_RESTORE - when set this script will use `etcdctl snapshot restore` instead of a restore pod yaml
-# ETCD_ETCDCTL_RESTORE_ENABLE_BUMP - when set this script will spawn the restore pod with a large enough revision bump
+# ETCD_ETCDCTL_RESTORE - when set this script will use `etcdctl snapshot restore` instead of a restore pod yaml,
+#                        which can be used when restoring a single member (e.g. on single node OCP).
+#                        Syncing very big snapshots (>8GiB) from the leader might also be expensive, this aids in
+#                        keeping the amount of data pulled to a minimum. This option will neither rev-bump nor mark-compact.
 
 if [[ $EUID -ne 0 ]]; then
   echo "This script must be run as root"
@@ -96,10 +96,7 @@ BACKUP_FILE=$(ls -vd "${BACKUP_DIR}"/static_kuberesources*.tar.gz | tail -1) || 
 SNAPSHOT_FILE=$(ls -vd "${BACKUP_DIR}"/snapshot*.db | tail -1) || true
 
 ETCD_STATIC_POD_LIST=("etcd-pod.yaml")
-AUX_STATIC_POD_LIST=("kube-apiserver-pod.yaml" "kube-controller-manager-pod.yaml" "kube-scheduler-pod.yaml")
-
-ETCD_STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "etcd-readyz")
-AUX_STATIC_POD_CONTAINERS=("kube-controller-manager" "kube-apiserver" "kube-scheduler")
+ETCD_STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "etcd-readyz" "etcd-rev" "etcd-backup-server")
 
 if [ ! -f "${SNAPSHOT_FILE}" ]; then
   echo "etcd snapshot ${SNAPSHOT_FILE} does not exist"
@@ -113,12 +110,6 @@ check_snapshot_status "${SNAPSHOT_FILE}"
 ETCD_CLIENT="${ETCD_ETCDCTL_BIN+etcdctl}"
 if [ -n "${ETCD_ETCDUTL_BIN}" ]; then
   ETCD_CLIENT="${ETCD_ETCDUTL_BIN}"
-fi
-
-# Move static pod manifests out of MANIFEST_DIR, if required
-if [ -z "${ETCD_RESTORE_SKIP_MOVE_CP_STATIC_PODS}" ]; then
-  mv_static_pods "${AUX_STATIC_POD_LIST[@]}"
-  wait_for_containers_to_stop "${AUX_STATIC_POD_CONTAINERS[@]}"
 fi
 
 # always move etcd pod and wait for all containers to exit
@@ -145,21 +136,28 @@ if [ -z "${ETCD_ETCDCTL_RESTORE}" ]; then
 
   # Copy snapshot to backupdir
   cp -p "${SNAPSHOT_FILE}" "${ETCD_DATA_DIR_BACKUP}"/snapshot.db
+  # Move the revision.json when it exists
+  [ ! -f "${ETCD_REV_JSON}" ] ||  mv -f "${ETCD_REV_JSON}" "${ETCD_DATA_DIR_BACKUP}"/revision.json
+  # removing any fio perf files left behind that could be deleted without problems
+  rm -f "${ETCD_DATA_DIR}"/etcd_perf*
 
-  echo "starting restore-etcd static pod"
-  # ideally this can be solved with jq and a real env var, but we don't have it available at this point
-  if [ -n "${ETCD_ETCDCTL_RESTORE_ENABLE_BUMP}" ]; then
-    sed "s/export ETCD_ETCDCTL_RESTORE_ENABLE_BUMP=\"false\"/export ETCD_ETCDCTL_RESTORE_ENABLE_BUMP=\"true\"/" "${RESTORE_ETCD_POD_YAML}" > "${MANIFEST_DIR}/etcd-pod.yaml"
-  else
-     cp -p "${RESTORE_ETCD_POD_YAML}" "${MANIFEST_DIR}/etcd-pod.yaml"
+  # ensure the folder is really empty, otherwise the restore pod will crash loop
+  if [ -n "$(ls -A "${ETCD_DATA_DIR}")" ]; then
+      echo "folder ${ETCD_DATA_DIR} is not empty, please review and remove all files in it"
+      exit 1
   fi
 
+  echo "starting restore-etcd static pod"
+  cp -p "${RESTORE_ETCD_POD_YAML}" "${MANIFEST_DIR}/etcd-pod.yaml"
 else
   echo "removing etcd data dir..."
   rm -rf "${ETCD_DATA_DIR}"
   mkdir -p "${ETCD_DATA_DIR}"
 
   echo "starting snapshot restore through etcdctl..."
+  # We are never going to rev-bump here to ensure we don't cause a revision split between the
+  # remainder of the running cluster and this restore member. Imagine your non-restore quorum members run at rev 100,
+  # we would attempt to rev bump this with snapshot at rev 120, now this member is 20 revisions ahead and RAFT is confused.
   if ! ${ETCD_CLIENT} snapshot restore "${SNAPSHOT_FILE}" --data-dir="${ETCD_DATA_DIR}"; then
       echo "Snapshot restore failed. Aborting!"
       exit 1
@@ -170,7 +168,3 @@ else
   mv "${MANIFEST_STOPPED_DIR}/etcd-pod.yaml" "${MANIFEST_DIR}/etcd-pod.yaml"
 fi
 
-# start remaining static pods
-if [ -z "${ETCD_RESTORE_SKIP_MOVE_CP_STATIC_PODS}" ]; then
-  restore_static_pods "${BACKUP_FILE}" "${AUX_STATIC_POD_LIST[@]}"
-fi

--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -4,6 +4,7 @@ CONFIG_FILE_DIR="/etc/kubernetes"
 MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
 ETCD_DATA_DIR="/var/lib/etcd"
 ETCD_DATA_DIR_BACKUP="/var/lib/etcd-backup"
+ETCD_REV_JSON="${ETCD_DATA_DIR}/revision.json"
 MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
 RESTORE_ETCD_POD_YAML="${CONFIG_FILE_DIR}/static-pod-resources/etcd-certs/configmaps/restore-etcd-pod/pod.yaml"
 ETCDCTL_BIN_DIR="${CONFIG_FILE_DIR}/static-pod-resources/bin"
@@ -24,6 +25,9 @@ function dl_etcdctl {
      if [ -f "${etcdmnt}/bin/etcdutl" ]; then
        cp ${etcdmnt}/bin/etcdutl ${ETCDCTL_BIN_DIR}/
        export ETCD_ETCDUTL_BIN=etcdutl
+     fi
+     if ! [ -x "$(command -v jq)" ]; then
+       cp ${etcdmnt}/bin/jq ${ETCDCTL_BIN_DIR}/
      fi
 
      umount "${etcdmnt}"

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -20,64 +20,75 @@ spec:
       - |
         #!/bin/sh
         set -euo pipefail
-        
-        # this can be controlled by cluster-restore.sh, which will replace this line entirely when enabled at runtime
-        export ETCD_ETCDCTL_RESTORE_ENABLE_BUMP="false"
-        
+               
         export ETCD_NAME=${NODE_NODE_ENVVAR_NAME_ETCD_NAME}
         export ETCD_INITIAL_CLUSTER="${ETCD_NAME}=https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:2380"
         env | grep ETCD | grep -v NODE
         export ETCD_NODE_PEER_URL=https://${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}:2380
+        export REV_JSON="/var/lib/etcd-backup/revision.json"
+        export SNAPSHOT_FILE="/var/lib/etcd-backup/snapshot.db"
 
-        # checking if there are any fio perf file left behind that could be deleted without problems
-        if [ ! -z $(ls -A "/var/lib/etcd/etcd_perf*") ]; then
-          rm -f /var/lib/etcd/etcd_perf*
-        fi
-
-        # checking if data directory is empty, if not etcdctl restore will fail
-        if [ ! -z $(ls -A "/var/lib/etcd") ]; then
-          echo "please delete the contents of data directory before restoring, running the restore script will do this for you"
+        # checking if data directory is empty, if not etcdctl restore will fail         
+        if [ -n "$(ls -A "/var/lib/etcd")" ]; then
+          echo "please delete the contents of the /var/lib/etcd directory before restoring, running the restore script will do this for you"
           exit 1
         fi
         
         ETCD_ETCDCTL_BIN="etcdctl"
         if [ -x "$(command -v etcdutl)" ]; then
-          echo "found newer etcdutl, using that instead of etcdctl"
+          echo "found etcdutl, using that instead of etcdctl for local operations"
           ETCD_ETCDCTL_BIN="etcdutl"
         fi      
 
         # check if we have backup file to be restored
         # if the file exist, check if it has not changed size in last 5 seconds
-        if [ ! -f /var/lib/etcd-backup/snapshot.db ]; then
-          echo "please make a copy of the snapshot db file, then move that copy to /var/lib/etcd-backup/snapshot.db"
+        if [ ! -f "${SNAPSHOT_FILE}" ]; then
+          echo "please make a copy of the snapshot db file, then move that copy to ${SNAPSHOT_FILE}"
           exit 1
         else
-          filesize=$(stat --format=%s "/var/lib/etcd-backup/snapshot.db")
+          filesize=$(stat --format=%s "${SNAPSHOT_FILE}")
           sleep 5
-          newfilesize=$(stat --format=%s "/var/lib/etcd-backup/snapshot.db")
+          newfilesize=$(stat --format=%s "${SNAPSHOT_FILE}")
           if [ "$filesize" != "$newfilesize" ]; then
             echo "file size has changed since last 5 seconds, retry sometime after copying is complete"
             exit 1
           fi
         fi
         
-        BUMP_ARGS=""
-        if [[ "${ETCD_ETCDCTL_RESTORE_ENABLE_BUMP}" == "true" ]]; then
-          echo "enabling restore bump"
-          BUMP_ARGS="--bump-revision 1000000000 --mark-compacted"
+        SNAPSHOT_REV=$(etcdutl snapshot status -wjson "$SNAPSHOT_FILE" | jq -r ".revision")
+        echo "snapshot is at revision ${SNAPSHOT_REV}"
+        
+        if [ -n "$(ls -A "${REV_JSON}")" ]; then
+           # this will bump by the amount of the last known live revision + 20% slack.
+           # Note: the bump amount is an addition to the current revision stored in the snapshot.
+           # We're avoiding to do any math with SNAPSHOT_REV, uint64 has plenty of space to double revisions
+           # and we're assuming that full disaster restores are a very rare occurrence anyway.
+           BUMP_REV=$(jq -r "(.maxRaftIndex*1.2|floor)" "${REV_JSON}")
+           echo "bumping revisions by ${BUMP_REV}"
+        else
+           # we can't take SNAPSHOT_REV as an indicator here, because the snapshot might be much older
+           # than any currently live served revision. 
+           # 1bn would be an etcd running at 1000 writes/s for about eleven days.
+           echo "no revision.json found, assuming a 1bn revision bump"
+           BUMP_REV=1000000000
         fi
-                
+        
         UUID=$(uuidgen)
         echo "restoring to a single node cluster"
-        ${ETCD_ETCDCTL_BIN} snapshot restore /var/lib/etcd-backup/snapshot.db \
-         --name  $ETCD_NAME \
+        ${ETCD_ETCDCTL_BIN} snapshot restore "${SNAPSHOT_FILE}" \
+         --name $ETCD_NAME \
          --initial-cluster=$ETCD_INITIAL_CLUSTER \
          --initial-cluster-token "openshift-etcd-${UUID}" \
          --initial-advertise-peer-urls $ETCD_NODE_PEER_URL \
          --data-dir="/var/lib/etcd/restore-${UUID}" \
-         ${BUMP_ARGS}
+         --mark-compacted \
+         --bump-revision "${BUMP_REV}"
 
         mv /var/lib/etcd/restore-${UUID}/* /var/lib/etcd/
+        # copy the revision.json back in case a second restore needs to be run afterwards
+        if [ -n "$(ls -A "${REV_JSON}")" ]; then
+           cp ${REV_JSON} /var/lib/etcd/
+        fi
 
         rmdir /var/lib/etcd/restore-${UUID}
         rm /var/lib/etcd-backup/snapshot.db


### PR DESCRIPTION
This updates the restore script and pod to take advantage of the revision file introduced in a previous PR.

/hold