### PR TITLE
NO-JIRA: fix log folder permission

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -23,7 +23,7 @@ spec:
         - |
           #!/bin/sh
           echo -n "Fixing etcd log permissions."
-          mkdir -p /var/log/etcd  && chmod 0700 /var/log/etcd
+          mkdir -p /var/log/etcd  && chmod 0600 /var/log/etcd
           echo -n "Fixing etcd auto backup permissions."
           mkdir -p /var/lib/etcd-auto-backup  && chmod 0600 /var/lib/etcd-auto-backup
       securityContext:

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -941,7 +941,7 @@ spec:
         - |
           #!/bin/sh
           echo -n "Fixing etcd log permissions."
-          mkdir -p /var/log/etcd  && chmod 0700 /var/log/etcd
+          mkdir -p /var/log/etcd  && chmod 0600 /var/log/etcd
           echo -n "Fixing etcd auto backup permissions."
           mkdir -p /var/lib/etcd-auto-backup  && chmod 0600 /var/lib/etcd-auto-backup
       securityContext:


### PR DESCRIPTION
This PR removes the executable bit from etcd log's permission. 

see https://github.com/openshift/cluster-etcd-operator/pull/1306#discussion_r1747217442