### PR TITLE
ETCD-668: add etcd-backup-server readiness probe

### DIFF
--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -358,15 +358,7 @@ ${COMPUTED_BACKUP_VARS}
         cpu: 10m
     env:
 ${COMPUTED_ENV_VARS}
-    livenessProbe:
-      httpGet:
-        path: healthz
-        port: 8000
-        scheme: HTTPS
-      timeoutSeconds: 30
-      periodSeconds: 5
-      successThreshold: 1
-      failureThreshold: 5
+${COMPUTED_BACKUP_PROBE}
     volumeMounts:
       - mountPath: /var/lib/etcd
         name: data-dir

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -358,6 +358,15 @@ ${COMPUTED_BACKUP_VARS}
         cpu: 10m
     env:
 ${COMPUTED_ENV_VARS}
+    livenessProbe:
+      httpGet:
+        path: healthz
+        port: 8000
+        scheme: HTTPS
+      timeoutSeconds: 30
+      periodSeconds: 5
+      successThreshold: 1
+      failureThreshold: 5
     volumeMounts:
       - mountPath: /var/lib/etcd
         name: data-dir

--- a/pkg/backuphelpers/backupvars.go
+++ b/pkg/backuphelpers/backupvars.go
@@ -18,6 +18,7 @@ type BackupVar interface {
 	AddListener(listener Enqueueable)
 	SetBackupSpec(spec *backupv1alpha1.EtcdBackupSpec)
 	ArgString() string
+	ProbeString() string
 }
 
 type BackupConfig struct {
@@ -85,13 +86,22 @@ func (b *BackupConfig) ArgString() string {
 	return strings.Join(args, "\n    ")
 }
 
+func (b *BackupConfig) ProbeString() string {
+	if !b.enabled {
+		return ""
+	}
+
+	probeString := []string{"    livenessProbe:", "  httpGet:",
+		"    path: healthz", "    port: 8000",
+		"    scheme: HTTPS", "  timeoutSeconds: 60",
+		"  periodSeconds: 5", "  successThreshold: 1", "  failureThreshold: 5"}
+
+	return strings.Join(probeString, "\n    ")
+}
+
 func (b *BackupConfig) AddListener(listener Enqueueable) {
 	b.mux.Lock()
 	defer b.mux.Unlock()
 
 	b.listeners = append(b.listeners, listener)
-}
-
-func isEmptyEtcdBackupSpec(spec backupv1alpha1.EtcdBackupSpec) bool {
-	return reflect.DeepEqual(backupv1alpha1.EtcdBackupSpec{}, spec)
 }

--- a/pkg/backuphelpers/backupvars_test.go
+++ b/pkg/backuphelpers/backupvars_test.go
@@ -65,6 +65,36 @@ func TestBackupConfig_ToArgs(t *testing.T) {
 	}
 }
 
+func TestBackupConfig_ProbeString(t *testing.T) {
+	scenarios := []struct {
+		name     string
+		cr       *backupv1alpha1.EtcdBackupSpec
+		expected string
+	}{
+		{
+			name:     "backup spec with timezone and schedule",
+			cr:       createEtcdBackupSpec(timezone, schedule),
+			expected: "    livenessProbe:\n      httpGet:\n        path: healthz\n        port: 8000\n        scheme: HTTPS\n      timeoutSeconds: 60\n      periodSeconds: 5\n      successThreshold: 1\n      failureThreshold: 5",
+		},
+		{
+			"backup spec with empty timezone and empty schedule",
+			nil,
+			"",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			c := NewDisabledBackupConfig()
+			c.SetBackupSpec(scenario.cr)
+
+			act := c.ProbeString()
+
+			require.Equal(t, scenario.expected, act)
+		})
+	}
+}
+
 func createEtcdBackupSpec(timezone, schedule string) *backupv1alpha1.EtcdBackupSpec {
 	return &backupv1alpha1.EtcdBackupSpec{
 		Schedule: schedule,

--- a/pkg/cmd/backuprestore/backupserver.go
+++ b/pkg/cmd/backuprestore/backupserver.go
@@ -121,7 +121,7 @@ func (b *backupServer) Run(ctx context.Context) error {
 	cCtx, cancel := signal.NotifyContext(ctx, shutdownSignals...)
 	defer cancel()
 
-	// add readiness probes
+	// add liveness probes
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", healthz)
 	srv := &http.Server{

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1276,15 +1276,7 @@ ${COMPUTED_BACKUP_VARS}
         cpu: 10m
     env:
 ${COMPUTED_ENV_VARS}
-    livenessProbe:
-      httpGet:
-        path: healthz
-        port: 8000
-        scheme: HTTPS
-      timeoutSeconds: 30
-      periodSeconds: 5
-      successThreshold: 1
-      failureThreshold: 5
+${COMPUTED_BACKUP_PROBE}
     volumeMounts:
       - mountPath: /var/lib/etcd
         name: data-dir

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1276,6 +1276,15 @@ ${COMPUTED_BACKUP_VARS}
         cpu: 10m
     env:
 ${COMPUTED_ENV_VARS}
+    livenessProbe:
+      httpGet:
+        path: healthz
+        port: 8000
+        scheme: HTTPS
+      timeoutSeconds: 30
+      periodSeconds: 5
+      successThreshold: 1
+      failureThreshold: 5
     volumeMounts:
       - mountPath: /var/lib/etcd
         name: data-dir

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -200,6 +200,7 @@ func (c *TargetConfigController) getSubstitutionReplacer(operatorSpec *operatorv
 		"${LOCALHOST_IP}", "127.0.0.1", // TODO this needs updating to detect ipv6-ness
 		"${COMPUTED_ENV_VARS}", strings.Join(envVarLines, "\n"), // lacks beauty, but it works
 		"${COMPUTED_BACKUP_VARS}", backupVar.ArgString(),
+		"${COMPUTED_BACKUP_PROBE}", backupVar.ProbeString(),
 	), nil
 }
 

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -152,13 +152,17 @@ func TestTargetConfigController(t *testing.T) {
 
 			etcdPodCM, err := fakeKubeClient.CoreV1().ConfigMaps(operatorclient.TargetNamespace).Get(context.TODO(), "etcd-pod", metav1.GetOptions{})
 			require.NoError(t, err)
+
 			expStr := "    args:\n    - --enabled=false"
+			expProbe := ""
 
 			if scenario.etcdBackupSpec != nil {
 				expStr = "    args:\n    - --enabled=true\n    - --timezone=GMT\n    - --schedule=0 */2 * * *"
+				expProbe = "    livenessProbe:\n      httpGet:\n        path: healthz\n        port: 8000\n        scheme: HTTPS\n      timeoutSeconds: 60\n      periodSeconds: 5\n      successThreshold: 1\n      failureThreshold: 5"
 			}
 
 			require.Contains(t, etcdPodCM.Data["pod.yaml"], expStr)
+			require.Contains(t, etcdPodCM.Data["pod.yaml"], expProbe)
 		})
 	}
 }


### PR DESCRIPTION
This PR adds *readiness probe* to the `etcd-backup-server` container. 

resolves https://issues.redhat.com/browse/ETCD-668 