### PR TITLE
ETCD-662: fix: etcd-backup-server prune path

### DIFF
--- a/pkg/cmd/backuprestore/backupserver.go
+++ b/pkg/cmd/backuprestore/backupserver.go
@@ -28,12 +28,13 @@ type backupRunnerImpl struct{}
 
 func (b backupRunnerImpl) runBackup(backupOpts *backupOptions, pruneOpts *prune.PruneOpts) error {
 	dateString := time.Now().Format("2006-01-02_150405")
-	backupOpts.backupDir = backupVolume + dateString
+	backupOpts.backupDir = backupVolume + "/" + dateString
 	err := backup(backupOpts)
 	if err != nil {
 		return err
 	}
 
+	pruneOpts.BackupPath = backupVolume + "/" + dateString
 	err = pruneOpts.Run()
 	if err != nil {
 		return err


### PR DESCRIPTION
During debugging [e2e](https://github.com/openshift/origin/pull/29098), found a bug within `etcd-backup-server`. 

cc @openshift/openshift-team-etcd 