### PR TITLE
ETCD-686: Remove etcd-backup-server StaticPod approach

### DIFF
--- a/bindata/etcd/pod.gotpl.yaml
+++ b/bindata/etcd/pod.gotpl.yaml
@@ -361,35 +361,6 @@ spec:
       name: data-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
-  - name: etcd-backup-server
-    image: {{.OperatorImage}}
-    imagePullPolicy: IfNotPresent
-    terminationMessagePolicy: FallbackToLogsOnError
-    command: [cluster-etcd-operator, backup-server]
-    args:
-    {{ range $i, $val := .BackupArgs -}}
-      - {{ $val | quote }}
-    {{ end -}}
-    securityContext:
-      privileged: true
-    resources:
-      requests:
-        memory: 50Mi
-        cpu: 10m
-    env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
-    {{ end -}}
-    volumeMounts:
-      - mountPath: /var/lib/etcd
-        name: data-dir
-      - mountPath: /etc/kubernetes
-        name: config-dir
-      - mountPath: /var/lib/etcd-auto-backup
-        name: etcd-auto-backup-dir
-      - mountPath: /etc/kubernetes/static-pod-certs
-        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/bindata/etcd/pod.yaml
+++ b/bindata/etcd/pod.yaml
@@ -24,8 +24,6 @@ spec:
           #!/bin/sh
           echo -n "Fixing etcd log permissions."
           mkdir -p /var/log/etcd  && chmod 0600 /var/log/etcd
-          echo -n "Fixing etcd auto backup permissions."
-          mkdir -p /var/lib/etcd-auto-backup  && chmod 0600 /var/lib/etcd-auto-backup
       securityContext:
         privileged: true
       resources:
@@ -343,30 +341,6 @@ ${COMPUTED_ENV_VARS}
       name: data-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
-  - name: etcd-backup-server
-    image: ${OPERATOR_IMAGE}
-    imagePullPolicy: IfNotPresent
-    terminationMessagePolicy: FallbackToLogsOnError
-    command: [cluster-etcd-operator, backup-server]
-    args:
-${COMPUTED_BACKUP_VARS}
-    securityContext:
-      privileged: true
-    resources:
-      requests:
-        memory: 50Mi
-        cpu: 10m
-    env:
-${COMPUTED_ENV_VARS}
-    volumeMounts:
-      - mountPath: /var/lib/etcd
-        name: data-dir
-      - mountPath: /etc/kubernetes
-        name: config-dir
-      - mountPath: /var/lib/etcd-auto-backup
-        name: etcd-auto-backup-dir
-      - mountPath: /etc/kubernetes/static-pod-certs
-        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -394,6 +368,3 @@ ${COMPUTED_ENV_VARS}
     - hostPath:
         path: /etc/kubernetes
       name: config-dir
-    - hostPath:
-        path: /var/lib/etcd-auto-backup
-      name: etcd-auto-backup-dir

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1332,35 +1332,6 @@ spec:
       name: data-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
-  - name: etcd-backup-server
-    image: {{.OperatorImage}}
-    imagePullPolicy: IfNotPresent
-    terminationMessagePolicy: FallbackToLogsOnError
-    command: [cluster-etcd-operator, backup-server]
-    args:
-    {{ range $i, $val := .BackupArgs -}}
-      - {{ $val | quote }}
-    {{ end -}}
-    securityContext:
-      privileged: true
-    resources:
-      requests:
-        memory: 50Mi
-        cpu: 10m
-    env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
-    {{ end -}}
-    volumeMounts:
-      - mountPath: /var/lib/etcd
-        name: data-dir
-      - mountPath: /etc/kubernetes
-        name: config-dir
-      - mountPath: /var/lib/etcd-auto-backup
-        name: etcd-auto-backup-dir
-      - mountPath: /etc/kubernetes/static-pod-certs
-        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -1434,8 +1405,6 @@ spec:
           #!/bin/sh
           echo -n "Fixing etcd log permissions."
           mkdir -p /var/log/etcd  && chmod 0600 /var/log/etcd
-          echo -n "Fixing etcd auto backup permissions."
-          mkdir -p /var/lib/etcd-auto-backup  && chmod 0600 /var/lib/etcd-auto-backup
       securityContext:
         privileged: true
       resources:
@@ -1753,30 +1722,6 @@ ${COMPUTED_ENV_VARS}
       name: data-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
-  - name: etcd-backup-server
-    image: ${OPERATOR_IMAGE}
-    imagePullPolicy: IfNotPresent
-    terminationMessagePolicy: FallbackToLogsOnError
-    command: [cluster-etcd-operator, backup-server]
-    args:
-${COMPUTED_BACKUP_VARS}
-    securityContext:
-      privileged: true
-    resources:
-      requests:
-        memory: 50Mi
-        cpu: 10m
-    env:
-${COMPUTED_ENV_VARS}
-    volumeMounts:
-      - mountPath: /var/lib/etcd
-        name: data-dir
-      - mountPath: /etc/kubernetes
-        name: config-dir
-      - mountPath: /var/lib/etcd-auto-backup
-        name: etcd-auto-backup-dir
-      - mountPath: /etc/kubernetes/static-pod-certs
-        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -1804,9 +1749,6 @@ ${COMPUTED_ENV_VARS}
     - hostPath:
         path: /etc/kubernetes
       name: config-dir
-    - hostPath:
-        path: /var/lib/etcd-auto-backup
-      name: etcd-auto-backup-dir
 `)
 
 func etcdPodYamlBytes() ([]byte, error) {

--- a/pkg/operator/periodicbackupcontroller/periodicbackupcontroller.go
+++ b/pkg/operator/periodicbackupcontroller/periodicbackupcontroller.go
@@ -3,10 +3,8 @@ package periodicbackupcontroller
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/labels"
 	clientv1 "k8s.io/client-go/listers/core/v1"
 
 	backupv1alpha1 "github.com/openshift/api/config/v1alpha1"
@@ -44,7 +42,6 @@ type PeriodicBackupController struct {
 	backupsClient         backupv1client.BackupsGetter
 	kubeClient            kubernetes.Interface
 	operatorImagePullSpec string
-	backupVarGetter       backuphelpers.BackupVar
 	featureGateAccessor   featuregates.FeatureGateAccess
 	kubeInformers         v1helpers.KubeInformersForNamespaces
 }
@@ -57,7 +54,6 @@ func NewPeriodicBackupController(
 	eventRecorder events.Recorder,
 	operatorImagePullSpec string,
 	accessor featuregates.FeatureGateAccess,
-	backupVarGetter backuphelpers.BackupVar,
 	backupsInformer factory.Informer,
 	kubeInformers v1helpers.KubeInformersForNamespaces) factory.Controller {
 
@@ -67,7 +63,6 @@ func NewPeriodicBackupController(
 		backupsClient:         backupsClient,
 		kubeClient:            kubeClient,
 		operatorImagePullSpec: operatorImagePullSpec,
-		backupVarGetter:       backupVarGetter,
 		featureGateAccessor:   accessor,
 		kubeInformers:         kubeInformers,
 	}
@@ -97,14 +92,7 @@ func (c *PeriodicBackupController) sync(ctx context.Context, _ factory.SyncConte
 		return fmt.Errorf("PeriodicBackupController could not list backup CRDs, error was: %w", err)
 	}
 
-	defaultFound := false
 	for _, item := range backups.Items {
-		if item.Name == defaultBackupCRName {
-			defaultFound = true
-			c.backupVarGetter.SetBackupSpec(&item.Spec.EtcdBackupSpec)
-			continue
-		}
-
 		err := reconcileCronJob(ctx, cronJobsClient, item, c.operatorImagePullSpec)
 		if err != nil {
 			_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
@@ -119,40 +107,6 @@ func (c *PeriodicBackupController) sync(ctx context.Context, _ factory.SyncConte
 
 			return fmt.Errorf("PeriodicBackupController could not reconcile backup [%s] with cronjob: %w", item.Name, err)
 		}
-	}
-
-	if defaultFound {
-		mirrorPods, err := c.podLister.List(labels.Set{"app": "etcd"}.AsSelector())
-		if err != nil {
-			return fmt.Errorf("PeriodicBackupController could not list etcd pods: %w", err)
-		}
-
-		var terminationReasons []string
-		for _, p := range mirrorPods {
-			for _, cStatus := range p.Status.ContainerStatuses {
-				if cStatus.Name == etcdBackupServerContainerName {
-					// TODO we can also try different cStatus.State.Terminated.ExitCode
-					terminationReasons = append(terminationReasons, fmt.Sprintf("container %s within pod %s has been terminated: %s", etcdBackupServerContainerName, p.Name, cStatus.State.Terminated.Message))
-				}
-			}
-		}
-
-		if len(terminationReasons) > 0 {
-			_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-				Type:    "PeriodicBackupControllerDegraded",
-				Status:  operatorv1.ConditionTrue,
-				Reason:  "Error",
-				Message: fmt.Sprintf("found default backup errors: %s", strings.Join(terminationReasons, " ,")),
-			}))
-			if updateErr != nil {
-				klog.V(4).Infof("PeriodicBackupController error during default backup UpdateStatus: %v", err)
-			}
-
-			return nil
-		}
-	} else {
-		// disable etcd-backup-server
-		c.backupVarGetter.SetBackupSpec(nil)
 	}
 
 	_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{

--- a/pkg/operator/periodicbackupcontroller/periodicbackupcontroller_test.go
+++ b/pkg/operator/periodicbackupcontroller/periodicbackupcontroller_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfakeclient "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -50,169 +48,12 @@ func TestSyncLoopHappyPath(t *testing.T) {
 		backupsClient:         operatorFake.ConfigV1alpha1(),
 		kubeClient:            client,
 		operatorImagePullSpec: "pullspec-image",
-		backupVarGetter:       backuphelpers.NewDisabledBackupConfig(),
 		featureGateAccessor:   backupFeatureGateAccessor,
 	}
 
 	err := controller.sync(context.TODO(), nil)
 	require.NoError(t, err)
 	requireBackupCronJobCreated(t, client, backup)
-	requireOperatorStatus(t, fakeOperatorClient, false)
-}
-
-func TestSyncLoopWithDefaultBackupCR(t *testing.T) {
-	var backups backupv1alpha1.BackupList
-
-	backup := backupv1alpha1.Backup{ObjectMeta: v1.ObjectMeta{Name: "test-backup"},
-		Spec: backupv1alpha1.BackupSpec{
-			EtcdBackupSpec: backupv1alpha1.EtcdBackupSpec{
-				Schedule: "20 4 * * *",
-				TimeZone: "UTC",
-				RetentionPolicy: backupv1alpha1.RetentionPolicy{
-					RetentionType:   backupv1alpha1.RetentionTypeNumber,
-					RetentionNumber: &backupv1alpha1.RetentionNumberConfig{MaxNumberOfBackups: 5}},
-				PVCName: "backup-happy-path-pvc"}}}
-
-	// no default CR
-	backups.Items = append(backups.Items, backup)
-	operatorFake := fake.NewClientset([]runtime.Object{&backups}...)
-	client := k8sfakeclient.NewClientset()
-	fakeKubeInformerForNamespace := v1helpers.NewKubeInformersForNamespaces(client, operatorclient.TargetNamespace)
-	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
-		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
-		&operatorv1.StaticPodOperatorStatus{}, nil, nil)
-
-	controller := PeriodicBackupController{
-		operatorClient:        fakeOperatorClient,
-		podLister:             fakeKubeInformerForNamespace.InformersFor(operatorclient.TargetNamespace).Core().V1().Pods().Lister(),
-		backupsClient:         operatorFake.ConfigV1alpha1(),
-		kubeClient:            client,
-		operatorImagePullSpec: "pullspec-image",
-		backupVarGetter:       backuphelpers.NewDisabledBackupConfig(),
-		featureGateAccessor:   backupFeatureGateAccessor,
-		kubeInformers:         fakeKubeInformerForNamespace,
-	}
-
-	stopChan := make(chan struct{})
-	t.Cleanup(func() {
-		close(stopChan)
-	})
-	fakeKubeInformerForNamespace.Start(stopChan)
-
-	expDisabledBackupVar := "    args:\n    - --enabled=false"
-	err := controller.sync(context.TODO(), nil)
-	require.NoError(t, err)
-	require.Equal(t, expDisabledBackupVar, controller.backupVarGetter.ArgString())
-
-	// create default CR
-	defaultBackup := backupv1alpha1.Backup{ObjectMeta: v1.ObjectMeta{Name: defaultBackupCRName},
-		Spec: backupv1alpha1.BackupSpec{
-			EtcdBackupSpec: backupv1alpha1.EtcdBackupSpec{
-				Schedule: "0 */2 * * *",
-				TimeZone: "GMT",
-				RetentionPolicy: backupv1alpha1.RetentionPolicy{
-					RetentionType:   backupv1alpha1.RetentionTypeNumber,
-					RetentionNumber: &backupv1alpha1.RetentionNumberConfig{MaxNumberOfBackups: 3}}}}}
-
-	backups.Items = append(backups.Items, defaultBackup)
-	operatorFake = fake.NewClientset([]runtime.Object{&backups}...)
-	controller.backupsClient = operatorFake.ConfigV1alpha1()
-
-	expEnabledBackupVar := "    args:\n    - --enabled=true\n    - --timezone=GMT\n    - --schedule=0 */2 * * *\n    - --type=RetentionNumber\n    - --maxNumberOfBackups=3"
-	err = controller.sync(context.TODO(), nil)
-	require.NoError(t, err)
-	require.Equal(t, expEnabledBackupVar, controller.backupVarGetter.ArgString())
-
-	// removing defaultCR
-	backups.Items = backups.Items[:len(backups.Items)-1]
-	operatorFake = fake.NewClientset([]runtime.Object{&backups}...)
-	controller.backupsClient = operatorFake.ConfigV1alpha1()
-
-	err = controller.sync(context.TODO(), nil)
-	require.NoError(t, err)
-	require.Equal(t, expDisabledBackupVar, controller.backupVarGetter.ArgString())
-}
-
-func TestSyncLoopFailsDegradesOperatorWithDefaultBackupCR(t *testing.T) {
-	var backups backupv1alpha1.BackupList
-
-	backup := backupv1alpha1.Backup{ObjectMeta: v1.ObjectMeta{Name: "test-backup"},
-		Spec: backupv1alpha1.BackupSpec{
-			EtcdBackupSpec: backupv1alpha1.EtcdBackupSpec{
-				Schedule: "20 4 * * *",
-				TimeZone: "UTC",
-				RetentionPolicy: backupv1alpha1.RetentionPolicy{
-					RetentionType:   backupv1alpha1.RetentionTypeNumber,
-					RetentionNumber: &backupv1alpha1.RetentionNumberConfig{MaxNumberOfBackups: 5}},
-				PVCName: "backup-happy-path-pvc"}}}
-
-	backupServerFailureMsg := fmt.Sprintf("error running etcd backup: %s", "error running backup")
-	client := k8sfakeclient.NewClientset([]runtime.Object{
-		etcdPodWithFailingBackupServerContainer("1", backupServerFailureMsg),
-		etcdPodWithFailingBackupServerContainer("2", backupServerFailureMsg),
-		etcdPodWithFailingBackupServerContainer("3", backupServerFailureMsg)}...)
-
-	fakeKubeInformerForNamespace := v1helpers.NewKubeInformersForNamespaces(client, operatorclient.TargetNamespace)
-
-	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
-		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
-		&operatorv1.StaticPodOperatorStatus{}, nil, nil)
-
-	// no default CR
-	backups.Items = append(backups.Items, backup)
-	operatorFake := fake.NewClientset([]runtime.Object{&backups}...)
-
-	controller := PeriodicBackupController{
-		operatorClient:        fakeOperatorClient,
-		podLister:             fakeKubeInformerForNamespace.InformersFor(operatorclient.TargetNamespace).Core().V1().Pods().Lister(),
-		backupsClient:         operatorFake.ConfigV1alpha1(),
-		kubeClient:            client,
-		operatorImagePullSpec: "pullspec-image",
-		backupVarGetter:       backuphelpers.NewDisabledBackupConfig(),
-		featureGateAccessor:   backupFeatureGateAccessor,
-		kubeInformers:         fakeKubeInformerForNamespace,
-	}
-
-	stopChan := make(chan struct{})
-	t.Cleanup(func() {
-		close(stopChan)
-	})
-	fakeKubeInformerForNamespace.Start(stopChan)
-
-	expDisabledBackupVar := "    args:\n    - --enabled=false"
-	err := controller.sync(context.TODO(), nil)
-	require.NoError(t, err)
-	require.Equal(t, expDisabledBackupVar, controller.backupVarGetter.ArgString())
-	requireOperatorStatus(t, fakeOperatorClient, false)
-
-	// create default CR
-	defaultBackup := backupv1alpha1.Backup{ObjectMeta: v1.ObjectMeta{Name: defaultBackupCRName},
-		Spec: backupv1alpha1.BackupSpec{
-			EtcdBackupSpec: backupv1alpha1.EtcdBackupSpec{
-				Schedule: "0 */2 * * *",
-				TimeZone: "GMT",
-				RetentionPolicy: backupv1alpha1.RetentionPolicy{
-					RetentionType:   backupv1alpha1.RetentionTypeNumber,
-					RetentionNumber: &backupv1alpha1.RetentionNumberConfig{MaxNumberOfBackups: 3}}}}}
-
-	backups.Items = append(backups.Items, defaultBackup)
-	operatorFake = fake.NewClientset([]runtime.Object{&backups}...)
-	controller.backupsClient = operatorFake.ConfigV1alpha1()
-
-	expEnabledBackupVar := "    args:\n    - --enabled=true\n    - --timezone=GMT\n    - --schedule=0 */2 * * *\n    - --type=RetentionNumber\n    - --maxNumberOfBackups=3"
-	err = controller.sync(context.TODO(), nil)
-	require.NoError(t, err)
-	require.Equal(t, expEnabledBackupVar, controller.backupVarGetter.ArgString())
-	requireOperatorStatus(t, fakeOperatorClient, true)
-
-	// removing defaultCR
-	backups.Items = backups.Items[:len(backups.Items)-1]
-	operatorFake = fake.NewClientset([]runtime.Object{&backups}...)
-	controller.backupsClient = operatorFake.ConfigV1alpha1()
-
-	err = controller.sync(context.TODO(), nil)
-	require.NoError(t, err)
-	require.Equal(t, expDisabledBackupVar, controller.backupVarGetter.ArgString())
 	requireOperatorStatus(t, fakeOperatorClient, false)
 }
 
@@ -239,7 +80,6 @@ func TestSyncLoopExistingCronJob(t *testing.T) {
 		backupsClient:         operatorFake.ConfigV1alpha1(),
 		kubeClient:            client,
 		operatorImagePullSpec: "pullspec-image",
-		backupVarGetter:       backuphelpers.NewDisabledBackupConfig(),
 		featureGateAccessor:   backupFeatureGateAccessor,
 	}
 
@@ -275,7 +115,6 @@ func TestSyncLoopFailsDegradesOperator(t *testing.T) {
 		backupsClient:         operatorFake.ConfigV1alpha1(),
 		kubeClient:            client,
 		operatorImagePullSpec: "pullspec-image",
-		backupVarGetter:       backuphelpers.NewDisabledBackupConfig(),
 		featureGateAccessor:   backupFeatureGateAccessor,
 	}
 
@@ -401,24 +240,4 @@ func findFirstCreateAction(client *k8sfakeclient.Clientset) *k8stesting.CreateAc
 		}
 	}
 	return createAction
-}
-
-func etcdPodWithFailingBackupServerContainer(nodeName string, failureMsg string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      fmt.Sprintf("etcd-%v", nodeName),
-			Namespace: "openshift-etcd",
-			Labels:    labels.Set{"app": "etcd"},
-		},
-		Status: corev1.PodStatus{
-			ContainerStatuses: []corev1.ContainerStatus{{
-				Name: etcdBackupServerContainerName,
-				State: corev1.ContainerState{
-					Terminated: &corev1.ContainerStateTerminated{
-						Message: failureMsg,
-					},
-				}},
-			},
-		},
-	}
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -251,8 +251,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorClient,
 		cachedMemberClient)
 
-	backupVar := backuphelpers.NewDisabledBackupConfig()
-
 	targetConfigReconciler := targetconfigcontroller.NewTargetConfigController(
 		AlivenessChecker,
 		os.Getenv("IMAGE"),
@@ -265,7 +263,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		masterNodeInformer,
 		kubeClient,
 		envVarController,
-		backupVar,
 		controllerContext.EventRecorder,
 	)
 
@@ -474,7 +471,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			controllerContext.EventRecorder,
 			os.Getenv("OPERATOR_IMAGE"),
 			featureGateAccessor,
-			backupVar,
 			configBackupInformer,
 			kubeInformersForNamespaces)
 

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -11,7 +11,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
-	"github.com/openshift/cluster-etcd-operator/pkg/backuphelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdenvvar"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcd_assets"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/health"
@@ -53,9 +52,8 @@ type TargetConfigController struct {
 
 	operatorClient v1helpers.StaticPodOperatorClient
 
-	kubeClient      kubernetes.Interface
-	envVarGetter    etcdenvvar.EnvVar
-	backupVarGetter backuphelpers.BackupVar
+	kubeClient   kubernetes.Interface
+	envVarGetter etcdenvvar.EnvVar
 
 	enqueueFn func()
 }
@@ -71,17 +69,15 @@ func NewTargetConfigController(
 	masterNodeInformer cache.SharedIndexInformer,
 	kubeClient kubernetes.Interface,
 	envVarGetter etcdenvvar.EnvVar,
-	backupVarGetter backuphelpers.BackupVar,
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &TargetConfigController{
 		targetImagePullSpec:   targetImagePullSpec,
 		operatorImagePullSpec: operatorImagePullSpec,
 
-		operatorClient:  operatorClient,
-		kubeClient:      kubeClient,
-		envVarGetter:    envVarGetter,
-		backupVarGetter: backupVarGetter,
+		operatorClient: operatorClient,
+		kubeClient:     kubeClient,
+		envVarGetter:   envVarGetter,
 	}
 
 	syncCtx := factory.NewSyncContext("TargetConfigController", eventRecorder.WithComponentSuffix("target-config-controller"))
@@ -89,7 +85,6 @@ func NewTargetConfigController(
 		syncCtx.Queue().Add(syncCtx.QueueKey())
 	}
 	envVarGetter.AddListener(c)
-	backupVarGetter.AddListener(c)
 
 	syncer := health.NewDefaultCheckingSyncWrapper(c.sync)
 	livenessChecker.Add("TargetConfigController", syncer)
@@ -121,7 +116,7 @@ func (c *TargetConfigController) sync(ctx context.Context, syncCtx factory.SyncC
 		return err
 	}
 
-	err = c.createTargetConfig(ctx, syncCtx.Recorder(), operatorSpec, envVars, c.backupVarGetter)
+	err = c.createTargetConfig(ctx, syncCtx.Recorder(), operatorSpec, envVars)
 	if err != nil {
 		condition := operatorv1.OperatorCondition{
 			Type:    "TargetConfigControllerDegraded",
@@ -156,15 +151,14 @@ func (c *TargetConfigController) createTargetConfig(
 	ctx context.Context,
 	recorder events.Recorder,
 	operatorSpec *operatorv1.StaticPodOperatorSpec,
-	envVars map[string]string,
-	backupVar backuphelpers.BackupVar) error {
+	envVars map[string]string) error {
 
 	var errs error
-	contentReplacer, err := c.getSubstitutionReplacer(operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, envVars, backupVar)
+	contentReplacer, err := c.getSubstitutionReplacer(operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, envVars)
 	if err != nil {
 		return err
 	}
-	podSub := c.getPodSubstitution(operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, envVars, backupVar)
+	podSub := c.getPodSubstitution(operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, envVars)
 	_, _, err = c.manageStandardPod(ctx, podSub, c.kubeClient.CoreV1(), recorder, operatorSpec)
 	if err != nil {
 		errs = errors.Join(errs, fmt.Errorf("%q: %w", "configmap/etcd-pod", err))
@@ -188,7 +182,7 @@ func loglevelToZap(logLevel operatorv1.LogLevel) string {
 }
 
 func (c *TargetConfigController) getSubstitutionReplacer(operatorSpec *operatorv1.StaticPodOperatorSpec,
-	imagePullSpec, operatorImagePullSpec string, envVarMap map[string]string, backupVar backuphelpers.BackupVar) (*strings.Replacer, error) {
+	imagePullSpec, operatorImagePullSpec string, envVarMap map[string]string) (*strings.Replacer, error) {
 	var envVarLines []string
 	for _, k := range sets.StringKeySet(envVarMap).List() {
 		v := envVarMap[k]
@@ -203,12 +197,11 @@ func (c *TargetConfigController) getSubstitutionReplacer(operatorSpec *operatorv
 		"${LISTEN_ON_ALL_IPS}", "0.0.0.0", // TODO this needs updating to detect ipv6-ness
 		"${LOCALHOST_IP}", "127.0.0.1", // TODO this needs updating to detect ipv6-ness
 		"${COMPUTED_ENV_VARS}", strings.Join(envVarLines, "\n"), // lacks beauty, but it works
-		"${COMPUTED_BACKUP_VARS}", backupVar.ArgString(),
 	), nil
 }
 
 func (c *TargetConfigController) getPodSubstitution(operatorSpec *operatorv1.StaticPodOperatorSpec,
-	imagePullSpec, operatorImagePullSpec string, envVarMap map[string]string, backupVar backuphelpers.BackupVar) *PodSubstitutionTemplate {
+	imagePullSpec, operatorImagePullSpec string, envVarMap map[string]string) *PodSubstitutionTemplate {
 
 	var nameValues []NameValue
 	for _, k := range sets.StringKeySet(envVarMap).List() {
@@ -223,7 +216,6 @@ func (c *TargetConfigController) getPodSubstitution(operatorSpec *operatorv1.Sta
 		LocalhostAddress: "127.0.0.1", // TODO this needs updating to detect ipv6-ness
 		LogLevel:         loglevelToZap(operatorSpec.LogLevel),
 		EnvVars:          nameValues,
-		BackupArgs:       backupVar.ArgList(),
 	}
 }
 

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -2,15 +2,12 @@ package targetconfigcontroller
 
 import (
 	"context"
-	"slices"
 	"testing"
 
 	"k8s.io/client-go/kubernetes/scheme"
 
 	configv1 "github.com/openshift/api/config/v1"
-	backupv1alpha1 "github.com/openshift/api/config/v1alpha1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/cluster-etcd-operator/pkg/backuphelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdenvvar"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
@@ -40,7 +37,6 @@ func TestTargetConfigController(t *testing.T) {
 		objects         []runtime.Object
 		staticPodStatus *operatorv1.StaticPodOperatorStatus
 		etcdMembers     []*etcdserverpb.Member
-		etcdBackupSpec  *backupv1alpha1.EtcdBackupSpec
 		expectedErr     error
 	}{
 		{
@@ -59,7 +55,6 @@ func TestTargetConfigController(t *testing.T) {
 				u.FakeEtcdMemberWithoutServer(1),
 				u.FakeEtcdMemberWithoutServer(2),
 			},
-			etcdBackupSpec: nil,
 		},
 		{
 			name: "Quorum not fault tolerant but bootstrapping",
@@ -76,57 +71,13 @@ func TestTargetConfigController(t *testing.T) {
 				u.FakeEtcdMemberWithoutServer(0),
 				u.FakeEtcdMemberWithoutServer(2),
 			},
-			etcdBackupSpec: nil,
-		},
-		{
-			name: "BackupVar Test HappyPath",
-			objects: []runtime.Object{
-				u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
-			},
-			staticPodStatus: u.StaticPodOperatorStatus(
-				u.WithLatestRevision(3),
-				u.WithNodeStatusAtCurrentRevision(3),
-				u.WithNodeStatusAtCurrentRevision(3),
-				u.WithNodeStatusAtCurrentRevision(3),
-			),
-			etcdMembers: []*etcdserverpb.Member{
-				u.FakeEtcdMemberWithoutServer(0),
-				u.FakeEtcdMemberWithoutServer(1),
-				u.FakeEtcdMemberWithoutServer(2),
-			},
-			etcdBackupSpec: u.CreateEtcdBackupSpecPtr("GMT", "0 */2 * * *"),
-		},
-		{
-			name: "Backup Var Test with empty spec",
-			objects: []runtime.Object{
-				u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
-			},
-			staticPodStatus: u.StaticPodOperatorStatus(
-				u.WithLatestRevision(3),
-				u.WithNodeStatusAtCurrentRevision(3),
-				u.WithNodeStatusAtCurrentRevision(3),
-				u.WithNodeStatusAtCurrentRevision(3),
-			),
-			etcdMembers: []*etcdserverpb.Member{
-				u.FakeEtcdMemberWithoutServer(0),
-				u.FakeEtcdMemberWithoutServer(1),
-				u.FakeEtcdMemberWithoutServer(2),
-			},
-			etcdBackupSpec: nil,
 		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			backupVar := backuphelpers.NewDisabledBackupConfig()
-			eventRecorder, _, controller, fakeKubeClient := getController(t, scenario.staticPodStatus, scenario.objects, backupVar)
-			backupVar.SetBackupSpec(scenario.etcdBackupSpec)
+			eventRecorder, _, controller, fakeKubeClient := getController(t, scenario.staticPodStatus, scenario.objects)
 			err := controller.sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
 			require.Equal(t, scenario.expectedErr, err)
-
-			if scenario.expectedErr != nil {
-				return
-			}
-
 			etcdPodCM, err := fakeKubeClient.CoreV1().ConfigMaps(operatorclient.TargetNamespace).Get(context.TODO(), "etcd-pod", metav1.GetOptions{})
 			require.NoError(t, err)
 
@@ -146,21 +97,19 @@ func TestTargetConfigController(t *testing.T) {
 			})
 
 			expectedEnv := map[string][]corev1.EnvVar{
-				"etcdctl":            envWithRevision,
-				"etcd":               envWithRevision,
-				"etcd-metrics":       envWithRevision,
-				"etcd-readyz":        envWithoutRevision,
-				"etcd-rev":           envWithoutRevision,
-				"etcd-backup-server": envWithoutRevision,
+				"etcdctl":      envWithRevision,
+				"etcd":         envWithRevision,
+				"etcd-metrics": envWithRevision,
+				"etcd-readyz":  envWithoutRevision,
+				"etcd-rev":     envWithoutRevision,
 			}
 
 			expectedImage := map[string]string{
-				"etcdctl":            etcdPullSpec,
-				"etcd":               etcdPullSpec,
-				"etcd-metrics":       etcdPullSpec,
-				"etcd-readyz":        operatorPullSpec,
-				"etcd-rev":           operatorPullSpec,
-				"etcd-backup-server": operatorPullSpec,
+				"etcdctl":      etcdPullSpec,
+				"etcd":         etcdPullSpec,
+				"etcd-metrics": etcdPullSpec,
+				"etcd-readyz":  operatorPullSpec,
+				"etcd-rev":     operatorPullSpec,
 			}
 
 			for _, container := range pod.Spec.Containers {
@@ -169,20 +118,11 @@ func TestTargetConfigController(t *testing.T) {
 				require.Contains(t, expectedImage, container.Name)
 				require.Equal(t, expectedImage[container.Name], container.Image)
 			}
-
-			backupContainerIndex := slices.IndexFunc(pod.Spec.Containers, func(container corev1.Container) bool {
-				return container.Name == "etcd-backup-server"
-			})
-			if scenario.etcdBackupSpec != nil {
-				require.Equal(t, []string{"--enabled=true", "--timezone=GMT", "--schedule=0 */2 * * *"}, pod.Spec.Containers[backupContainerIndex].Args)
-			} else {
-				require.Equal(t, []string{"--enabled=false"}, pod.Spec.Containers[backupContainerIndex].Args)
-			}
 		})
 	}
 }
 
-func getController(t *testing.T, staticPodStatus *operatorv1.StaticPodOperatorStatus, objects []runtime.Object, backupVar *backuphelpers.BackupConfig) (events.Recorder, v1helpers.StaticPodOperatorClient, *TargetConfigController, *fake.Clientset) {
+func getController(t *testing.T, staticPodStatus *operatorv1.StaticPodOperatorStatus, objects []runtime.Object) (events.Recorder, v1helpers.StaticPodOperatorClient, *TargetConfigController, *fake.Clientset) {
 	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
 		&operatorv1.StaticPodOperatorSpec{
 			OperatorSpec: operatorv1.OperatorSpec{
@@ -231,7 +171,6 @@ func getController(t *testing.T, staticPodStatus *operatorv1.StaticPodOperatorSt
 		operatorClient:        fakeOperatorClient,
 		kubeClient:            fakeKubeClient,
 		envVarGetter:          envVar,
-		backupVarGetter:       backupVar,
 		enqueueFn:             func() {},
 	}
 

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	backupv1alpha1 "github.com/openshift/api/config/v1alpha1"
 	"github.com/openshift/cluster-etcd-operator/pkg/tlshelpers"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/stretchr/testify/require"
@@ -541,11 +540,4 @@ func AssertNodeSpecificCertificates(t *testing.T, node *corev1.Node, secrets []c
 	}
 
 	require.Equalf(t, 0, expectedSet.Len(), "missing certificates for node: %v", expectedSet.List())
-}
-
-func CreateEtcdBackupSpecPtr(timezone, schedule string) *backupv1alpha1.EtcdBackupSpec {
-	return &backupv1alpha1.EtcdBackupSpec{
-		Schedule: schedule,
-		TimeZone: timezone,
-	}
 }


### PR DESCRIPTION
This PR removes `etcd-backup-server` based on StaticPod. 

The `StaticPod` approach has been replaced by https://github.com/openshift/cluster-etcd-operator/pull/1354 

Comparing against 4.17 branch [link](https://github.com/openshift/cluster-etcd-operator/compare/release-4.17...Elbehery:remove_etcd-backup-server_staticPod)

resolves https://issues.redhat.com/browse/ETCD-686 

cc @openshift/openshift-team-etcd 