### PR TITLE
OCPBUGS-43920: operator: remove duplicate kube client

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -109,10 +109,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
-	clientset, err := kubernetes.NewForConfig(controllerContext.KubeConfig)
-	if err != nil {
-		return err
-	}
 	machineClientSet, err := machineclient.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {
 		return err
@@ -361,7 +357,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		},
 	).Inertia)
 
-	coreClient := clientset
+	coreClient := kubeClient
 
 	etcdCertSignerController := etcdcertsigner.NewEtcdCertSignerController(
 		AlivenessChecker,


### PR DESCRIPTION
This one is using JSON instead of protobuf