### PR TITLE
OCPBUGS-43748: etcd pod containers do not start when tls min version is 1.3

### DIFF
--- a/bindata/etcd/pod.gotpl.yaml
+++ b/bindata/etcd/pod.gotpl.yaml
@@ -131,9 +131,9 @@ spec:
       - mountPath: /var/lib/etcd/
         name: data-dir
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
@@ -195,10 +195,10 @@ spec:
           --metrics=extensive \
           --listen-metrics-urls=https://{{.ListenAddress}}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
-    {{ end -}}
+    {{- range .EnvVars }}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
+    {{- end }}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
     resources:
@@ -268,11 +268,14 @@ spec:
           --cert-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.crt \
           --cacert /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
           --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/metrics-ca-bundle.crt \
-          --listen-cipher-suites ${ETCD_CIPHER_SUITES}
+        {{- if .CipherSuites }}
+          --listen-cipher-suites {{ .CipherSuites }} \
+          {{ end -}}
+          --tls-min-version $(ETCD_TLS_MIN_VERSION)
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{- range .EnvVars }}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
@@ -308,7 +311,10 @@ spec:
           --client-cert-file=$(ETCDCTL_CERT) \
           --client-key-file=$(ETCDCTL_KEY) \
           --client-cacert-file=$(ETCDCTL_CACERT) \
-          --listen-cipher-suites=$(ETCD_CIPHER_SUITES)
+        {{- if .CipherSuites }}
+          --listen-cipher-suites {{ .CipherSuites }} \
+          {{ end -}}
+          --listen-tls-min-version=$(ETCD_TLS_MIN_VERSION)
     securityContext:
       privileged: true
     ports:
@@ -320,9 +326,9 @@ spec:
         memory: 50Mi
         cpu: 10m
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     volumeMounts:
       - mountPath: /var/log/etcd/
@@ -352,9 +358,9 @@ spec:
         memory: 50Mi
         cpu: 10m
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     volumeMounts:
     - mountPath: /var/lib/etcd

--- a/pkg/cmd/readyz/readyz.go
+++ b/pkg/cmd/readyz/readyz.go
@@ -44,6 +44,7 @@ type readyzOpts struct {
 	clientKeyFile    string
 	clientCACertFile string
 	cipherSuites     []string
+	tlsMinVersion    string
 
 	clientPool *etcdcli.EtcdClientPool
 }
@@ -91,6 +92,7 @@ func (r *readyzOpts) AddFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.Uint16Var(&r.listenPort, "listen-port", r.listenPort, "Listen on this port. Default 9980")
 	fs.StringSliceVar(&r.cipherSuites, "listen-cipher-suites", r.cipherSuites, "readyZ server TLS cipher suites.")
+	fs.StringVar(&r.tlsMinVersion, "listen-tls-min-version", r.tlsMinVersion, "Minimum TLS version supported by readyZ server. Possible values: TLS1.2, TLS1.3.")
 	fs.DurationVar(&r.dialTimeout, "dial-timeout", r.dialTimeout, "Dial timeout for the client. Default 2s")
 	fs.StringVar(&r.targetEndpoint, "target", r.targetEndpoint, "Target endpoint to perform health check against. Default https://localhost:2379")
 	fs.StringVar(&r.servingCertFile, "serving-cert-file", r.servingCertFile, "Health probe server TLS client certificate file. (required)")
@@ -178,12 +180,19 @@ func (r *readyzOpts) Run() error {
 		return err
 	}
 
+	tlsMinVersion, err := tlsutil.GetTLSVersion(r.tlsMinVersion)
+	if err != nil {
+		cancel()
+		return err
+	}
+
 	httpServer := &http.Server{
 		Addr:        addr,
 		Handler:     mux,
 		BaseContext: func(_ net.Listener) context.Context { return shutdownCtx },
-		TLSConfig:   &tls.Config{CipherSuites: suites},
+		TLSConfig:   &tls.Config{CipherSuites: suites, MinVersion: tlsMinVersion},
 	}
+
 	go func() {
 		defer cancel()
 		<-shutdownHandler

--- a/pkg/etcdenvvar/envvarcontroller_test.go
+++ b/pkg/etcdenvvar/envvarcontroller_test.go
@@ -55,6 +55,7 @@ var (
 		"ETCD_INITIAL_CLUSTER_STATE":                       "existing",
 		"ETCD_QUOTA_BACKEND_BYTES":                         "8589934592",
 		"ETCD_SOCKET_REUSE_ADDRESS":                        "true",
+		"ETCD_TLS_MIN_VERSION":                             "TLS1.2",
 		"NODE_master_0_ETCD_NAME":                          "master-0",
 		"NODE_master_0_ETCD_URL_HOST":                      "192.168.2.0",
 		"NODE_master_0_IP":                                 "192.168.2.0",

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1102,9 +1102,9 @@ spec:
       - mountPath: /var/lib/etcd/
         name: data-dir
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
@@ -1166,10 +1166,10 @@ spec:
           --metrics=extensive \
           --listen-metrics-urls=https://{{.ListenAddress}}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
-    {{ end -}}
+    {{- range .EnvVars }}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
+    {{- end }}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
     resources:
@@ -1239,11 +1239,14 @@ spec:
           --cert-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.crt \
           --cacert /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
           --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/metrics-ca-bundle.crt \
-          --listen-cipher-suites ${ETCD_CIPHER_SUITES}
+        {{- if .CipherSuites }}
+          --listen-cipher-suites {{ .CipherSuites }} \
+          {{ end -}}
+          --tls-min-version $(ETCD_TLS_MIN_VERSION)
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{- range .EnvVars }}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
@@ -1279,7 +1282,10 @@ spec:
           --client-cert-file=$(ETCDCTL_CERT) \
           --client-key-file=$(ETCDCTL_KEY) \
           --client-cacert-file=$(ETCDCTL_CACERT) \
-          --listen-cipher-suites=$(ETCD_CIPHER_SUITES)
+        {{- if .CipherSuites }}
+          --listen-cipher-suites {{ .CipherSuites }} \
+          {{ end -}}
+          --listen-tls-min-version=$(ETCD_TLS_MIN_VERSION)
     securityContext:
       privileged: true
     ports:
@@ -1291,9 +1297,9 @@ spec:
         memory: 50Mi
         cpu: 10m
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     volumeMounts:
       - mountPath: /var/log/etcd/
@@ -1323,9 +1329,9 @@ spec:
         memory: 50Mi
         cpu: 10m
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     volumeMounts:
     - mountPath: /var/lib/etcd

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -44,6 +44,7 @@ type PodSubstitutionTemplate struct {
 	LogLevel         string
 	EnvVars          []NameValue
 	BackupArgs       []string
+	CipherSuites     string
 }
 
 type TargetConfigController struct {
@@ -216,6 +217,7 @@ func (c *TargetConfigController) getPodSubstitution(operatorSpec *operatorv1.Sta
 		LocalhostAddress: "127.0.0.1", // TODO this needs updating to detect ipv6-ness
 		LogLevel:         loglevelToZap(operatorSpec.LogLevel),
 		EnvVars:          nameValues,
+		CipherSuites:     envVarMap["ETCD_CIPHER_SUITES"],
 	}
 }
 


### PR DESCRIPTION
- **add ETCD_TLS_MIN_VERSION env to etcd pods**
- **add listen-tls-min-version flag to readyz cmd**
- **do not start etcd with --cipher-suites with tls1.3**
