### PR TITLE
OCPBUGS-42810: remove bootstrap member earlier

### DIFF
--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
@@ -9,7 +9,6 @@ import (
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/health"
 	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/operator/bootstrap"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
@@ -137,10 +136,6 @@ func (c *BootstrapTeardownController) removeBootstrap(ctx context.Context, safeT
 		return fmt.Errorf("error while updating EnoughEtcdMembers: %w", updateErr)
 	}
 
-	// check to see if bootstrapping is complete
-	if isBootstrapComplete, err := bootstrap.IsBootstrapComplete(c.configmapLister); !isBootstrapComplete || err != nil {
-		return err
-	}
 	klog.Warningf("Removing bootstrap member [%x]", bootstrapID)
 
 	// this is ugly until bootkube is updated, but we want to be sure that bootkube has time to be waiting to watch the condition coming back.

--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller_test.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller_test.go
@@ -217,25 +217,6 @@ func TestRemoveBootstrap(t *testing.T) {
 				conditionWaitingForEtcdMembers,
 			},
 		},
-		"safe, has bootstrap, incomplete process": {
-			safeToRemove: true,
-			hasBootstrap: true,
-			bootstrapId:  0,
-			expectedConditions: []operatorv1.OperatorCondition{
-				conditionEnoughEtcdMembers,
-			},
-		},
-		"safe, has bootstrap, incomplete process progressing": {
-			safeToRemove: true,
-			hasBootstrap: true,
-			bootstrapId:  0,
-			expectedConditions: []operatorv1.OperatorCondition{
-				conditionEnoughEtcdMembers,
-			},
-			indexerObjs: []interface{}{
-				bootstrapProgressing,
-			},
-		},
 		"safe, has bootstrap, complete process, fails removal": {
 			safeToRemove: true,
 			hasBootstrap: true,


### PR DESCRIPTION
This PR will remove the bootstrap configmap check before removing the etcd bootstrap member from etcd.
That should cause the bootstrap member to be removed earlier and avoid racing with the bootstrap node termination.