### PR TITLE
OCPBUGS-48400: generate event upon successfull bootstrap member removal

### DIFF
--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -254,7 +254,7 @@ func (g *etcdClientGetter) MemberRemove(ctx context.Context, memberID uint64) er
 	defer cancel()
 	_, err = cli.MemberRemove(ctx, memberID)
 	if err == nil {
-		g.eventRecorder.Eventf("MemberRemove", "removed member with ID: %v", memberID)
+		g.eventRecorder.Eventf("MemberRemove", "removed member with ID: [%x]", memberID)
 	}
 	return err
 }


### PR DESCRIPTION
This generates an event upon successful bootstrap member removal 

see https://issues.redhat.com/browse/OCPBUGS-48400