### PR TITLE
NO-JIRA: fix schedule backup test

### DIFF
--- a/pkg/cmd/backuprestore/backupserver_test.go
+++ b/pkg/cmd/backuprestore/backupserver_test.go
@@ -137,7 +137,7 @@ func TestNewBackupServer_scheduleBackup(t *testing.T) {
 			schedule:   "*/2 * * * * *",
 			timeout:    time.Second * 8,
 			slow:       true,
-			expBackups: 3,
+			expBackups: 2,
 			expErr:     nil,
 		},
 		{


### PR DESCRIPTION
This PR fixes `TestNewBackupServer_scheduleBackup` due to changes in go1.23 `ticker` implementation.

Changes that caused the issue

```
Second, the timer channel associated with a Timer or Ticker is now unbuffered, with capacity 0. The main effect of this change is that Go now guarantees that for any call to a Reset or Stop method, no stale values prepared before that call will be sent or received after the call. Earlier versions of Go used channels with a one-element buffer, making it difficult to use Reset and Stop correctly. A visible effect of this change is that len and cap of timer channels now returns 0 instead of 1, which may affect programs that poll the length to decide whether a receive on the timer channel will succeed. Such code should use a non-blocking receive instead.
```