### PR TITLE
NO-JIRA: restrict `etcdctl defrag` to single member

### DIFF
--- a/test/e2e/etcdctl_test.go
+++ b/test/e2e/etcdctl_test.go
@@ -32,7 +32,7 @@ func TestEtcdctlCommands(t *testing.T) {
 		{"etcdctl alarm list", false, "", ""},
 		{"etcdctl check perf", true, "OpenShift disabled command", ""},
 		{"etcdctl compaction 0", false, "", "Error: etcdserver: mvcc: required revision has been compacted"},
-		{"env ETCDCTL_ENDPOINTS=https://127.0.0.1:2379 etcdctl defrag", false, "", ""},
+		{"env ETCDCTL_ENDPOINTS=https://localhost:2379 etcdctl defrag", false, "", ""},
 		{"etcdctl elect myelection", false, "", "no proposal argument but -l not set"},
 		// endpoint
 		{"etcdctl endpoint hashkv", false, "", ""},

--- a/test/e2e/etcdctl_test.go
+++ b/test/e2e/etcdctl_test.go
@@ -32,7 +32,7 @@ func TestEtcdctlCommands(t *testing.T) {
 		{"etcdctl alarm list", false, "", ""},
 		{"etcdctl check perf", true, "OpenShift disabled command", ""},
 		{"etcdctl compaction 0", false, "", "Error: etcdserver: mvcc: required revision has been compacted"},
-		{"etcdctl defrag", false, "", ""},
+		{"env ETCDCTL_ENDPOINTS=https://127.0.0.1:2379 etcdctl defrag", false, "", ""},
 		{"etcdctl elect myelection", false, "", "no proposal argument but -l not set"},
 		// endpoint
 		{"etcdctl endpoint hashkv", false, "", ""},


### PR DESCRIPTION
Most of `etcdctl` [e2e](https://github.com/openshift/cluster-etcd-operator/blob/c956ac315dddcb510a1f4ca75fe7a0fdf8569711/test/e2e/etcdctl_test.go#L18)  test are disabled by default.

During last weeks, this test has failed most of the time, from changes that is non related to it. 

It is better to disable it, as it blocks more important work, for no reason. 

cc @tjungblu 