### PR TITLE
OCPEDGE-1498: support updates to external etcd

### DIFF
--- a/bindata/etcd/external-etcd-pod-cm.yaml
+++ b/bindata/etcd/external-etcd-pod-cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-etcd
+  name: external-etcd-pod
+data:
+  pod.yaml:

--- a/pkg/dualreplicahelpers/dual_replica_helpers.go
+++ b/pkg/dualreplicahelpers/dual_replica_helpers.go
@@ -1,0 +1,18 @@
+package dualreplicahelpers
+
+import (
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+)
+
+const DualReplicaFeatureGateName = "DualReplica"
+
+func DualReplicaFeatureGateEnabled(featureGateAccessor featuregates.FeatureGateAccess) (bool, error) {
+	gates, err := featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return false, fmt.Errorf("could not access feature gates, error was: %w", err)
+	}
+
+	return gates.Enabled(DualReplicaFeatureGateName), nil
+}

--- a/pkg/dualreplicahelpers/dual_replica_helpers_test.go
+++ b/pkg/dualreplicahelpers/dual_replica_helpers_test.go
@@ -1,0 +1,27 @@
+package dualreplicahelpers
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDualReplicaFeatureGateEnabled(t *testing.T) {
+	dualReplicaFeatureGateAccessor := featuregates.NewHardcodedFeatureGateAccess(
+		[]configv1.FeatureGateName{DualReplicaFeatureGateName},
+		[]configv1.FeatureGateName{})
+	enabled, err := DualReplicaFeatureGateEnabled(dualReplicaFeatureGateAccessor)
+	require.True(t, enabled)
+	require.NoError(t, err)
+}
+
+func TestDualReplicaFeatureGateDisabled(t *testing.T) {
+	dualReplicaFeatureGateAccessor := featuregates.NewHardcodedFeatureGateAccess(
+		[]configv1.FeatureGateName{},
+		[]configv1.FeatureGateName{DualReplicaFeatureGateName})
+	enabled, err := DualReplicaFeatureGateEnabled(dualReplicaFeatureGateAccessor)
+	require.False(t, enabled)
+	require.NoError(t, err)
+}

--- a/pkg/operator/ceohelpers/control_plane_topology.go
+++ b/pkg/operator/ceohelpers/control_plane_topology.go
@@ -37,3 +37,11 @@ func IsArbiterNodeTopology(ctx context.Context, infraClient configv1client.Infra
 	return infra.Status.ControlPlaneTopology == configv1.HighlyAvailableArbiterMode, nil
 
 }
+
+func IsDualReplicaTopology(ctx context.Context, infraLister configv1listers.InfrastructureLister) (bool, error) {
+	cpTopology, err := GetControlPlaneTopology(infraLister)
+	if err != nil {
+		return false, err
+	}
+	return configv1.DualReplicaTopologyMode == cpTopology, nil
+}

--- a/pkg/operator/ceohelpers/podsubstitution.go
+++ b/pkg/operator/ceohelpers/podsubstitution.go
@@ -1,0 +1,88 @@
+package ceohelpers
+
+import (
+	"reflect"
+	"strings"
+	"text/template"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcd_assets"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type NameValue struct {
+	Name  string
+	Value string
+}
+
+type PodSubstitutionTemplate struct {
+	Image               string
+	OperatorImage       string
+	ListenAddress       string
+	LocalhostAddress    string
+	LogLevel            string
+	EnvVars             []NameValue
+	BackupArgs          []string
+	CipherSuites        string
+	EnableEtcdContainer bool
+}
+
+// GetPodSubstitution creates a PodSubstitutionTemplate with values derived from StaticPodOperatorSpec,
+// image pull spec and environment variables. It determines whether the Etcd container should be enabled
+// based on the operator's configuration.
+func GetPodSubstitution(
+	operatorSpec *operatorv1.StaticPodOperatorSpec,
+	imagePullSpec, operatorImagePullSpec string,
+	envVarMap map[string]string) (*PodSubstitutionTemplate, error) {
+
+	var nameValues []NameValue
+	for _, k := range sets.StringKeySet(envVarMap).List() {
+		v := envVarMap[k]
+		nameValues = append(nameValues, NameValue{Name: k, Value: v})
+	}
+
+	shouldRemoveEtcdContainer, err := IsUnsupportedUnsafeEtcdContainerRemoval(operatorSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PodSubstitutionTemplate{
+		Image:               imagePullSpec,
+		OperatorImage:       operatorImagePullSpec,
+		ListenAddress:       "0.0.0.0",   // TODO: this needs updating to detect ipv6-ness
+		LocalhostAddress:    "127.0.0.1", // TODO: this needs updating to detect ipv6-ness
+		LogLevel:            LoglevelToZap(operatorSpec.LogLevel),
+		EnvVars:             nameValues,
+		CipherSuites:        envVarMap["ETCD_CIPHER_SUITES"],
+		EnableEtcdContainer: !shouldRemoveEtcdContainer,
+	}, nil
+}
+
+// RenderTemplate renders a Pod template from the Assets with the data from a PodSubstitutionTemplate
+func RenderTemplate(templateName string, subs *PodSubstitutionTemplate) (string, error) {
+	fm := template.FuncMap{"quote": func(arg reflect.Value) string {
+		return "\"" + arg.String() + "\""
+	}}
+	podBytes := etcd_assets.MustAsset(templateName)
+	tmpl, err := template.New("pod").Funcs(fm).Parse(string(podBytes))
+	if err != nil {
+		return "", err
+	}
+
+	w := &strings.Builder{}
+	err = tmpl.Execute(w, subs)
+	if err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}
+
+// LoglevelToZap converts a openshift/api/operator/v1 LogLevel into a corresponding Zap log level string
+func LoglevelToZap(logLevel operatorv1.LogLevel) string {
+	switch logLevel {
+	case operatorv1.Debug, operatorv1.Trace, operatorv1.TraceAll:
+		return "debug"
+	default:
+		return "info"
+	}
+}

--- a/pkg/operator/ceohelpers/unsupported_override.go
+++ b/pkg/operator/ceohelpers/unsupported_override.go
@@ -21,6 +21,11 @@ func IsUnsupportedUnsafeEtcdContainerRemoval(spec *operatorv1.StaticPodOperatorS
 	return tryGetUnsupportedValue(spec, "useUnsupportedUnsafeEtcdContainerRemoval")
 }
 
+// IsExternalEtcdSupport returns true if useExternalEtcdSupport is set to any parsable value.
+func IsExternalEtcdSupport(spec *operatorv1.StaticPodOperatorSpec) (bool, error) {
+	return tryGetUnsupportedValue(spec, "useExternalEtcdSupport")
+}
+
 func tryGetUnsupportedValue(spec *operatorv1.StaticPodOperatorSpec, key string) (bool, error) {
 	unsupportedConfig := map[string]interface{}{}
 	if spec.UnsupportedConfigOverrides.Raw == nil {

--- a/pkg/operator/ceohelpers/unsupported_override_test.go
+++ b/pkg/operator/ceohelpers/unsupported_override_test.go
@@ -2,15 +2,16 @@ package ceohelpers
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 )
 
 func TestIsUnsupportedOptions(t *testing.T) {
-	options := []string{"useUnsupportedUnsafeNonHANonProductionUnstableEtcd", "useUnsupportedUnsafeEtcdContainerRemoval"}
+	options := []string{"useUnsupportedUnsafeNonHANonProductionUnstableEtcd", "useUnsupportedUnsafeEtcdContainerRemoval", "useExternalEtcdSupport"}
 	tests := []struct {
 		name    string
 		args    string

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -10,6 +10,7 @@
 // bindata/etcd/cm.yaml
 // bindata/etcd/disable-etcd.sh
 // bindata/etcd/etcd-common-tools
+// bindata/etcd/external-etcd-pod-cm.yaml
 // bindata/etcd/minimal-sm.yaml
 // bindata/etcd/ns.yaml
 // bindata/etcd/pod-cm.yaml
@@ -855,6 +856,30 @@ func etcdEtcdCommonTools() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "etcd/etcd-common-tools", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _etcdExternalEtcdPodCmYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-etcd
+  name: external-etcd-pod
+data:
+  pod.yaml:
+`)
+
+func etcdExternalEtcdPodCmYamlBytes() ([]byte, error) {
+	return _etcdExternalEtcdPodCmYaml, nil
+}
+
+func etcdExternalEtcdPodCmYaml() (*asset, error) {
+	bytes, err := etcdExternalEtcdPodCmYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "etcd/external-etcd-pod-cm.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2500,6 +2525,7 @@ var _bindata = map[string]func() (*asset, error){
 	"etcd/cm.yaml":                     etcdCmYaml,
 	"etcd/disable-etcd.sh":             etcdDisableEtcdSh,
 	"etcd/etcd-common-tools":           etcdEtcdCommonTools,
+	"etcd/external-etcd-pod-cm.yaml":   etcdExternalEtcdPodCmYaml,
 	"etcd/minimal-sm.yaml":             etcdMinimalSmYaml,
 	"etcd/ns.yaml":                     etcdNsYaml,
 	"etcd/pod-cm.yaml":                 etcdPodCmYaml,
@@ -2571,6 +2597,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"cm.yaml":                     {etcdCmYaml, map[string]*bintree{}},
 		"disable-etcd.sh":             {etcdDisableEtcdSh, map[string]*bintree{}},
 		"etcd-common-tools":           {etcdEtcdCommonTools, map[string]*bintree{}},
+		"external-etcd-pod-cm.yaml":   {etcdExternalEtcdPodCmYaml, map[string]*bintree{}},
 		"minimal-sm.yaml":             {etcdMinimalSmYaml, map[string]*bintree{}},
 		"ns.yaml":                     {etcdNsYaml, map[string]*bintree{}},
 		"pod-cm.yaml":                 {etcdPodCmYaml, map[string]*bintree{}},

--- a/pkg/operator/externaletcdsupportcontroller/external_etcd_support_controller.go
+++ b/pkg/operator/externaletcdsupportcontroller/external_etcd_support_controller.go
@@ -1,0 +1,192 @@
+package externaletcdsupportcontroller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/ghodss/yaml"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	"github.com/openshift/cluster-etcd-operator/pkg/etcdenvvar"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcd_assets"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/health"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/targetconfigcontroller"
+	"github.com/openshift/cluster-etcd-operator/pkg/version"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+type ExternalEtcdEnablerController struct {
+	operatorClient v1helpers.StaticPodOperatorClient
+
+	targetImagePullSpec   string
+	operatorImagePullSpec string
+	envVarGetter          etcdenvvar.EnvVar
+
+	kubeClient kubernetes.Interface
+
+	enqueueFn func()
+}
+
+func NewExternalEtcdEnablerController(
+	operatorClient v1helpers.StaticPodOperatorClient,
+	targetImagePullSpec, operatorImagePullSpec string,
+	envVarGetter etcdenvvar.EnvVar,
+	kubeInformersForOpenshiftEtcdNamespace informers.SharedInformerFactory,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	infrastructureInformer configv1informers.InfrastructureInformer,
+	networkInformer configv1informers.NetworkInformer,
+	masterNodeInformer cache.SharedIndexInformer,
+	kubeClient kubernetes.Interface,
+	eventRecorder events.Recorder) factory.Controller {
+
+	c := &ExternalEtcdEnablerController{
+		operatorClient:        operatorClient,
+		targetImagePullSpec:   targetImagePullSpec,
+		operatorImagePullSpec: operatorImagePullSpec,
+		envVarGetter:          envVarGetter,
+		kubeClient:            kubeClient,
+	}
+	syncCtx := factory.NewSyncContext("ExternalEtcdSupportController", eventRecorder.WithComponentSuffix("external-etcd-support-controller"))
+	c.enqueueFn = func() {
+		syncCtx.Queue().Add(syncCtx.QueueKey())
+	}
+	envVarGetter.AddListener(c)
+	syncer := health.NewDefaultCheckingSyncWrapper(c.sync)
+
+	return factory.New().
+		WithSyncContext(syncCtx).
+		ResyncEvery(time.Minute).
+		WithSync(syncer.Sync).
+		WithInformers(
+			operatorClient.Informer(),
+			kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Informer(),
+			kubeInformersForOpenshiftEtcdNamespace.Core().V1().ConfigMaps().Informer(),
+			kubeInformersForOpenshiftEtcdNamespace.Core().V1().Secrets().Informer(),
+			masterNodeInformer,
+			infrastructureInformer.Informer(),
+			networkInformer.Informer(),
+		).ToController("ExternalEtcdController", eventRecorder.WithComponentSuffix("external-etcd-controller"))
+}
+
+func (c *ExternalEtcdEnablerController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+
+	operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorState()
+	if err != nil {
+		return err
+	}
+
+	envVars := c.envVarGetter.GetEnvVars()
+	if len(envVars) == 0 {
+		// note this will not degrade the controller, that can happen during CEO restarts often due to cold informer caches (expected)
+		return fmt.Errorf("ExternalEtcdEnablerController missing env var values")
+	}
+
+	podSub := c.getPodSubstitution(c.targetImagePullSpec, c.operatorImagePullSpec, envVars)
+	_, _, err = c.supportExternalPod(ctx, podSub, c.kubeClient.CoreV1(), syncCtx.Recorder(), operatorSpec)
+	if err != nil {
+		err = fmt.Errorf("%q: %w", "configmap/external-etcd-pod", err)
+	}
+
+	return err
+}
+
+func (c *ExternalEtcdEnablerController) getPodSubstitution(
+	imagePullSpec, operatorImagePullSpec string,
+	envVarMap map[string]string) *targetconfigcontroller.PodSubstitutionTemplate {
+
+	var nameValues []targetconfigcontroller.NameValue
+	for _, k := range sets.StringKeySet(envVarMap).List() {
+		v := envVarMap[k]
+		nameValues = append(nameValues, targetconfigcontroller.NameValue{k, v})
+	}
+
+	return &targetconfigcontroller.PodSubstitutionTemplate{
+		Image:               imagePullSpec,
+		OperatorImage:       operatorImagePullSpec,
+		ListenAddress:       "0.0.0.0",   // TODO this needs updating to detect ipv6-ness
+		LocalhostAddress:    "127.0.0.1", // TODO this needs updating to detect ipv6-ness
+		LogLevel:            "info",
+		EnvVars:             nameValues,
+		EnableEtcdContainer: true,
+	}
+}
+
+func (c *ExternalEtcdEnablerController) supportExternalPod(ctx context.Context, subs *targetconfigcontroller.PodSubstitutionTemplate,
+	client coreclientv1.ConfigMapsGetter, recorder events.Recorder,
+	operatorSpec *operatorv1.StaticPodOperatorSpec) (*corev1.ConfigMap, bool, error) {
+
+	fm := template.FuncMap{"quote": func(arg reflect.Value) string {
+		return "\"" + arg.String() + "\""
+	}}
+	podBytes := etcd_assets.MustAsset("etcd/pod.gotpl.yaml")
+	tmpl, err := template.New("pod").Funcs(fm).Parse(string(podBytes))
+	if err != nil {
+		return nil, false, err
+	}
+
+	w := &strings.Builder{}
+	err = tmpl.Execute(w, subs)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// keep only the etcd container
+	var pod corev1.Pod
+	if err := yaml.Unmarshal([]byte(w.String()), &pod); err != nil {
+		return nil, false, err
+	}
+
+	filteredContainer := []corev1.Container{}
+	for _, container := range pod.Spec.Containers {
+		if container.Name == "etcd" {
+			filteredContainer = append(filteredContainer, container)
+			break
+		}
+	}
+	pod.Spec.Containers = filteredContainer
+
+	// convert it back in json format. The external Etcd manager might need to
+	// modify this manifest and the node is expected to have jq installed and not yq
+	filteredPodBytes, err := json.Marshal(&pod)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to marshal pod.yaml: %w", err)
+	}
+
+	podConfigMap := resourceread.ReadConfigMapV1OrDie(etcd_assets.MustAsset("etcd/external-etcd-pod-cm.yaml"))
+	podConfigMap.Data["pod.yaml"] = string(filteredPodBytes)
+	podConfigMap.Data["forceRedeploymentReason"] = operatorSpec.ForceRedeploymentReason
+	podConfigMap.Data["version"] = version.Get().String()
+
+	enabled, err := ceohelpers.IsExternalEtcdSupport(operatorSpec)
+	if err != nil {
+		return nil, false, fmt.Errorf("could not determine useExternalEtcdSupport config override: %w", err)
+	}
+	if !enabled {
+		klog.V(4).Infof("external etcd support is disabled: deleting configmap")
+		return resourceapply.DeleteConfigMap(ctx, client, recorder, podConfigMap)
+	}
+	klog.V(4).Infof("external etcd support enabled: creating configmap")
+	return resourceapply.ApplyConfigMap(ctx, client, recorder, podConfigMap)
+}
+
+func (c *ExternalEtcdEnablerController) Enqueue() {
+	c.enqueueFn()
+}

--- a/pkg/operator/externaletcdsupportcontroller/external_etcd_support_controller_test.go
+++ b/pkg/operator/externaletcdsupportcontroller/external_etcd_support_controller_test.go
@@ -1,0 +1,157 @@
+package externaletcdsupportcontroller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-etcd-operator/pkg/etcdenvvar"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+	"github.com/openshift/cluster-etcd-operator/pkg/testutils"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/clock"
+)
+
+const etcdPullSpec = "etcd-pull-spec"
+const operatorPullSpec = "operator-pull-spec"
+
+func TestExternalEtcdSupportController(t *testing.T) {
+	scenarios := []struct {
+		name                      string
+		objects                   []runtime.Object
+		staticPodStatus           *operatorv1.StaticPodOperatorStatus
+		enableExternalEtcdSupport bool
+		expectedErr               error
+	}{
+		{
+			name: "DisabledExternalEtcdSupport",
+			objects: []runtime.Object{
+				testutils.BootstrapConfigMap(testutils.WithBootstrapStatus("complete")),
+			},
+			staticPodStatus: testutils.StaticPodOperatorStatus(
+				testutils.WithLatestRevision(3),
+				testutils.WithNodeStatusAtCurrentRevision(3),
+				testutils.WithNodeStatusAtCurrentRevision(3),
+				testutils.WithNodeStatusAtCurrentRevision(3),
+			),
+			enableExternalEtcdSupport: false,
+			expectedErr:               nil,
+		},
+		{
+			name: "EnabledExternalEtcdSupport",
+			objects: []runtime.Object{
+				testutils.BootstrapConfigMap(testutils.WithBootstrapStatus("complete")),
+			},
+			staticPodStatus: testutils.StaticPodOperatorStatus(
+				testutils.WithLatestRevision(3),
+				testutils.WithNodeStatusAtCurrentRevision(3),
+				testutils.WithNodeStatusAtCurrentRevision(3),
+				testutils.WithNodeStatusAtCurrentRevision(3),
+			),
+			enableExternalEtcdSupport: true,
+			expectedErr:               nil,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			eventRecorder, _, controller, fakeKubeClient := getController(t, scenario.staticPodStatus, scenario.objects, scenario.enableExternalEtcdSupport)
+			err := controller.sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
+			require.Equal(t, scenario.expectedErr, err)
+
+			if scenario.expectedErr != nil {
+				return
+			}
+
+			etcdPodCM, err := fakeKubeClient.CoreV1().ConfigMaps(operatorclient.TargetNamespace).Get(context.TODO(), "external-etcd-pod", metav1.GetOptions{})
+			if !scenario.enableExternalEtcdSupport {
+				require.Error(t, err)
+				return
+			}
+
+			podYaml := etcdPodCM.Data["pod.yaml"]
+			pod := &corev1.Pod{}
+			_, _, err = scheme.Codecs.UniversalDeserializer().Decode([]byte(podYaml), nil, pod)
+			require.NoError(t, err)
+
+			require.Equal(t, 1, len(pod.Spec.Containers))
+			require.Equal(t, "etcd", pod.Spec.Containers[0].Name)
+			require.Equal(t, etcdPullSpec, pod.Spec.Containers[0].Image)
+		})
+	}
+}
+
+func getController(
+	t *testing.T,
+	staticPodStatus *operatorv1.StaticPodOperatorStatus,
+	objects []runtime.Object,
+	useExternalEtcdSupport bool) (events.Recorder, v1helpers.StaticPodOperatorClient, *ExternalEtcdEnablerController, *fake.Clientset) {
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{
+			OperatorSpec: operatorv1.OperatorSpec{
+				ManagementState: operatorv1.Managed,
+				UnsupportedConfigOverrides: runtime.RawExtension{
+					Raw: []byte(fmt.Sprintf(`{"useExternalEtcdSupport": "%t"}`, useExternalEtcdSupport)),
+				},
+			},
+		},
+		staticPodStatus,
+		nil,
+		nil,
+	)
+
+	fakeKubeClient := fake.NewSimpleClientset(objects...)
+
+	defaultObjects := []runtime.Object{
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: operatorclient.TargetNamespace},
+		},
+		&configv1.Infrastructure{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ceohelpers.InfrastructureClusterName,
+			},
+			Status: configv1.InfrastructureStatus{
+				ControlPlaneTopology: configv1.HighlyAvailableTopologyMode},
+		},
+	}
+
+	eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events(operatorclient.TargetNamespace),
+		"test-externaletcdsupportcontroller", &corev1.ObjectReference{}, clock.RealClock{})
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, obj := range defaultObjects {
+		require.NoError(t, indexer.Add(obj))
+	}
+	for _, obj := range objects {
+		require.NoError(t, indexer.Add(obj))
+	}
+
+	envVar := etcdenvvar.FakeEnvVar{EnvVars: map[string]string{
+		"ALL_ETCD_ENDPOINTS": "1,3",
+		"OTHER_ENDPOINTS_IP": "192.168.2.42",
+	}}
+
+	controller := &ExternalEtcdEnablerController{
+		operatorClient:        fakeOperatorClient,
+		targetImagePullSpec:   etcdPullSpec,
+		operatorImagePullSpec: operatorPullSpec,
+		envVarGetter:          envVar,
+		kubeClient:            fakeKubeClient,
+		enqueueFn:             func() {},
+	}
+	return eventRecorder, fakeOperatorClient, controller, fakeKubeClient
+}


### PR DESCRIPTION
The _EnableEtcdContainer unsupported config override_ removes the etcd container from the static pod definition when set to FALSE.

This change extends that behavior by writing a separate Pod definition containing **only** the etcd container, using the same source from which it was removed, but placing it in a location that does not trigger pod creation.

This allows an external etcd manager to run etcd independently while ensuring it has a reliable source for updates from CEO (e.g., new image, path to certificates, etc.).