### PR TITLE
OCPBUGS-54222: increase etcdGRPCRequestsSlow duration

### DIFF
--- a/jsonnet/custom.libsonnet
+++ b/jsonnet/custom.libsonnet
@@ -10,7 +10,7 @@
               histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method!="Defragment", grpc_type="unary"}[10m])) without(grpc_type))
               > 1
             |||,
-            'for': '30m',
+            'for': '60m',
             labels: {
               severity: 'critical',
             },

--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -126,7 +126,7 @@ spec:
       expr: |
         histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method!="Defragment", grpc_type="unary"}[10m])) without(grpc_type))
         > 1
-      for: 30m
+      for: 60m
       labels:
         severity: critical
     - alert: etcdHighNumberOfFailedGRPCRequests


### PR DESCRIPTION
This PR bumps the `etcdGRPCRequestsSlow` alert duration from `30m` to `60m`.

fixes https://issues.redhat.com/browse/OCPBUGS-54222.



