### PR TITLE
NO-JIRA: redundant unhealthy check

### DIFF
--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -344,6 +344,7 @@ func (g *etcdClientGetter) UnhealthyMembers(ctx context.Context) ([]*etcdserverp
 	unstartedMemberNames := GetUnstartedMemberNames(memberHealth)
 	if len(unstartedMemberNames) > 0 {
 		klog.Warningf("UnstartedEtcdMember found: %v", unstartedMemberNames)
+		return memberHealth.GetUnstartedMembers(), nil
 	}
 
 	unhealthyMemberNames := GetUnhealthyMemberNames(memberHealth)


### PR DESCRIPTION
In ocp 4.16, we found the ceo logs show as follows:
```
E0416 07:21:35.302735       1 base_controller.go:268] GuardController reconciliation failed: Missing operand on node node-1
E0416 07:21:36.102619       1 guard_controller.go:285] Missing operand on node node-1
E0416 07:21:36.902893       1 base_controller.go:268] GuardController reconciliation failed: Missing operand on node node-1
E0416 07:21:37.269313       1 guard_controller.go:285] Missing operand on node node-1
W0416 07:21:37.280734       1 etcdcli.go:346] UnstartedEtcdMember found: [NAME-PENDING-10.255.10.1]
W0416 07:21:37.280756       1 etcdcli.go:351] UnhealthyEtcdMember found: [NAME-PENDING-10.255.10.1]
W0416 07:21:38.536782       1 etcdcli.go:346] UnstartedEtcdMember found: [NAME-PENDING-10.255.10.1]
W0416 07:21:38.536797       1 etcdcli.go:351] UnhealthyEtcdMember found: [NAME-PENDING-10.255.10.1]
```
If the cluster has unstarted member, the cluster is unhealthy now, and no need to output more ' UnhealthyEtcdMember found'  log