### PR TITLE
OCPEDGE-1773: Fix arbiter field in install-config

### DIFF
--- a/pkg/operator/configobservation/controlplanereplicascount/observe_control_plane_replicas_count.go
+++ b/pkg/operator/configobservation/controlplanereplicascount/observe_control_plane_replicas_count.go
@@ -67,9 +67,9 @@ func readDesiredControlPlaneReplicas(configMapListerForKubeSystemNamespace corev
 		return 0, fmt.Errorf("required field: %s.controlPlane.replicas doesn't exist in cm: %s/kube-system", installConfigKeyName, clusterConfigConfigMapName)
 	}
 
-	desiredArbiterReplicas, exists, err := unstructured.NestedFloat64(unstructuredInstallConfig, "arbiterNode", "replicas")
+	desiredArbiterReplicas, exists, err := unstructured.NestedFloat64(unstructuredInstallConfig, "arbiter", "replicas")
 	if err != nil {
-		return 0, fmt.Errorf("failed to extract field: %s.arbiterNode.replicas from cm: %s/kube-system, err: %v", installConfigKeyName, clusterConfigConfigMapName, err)
+		return 0, fmt.Errorf("failed to extract field: %s.arbiter.replicas from cm: %s/kube-system, err: %v", installConfigKeyName, clusterConfigConfigMapName, err)
 	}
 	if exists {
 		desiredReplicas += desiredArbiterReplicas


### PR DESCRIPTION
When using TNA clusters, the observedConfig.controlPlane.replicas needs to include the arbiter nodes.
Currently it uses an incorrect field to get the number of arbiter nodes - it uses `arbiterNode` but the actual field is called `arbiter`.