### PR TITLE
OCPBUGS-55111: Remove 'meta' keyword from pcs resource create command

### DIFF
--- a/pkg/tnf/pkg/pcs/etcd.go
+++ b/pkg/tnf/pkg/pcs/etcd.go
@@ -22,7 +22,7 @@ func ConfigureEtcd(ctx context.Context, cfg config.ClusterConfig) error {
 	}
 	if !strings.Contains(stdOut, "etcd") {
 		klog.Info("Creating etcd resource")
-		cmd := fmt.Sprintf("/usr/sbin/pcs resource create etcd podman-etcd node_ip_map=\"%s:%s;%s:%s\" drop_in_dependency=true clone meta interleave=true notify=true",
+		cmd := fmt.Sprintf("/usr/sbin/pcs resource create etcd podman-etcd node_ip_map=\"%s:%s;%s:%s\" drop_in_dependency=true clone interleave=true notify=true",
 			cfg.NodeName1, cfg.NodeIP1, cfg.NodeName2, cfg.NodeIP2)
 		stdOut, stdErr, err = exec.Execute(ctx, cmd)
 		if err != nil || len(stdErr) > 0 {


### PR DESCRIPTION
Specifying 'meta' after 'clone' defines meta attributes for the base resource, not for the clone as the agent needs for the "notify=true" meta attribute.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2168155
Fixes: OCPBUGS-55111