### PR TITLE
 [release-4.18] OCPBUGS-56834:etcd pod containers do not start when tls min version is 1.3

### DIFF
--- a/bindata/etcd/pod.gotpl.yaml
+++ b/bindata/etcd/pod.gotpl.yaml
@@ -131,9 +131,9 @@ spec:
       - mountPath: /var/lib/etcd/
         name: data-dir
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
@@ -196,10 +196,10 @@ spec:
           --metrics=extensive \
           --listen-metrics-urls=https://{{.ListenAddress}}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
-    {{ end -}}
+    {{- range .EnvVars }}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
+    {{- end }}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
     resources:
@@ -270,11 +270,14 @@ spec:
           --cert-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.crt \
           --cacert /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
           --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/metrics-ca-bundle.crt \
-          --listen-cipher-suites ${ETCD_CIPHER_SUITES}
+        {{- if .CipherSuites }}
+          --listen-cipher-suites {{ .CipherSuites }} \
+          {{ end -}}
+          --tls-min-version $(ETCD_TLS_MIN_VERSION)
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+     {{- range .EnvVars }}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
@@ -310,7 +313,10 @@ spec:
           --client-cert-file=$(ETCDCTL_CERT) \
           --client-key-file=$(ETCDCTL_KEY) \
           --client-cacert-file=$(ETCDCTL_CACERT) \
-          --listen-cipher-suites=$(ETCD_CIPHER_SUITES)
+        {{- if .CipherSuites }}
+          --listen-cipher-suites {{ .CipherSuites }} \
+          {{ end -}}
+          --listen-tls-min-version=$(ETCD_TLS_MIN_VERSION)
     securityContext:
       privileged: true
     ports:
@@ -322,9 +328,9 @@ spec:
         memory: 50Mi
         cpu: 10m
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     volumeMounts:
       - mountPath: /var/log/etcd/
@@ -354,9 +360,9 @@ spec:
         memory: 50Mi
         cpu: 10m
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     volumeMounts:
     - mountPath: /var/lib/etcd

--- a/pkg/cmd/readyz/readyz.go
+++ b/pkg/cmd/readyz/readyz.go
@@ -44,6 +44,7 @@ type readyzOpts struct {
 	clientKeyFile    string
 	clientCACertFile string
 	cipherSuites     []string
+	tlsMinVersion    string
 
 	clientPool *etcdcli.EtcdClientPool
 }
@@ -91,6 +92,7 @@ func (r *readyzOpts) AddFlags(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.Uint16Var(&r.listenPort, "listen-port", r.listenPort, "Listen on this port. Default 9980")
 	fs.StringSliceVar(&r.cipherSuites, "listen-cipher-suites", r.cipherSuites, "readyZ server TLS cipher suites.")
+	fs.StringVar(&r.tlsMinVersion, "listen-tls-min-version", r.tlsMinVersion, "Minimum TLS version supported by readyZ server. Possible values: TLS1.2, TLS1.3.")
 	fs.DurationVar(&r.dialTimeout, "dial-timeout", r.dialTimeout, "Dial timeout for the client. Default 2s")
 	fs.StringVar(&r.targetEndpoint, "target", r.targetEndpoint, "Target endpoint to perform health check against. Default https://localhost:2379")
 	fs.StringVar(&r.servingCertFile, "serving-cert-file", r.servingCertFile, "Health probe server TLS client certificate file. (required)")
@@ -178,12 +180,19 @@ func (r *readyzOpts) Run() error {
 		return err
 	}
 
+	tlsMinVersion, err := tlsutil.GetTLSVersion(r.tlsMinVersion)
+	if err != nil {
+		cancel()
+		return err
+	}
+
 	httpServer := &http.Server{
 		Addr:        addr,
 		Handler:     mux,
 		BaseContext: func(_ net.Listener) context.Context { return shutdownCtx },
-		TLSConfig:   &tls.Config{CipherSuites: suites},
+		TLSConfig:   &tls.Config{CipherSuites: suites, MinVersion: tlsMinVersion},
 	}
+
 	go func() {
 		defer cancel()
 		<-shutdownHandler

--- a/pkg/etcdenvvar/envvarcontroller_test.go
+++ b/pkg/etcdenvvar/envvarcontroller_test.go
@@ -56,6 +56,7 @@ var (
 		"ETCD_INITIAL_CLUSTER_STATE":                       "existing",
 		"ETCD_QUOTA_BACKEND_BYTES":                         "8589934592",
 		"ETCD_SOCKET_REUSE_ADDRESS":                        "true",
+		"ETCD_TLS_MIN_VERSION":                             "TLS1.2",
 		"NODE_master_0_ETCD_NAME":                          "master-0",
 		"NODE_master_0_ETCD_URL_HOST":                      "192.168.2.0",
 		"NODE_master_0_IP":                                 "192.168.2.0",

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -1,6 +1,7 @@
 package etcdenvvar
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"runtime"
@@ -17,7 +18,9 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/hwspeedhelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-etcd-operator/pkg/tlshelpers"
+	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -75,6 +78,7 @@ var envVarFns = []envVarFunc{
 	getEtcdDBSize,
 	getUnsupportedArch,
 	getCipherSuites,
+	getTLSMinVersion,
 	getMaxLearners,
 }
 
@@ -283,6 +287,39 @@ func getUnsupportedArch(_ envVarContext) (map[string]string, error) {
 	}, nil
 }
 
+func getObservedTLSMinVersion(envVarContext envVarContext) (tlsutil.TLSVersion, error) {
+	var observedConfig map[string]interface{}
+	if err := yaml.Unmarshal(envVarContext.spec.ObservedConfig.Raw, &observedConfig); err != nil {
+		return "", fmt.Errorf("failed to unmarshal the observedConfig: %w", err)
+	}
+	observedMinTLSVersion, _, err := unstructured.NestedString(observedConfig, "servingInfo", "minTLSVersion")
+	if err != nil {
+		return "", fmt.Errorf("couldn't get minTLSVersion from observedConfig: %w", err)
+	}
+
+	// map tls version to string recognized by etcd
+	v, err := crypto.TLSVersion(observedMinTLSVersion)
+	if err != nil {
+		return "", fmt.Errorf("couldn't get minTLSVersion from observedConfig: %w", err)
+	}
+	switch v {
+	case tls.VersionTLS13:
+		return tlsutil.TLSVersion13, nil
+	default:
+		return tlsutil.TLSVersion12, nil
+	}
+}
+
+func getTLSMinVersion(envVarContext envVarContext) (map[string]string, error) {
+	observedMinTLSVersion, err := getObservedTLSMinVersion(envVarContext)
+	if err != nil {
+		return nil, fmt.Errorf("unable to compute ETCD_TLS_MIN_VERSION: %v", err)
+	}
+	return map[string]string{
+		"ETCD_TLS_MIN_VERSION": string(observedMinTLSVersion),
+	}, nil
+}
+
 func getCipherSuites(envVarContext envVarContext) (map[string]string, error) {
 	var observedConfig map[string]interface{}
 	if err := yaml.Unmarshal(envVarContext.spec.ObservedConfig.Raw, &observedConfig); err != nil {
@@ -299,8 +336,19 @@ func getCipherSuites(envVarContext envVarContext) (map[string]string, error) {
 		return nil, fmt.Errorf("no supported cipherSuites not found in observedConfig")
 	}
 
+	observedMinTLSVersion, err := getObservedTLSMinVersion(envVarContext)
+	if err != nil {
+		return nil, fmt.Errorf("unable to compute ETCD_CIPHER_SUITES: %v", err)
+	}
+
+	envName := "ETCD_CIPHER_SUITES"
+	if observedMinTLSVersion == tlsutil.TLSVersion13 {
+		// When --tls-min-version is set to 'TLS1.3', etcd does not allow --cipher-suites to also be specified.
+		// We still outout an env var for informational purposes.
+		envName = "CIPHER_SUITES"
+	}
 	return map[string]string{
-		"ETCD_CIPHER_SUITES": strings.Join(actualCipherSuites, ","),
+		envName: strings.Join(actualCipherSuites, ","),
 	}, nil
 }
 

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1102,9 +1102,9 @@ spec:
       - mountPath: /var/lib/etcd/
         name: data-dir
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
@@ -1167,10 +1167,10 @@ spec:
           --metrics=extensive \
           --listen-metrics-urls=https://{{.ListenAddress}}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
-    {{ end -}}
+    {{- range .EnvVars }}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
+    {{- end }}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
     resources:
@@ -1241,11 +1241,14 @@ spec:
           --cert-file /etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-metrics-NODE_NAME.crt \
           --cacert /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/server-ca-bundle.crt \
           --trusted-ca-file /etc/kubernetes/static-pod-certs/configmaps/etcd-all-bundles/metrics-ca-bundle.crt \
-          --listen-cipher-suites ${ETCD_CIPHER_SUITES}
+        {{- if .CipherSuites }}
+          --listen-cipher-suites {{ .CipherSuites }} \
+          {{ end -}}
+          --tls-min-version $(ETCD_TLS_MIN_VERSION)
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+     {{- range .EnvVars }}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     - name: "ETCD_STATIC_POD_VERSION"
       value: "REVISION"
@@ -1281,7 +1284,10 @@ spec:
           --client-cert-file=$(ETCDCTL_CERT) \
           --client-key-file=$(ETCDCTL_KEY) \
           --client-cacert-file=$(ETCDCTL_CACERT) \
-          --listen-cipher-suites=$(ETCD_CIPHER_SUITES)
+        {{- if .CipherSuites }}
+          --listen-cipher-suites {{ .CipherSuites }} \
+          {{ end -}}
+          --listen-tls-min-version=$(ETCD_TLS_MIN_VERSION)
     securityContext:
       privileged: true
     ports:
@@ -1293,9 +1299,9 @@ spec:
         memory: 50Mi
         cpu: 10m
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     volumeMounts:
       - mountPath: /var/log/etcd/
@@ -1325,9 +1331,9 @@ spec:
         memory: 50Mi
         cpu: 10m
     env:
-    {{ range $i, $k := .EnvVars -}}
-    - name: {{ $k.Name | quote }}
-      value: {{ $k.Value | quote }}
+    {{ range .EnvVars -}}
+    - name: {{ .Name | quote }}
+      value: {{ .Value | quote }}
     {{ end -}}
     volumeMounts:
     - mountPath: /var/lib/etcd

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
 	"reflect"
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
@@ -46,6 +47,7 @@ type PodSubstitutionTemplate struct {
 	EnvVars             []NameValue
 	BackupArgs          []string
 	EnableEtcdContainer bool
+	CipherSuites        string
 }
 
 type TargetConfigController struct {
@@ -227,6 +229,7 @@ func (c *TargetConfigController) getPodSubstitution(operatorSpec *operatorv1.Sta
 		LogLevel:            loglevelToZap(operatorSpec.LogLevel),
 		EnvVars:             nameValues,
 		EnableEtcdContainer: !shouldRemoveEtcdContainer,
+		CipherSuites:        envVarMap["ETCD_CIPHER_SUITES"],
 	}, nil
 }
 


### PR DESCRIPTION
Manually backport https://github.com/openshift/cluster-etcd-operator/pull/1364 to release 4.18