### PR TITLE
OCPEDGE-1920: Comply with OCP pod standards for TNF jobs

### DIFF
--- a/bindata/tnfdeployment/aftersetupjob.yaml
+++ b/bindata/tnfdeployment/aftersetupjob.yaml
@@ -20,15 +20,13 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 128Mi
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
       hostIPC: false
       hostNetwork: false
       hostPID: true
+      priorityClassName: system-node-critical
       serviceAccountName: tnf-setup-manager
       terminationGracePeriodSeconds: 10
       restartPolicy: Never

--- a/bindata/tnfdeployment/authjob.yaml
+++ b/bindata/tnfdeployment/authjob.yaml
@@ -20,15 +20,13 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 128Mi
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
       hostIPC: false
       hostNetwork: false
       hostPID: true
+      priorityClassName: system-node-critical
       serviceAccountName: tnf-setup-manager
       terminationGracePeriodSeconds: 10
       restartPolicy: Never

--- a/bindata/tnfdeployment/setupjob.yaml
+++ b/bindata/tnfdeployment/setupjob.yaml
@@ -20,15 +20,13 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 128Mi
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
       hostIPC: false
       hostNetwork: false
       hostPID: true
+      priorityClassName: system-node-critical
       serviceAccountName: tnf-setup-manager
       terminationGracePeriodSeconds: 10
       restartPolicy: Never

--- a/pkg/tnf/assets/bindata.go
+++ b/pkg/tnf/assets/bindata.go
@@ -83,15 +83,13 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 128Mi
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
       hostIPC: false
       hostNetwork: false
       hostPID: true
+      priorityClassName: system-node-critical
       serviceAccountName: tnf-setup-manager
       terminationGracePeriodSeconds: 10
       restartPolicy: Never
@@ -135,15 +133,13 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 128Mi
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
       hostIPC: false
       hostNetwork: false
       hostPID: true
+      priorityClassName: system-node-critical
       serviceAccountName: tnf-setup-manager
       terminationGracePeriodSeconds: 10
       restartPolicy: Never
@@ -379,15 +375,13 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 128Mi
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
       hostIPC: false
       hostNetwork: false
       hostPID: true
+      priorityClassName: system-node-critical
       serviceAccountName: tnf-setup-manager
       terminationGracePeriodSeconds: 10
       restartPolicy: Never


### PR DESCRIPTION
- remove resource limits
- add priorityClass

Note: I will consider to have 1 job manifest for all TNF jobs, and set the actual name and command dynamically, in order to reduce duplication. Since this is going to be backported to 4.19, I keep the change small here.