### PR TITLE
OCPBUGS-57372: Wait for 2 cp nodes before starting TNF jobs

### DIFF
--- a/pkg/tnf/operator/starter.go
+++ b/pkg/tnf/operator/starter.go
@@ -69,15 +69,37 @@ func HandleDualReplicaClusters(
 	runTnfResourceController(ctx, controllerContext, kubeClient, dynamicClient, operatorClient, kubeInformersForNamespaces)
 
 	// we need node names for assigning auth and after-setup jobs to specific nodes
+	var once sync.Once
 	klog.Infof("watching for nodes...")
 	_, err := controlPlaneNodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			node, ok := obj.(*corev1.Node)
+			_, ok := obj.(*corev1.Node)
 			if !ok {
 				klog.Warningf("failed to convert added object to Node %+v", obj)
 			}
-			runTnfAuthJobController(ctx, node.GetName(), controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces)
-			runTnfAfterSetupJobController(ctx, node.GetName(), controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces)
+			// ensure we have both control plane nodes before creating jobs
+			nodeList, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+				LabelSelector: "node-role.kubernetes.io/master",
+			})
+			if err != nil {
+				klog.Errorf("failed to list nodes while waiting to create TNF jobs: %v", err)
+				return
+			}
+			if len(nodeList.Items) != 2 {
+				klog.Info("not starting TNF jobs yet, waiting for 2 control plane nodes to exist")
+				return
+			}
+			// we can have 2 nodes on the first call of AddFunc already, ensure we create job controllers once only
+			once.Do(func() {
+				klog.Info("found 2 control plane nodes, creating TNF jobs")
+				// the order of job creation does not matter, the jobs wait on each other as needed
+				for _, node := range nodeList.Items {
+					runTnfAuthJobController(ctx, node.GetName(), controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces)
+					runTnfAfterSetupJobController(ctx, node.GetName(), controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces)
+				}
+				runTnfSetupJobController(ctx, controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces)
+				runTnfFencingJobController(ctx, controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces)
+			})
 		},
 	})
 	if err != nil {
@@ -104,9 +126,6 @@ func HandleDualReplicaClusters(
 		klog.Errorf("failed to add eventhandler to secrets informer: %v", err)
 		return false, err
 	}
-
-	runTnfSetupJobController(ctx, controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces)
-	runTnfFencingJobController(ctx, controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces)
 
 	return true, nil
 }

--- a/pkg/tnf/operator/starter.go
+++ b/pkg/tnf/operator/starter.go
@@ -20,9 +20,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -68,32 +70,35 @@ func HandleDualReplicaClusters(
 	runExternalEtcdSupportController(ctx, controllerContext, operatorClient, envVarGetter, kubeInformersForNamespaces, configInformers, networkInformer, controlPlaneNodeInformer, kubeClient)
 	runTnfResourceController(ctx, controllerContext, kubeClient, dynamicClient, operatorClient, kubeInformersForNamespaces)
 
+	controlPlaneNodeLister := corev1listers.NewNodeLister(controlPlaneNodeInformer.GetIndexer())
+
 	// we need node names for assigning auth and after-setup jobs to specific nodes
 	var once sync.Once
 	klog.Infof("watching for nodes...")
 	_, err := controlPlaneNodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			_, ok := obj.(*corev1.Node)
+			node, ok := obj.(*corev1.Node)
 			if !ok {
 				klog.Warningf("failed to convert added object to Node %+v", obj)
-			}
-			// ensure we have both control plane nodes before creating jobs
-			nodeList, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-				LabelSelector: "node-role.kubernetes.io/master",
-			})
-			if err != nil {
-				klog.Errorf("failed to list nodes while waiting to create TNF jobs: %v", err)
 				return
 			}
-			if len(nodeList.Items) != 2 {
+			klog.Infof("node added: %s", node.GetName())
+
+			// ensure we have both control plane nodes before creating jobs
+			nodeList, err := controlPlaneNodeLister.List(labels.Everything())
+			if err != nil {
+				klog.Errorf("failed to list control plane nodes while waiting to create TNF jobs: %v", err)
+				return
+			}
+			if len(nodeList) != 2 {
 				klog.Info("not starting TNF jobs yet, waiting for 2 control plane nodes to exist")
 				return
 			}
 			// we can have 2 nodes on the first call of AddFunc already, ensure we create job controllers once only
 			once.Do(func() {
-				klog.Info("found 2 control plane nodes, creating TNF jobs")
+				klog.Infof("found 2 control plane nodes (%q, %q), creating TNF jobs", nodeList[0].GetName(), nodeList[1].GetName())
 				// the order of job creation does not matter, the jobs wait on each other as needed
-				for _, node := range nodeList.Items {
+				for _, node := range nodeList {
 					runTnfAuthJobController(ctx, node.GetName(), controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces)
 					runTnfAfterSetupJobController(ctx, node.GetName(), controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces)
 				}

--- a/pkg/tnf/pkg/config/cluster.go
+++ b/pkg/tnf/pkg/config/cluster.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,9 +25,14 @@ func GetClusterConfig(ctx context.Context, kubeClient kubernetes.Interface) (Clu
 	clusterCfg := ClusterConfig{}
 
 	// Get nodes
-	nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: "node-role.kubernetes.io/master",
+	})
 	if err != nil {
 		return clusterCfg, err
+	}
+	if len(nodes.Items) != 2 {
+		return clusterCfg, fmt.Errorf("expected 2 nodes, got %d", len(nodes.Items))
 	}
 
 	sort.Slice(nodes.Items, func(i, j int) bool {

--- a/pkg/tnf/pkg/config/cluster_test.go
+++ b/pkg/tnf/pkg/config/cluster_test.go
@@ -80,6 +80,29 @@ func TestGetClusterConfig(t *testing.T) {
 			want:    ClusterConfig{},
 			wantErr: true,
 		},
+		{
+			name: "one control plane node only should fail",
+			args: getArgs(t, []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/master": "",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test2",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/no-master": "",
+						},
+					},
+				},
+			}),
+			want:    ClusterConfig{},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/tnf/pkg/config/cluster_test.go
+++ b/pkg/tnf/pkg/config/cluster_test.go
@@ -17,6 +17,7 @@ type args struct {
 }
 
 func TestGetClusterConfig(t *testing.T) {
+
 	tests := []struct {
 		name    string
 		args    args
@@ -29,6 +30,9 @@ func TestGetClusterConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test1",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/master": "",
+						},
 					},
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{
@@ -41,6 +45,9 @@ func TestGetClusterConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test2",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/master": "",
+						},
 					},
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{
@@ -58,6 +65,21 @@ func TestGetClusterConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "one node only should fail",
+			args: getArgs(t, []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/master": "",
+						},
+					},
+				},
+			}),
+			want:    ClusterConfig{},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -68,6 +90,12 @@ func TestGetClusterConfig(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetClusterConfig() got = %v, want %v", got, tt.want)
+			}
+			// delete nodes
+			c := tt.args.kubeClient
+			nodes, _ := c.CoreV1().Nodes().List(tt.args.ctx, metav1.ListOptions{})
+			for _, node := range nodes.Items {
+				c.CoreV1().Nodes().Delete(tt.args.ctx, node.Name, metav1.DeleteOptions{})
 			}
 		})
 	}


### PR DESCRIPTION
When being installed with assisted installer, the 1st auth job  is already created when 1 cp node is available only. Wait with the job creation until both nodes exist, ensure jobs are created once only, and double check node count inside jobs.