### PR TITLE
CNTRLPLANE-806: Explicitly use podman-etcd from two-node-ha extension

### DIFF
--- a/pkg/tnf/pkg/pcs/etcd.go
+++ b/pkg/tnf/pkg/pcs/etcd.go
@@ -22,7 +22,7 @@ func ConfigureEtcd(ctx context.Context, cfg config.ClusterConfig) error {
 	}
 	if !strings.Contains(stdOut, "etcd") {
 		klog.Info("Creating etcd resource")
-		cmd := fmt.Sprintf("/usr/sbin/pcs resource create etcd podman-etcd node_ip_map=\"%s:%s;%s:%s\" drop_in_dependency=true clone interleave=true notify=true",
+		cmd := fmt.Sprintf("/usr/sbin/pcs resource create etcd ocf:heartbeat:podman-etcd node_ip_map=\"%s:%s;%s:%s\" drop_in_dependency=true clone interleave=true notify=true",
 			cfg.NodeName1, cfg.NodeIP1, cfg.NodeName2, cfg.NodeIP2)
 		stdOut, stdErr, err = exec.Execute(ctx, cmd)
 		if err != nil || len(stdErr) > 0 {


### PR DESCRIPTION
Use the podman-etcd agent installed by the `two-node-ha` extension instead of the one installed by MCO/RHCOS symlink