### PR TITLE
Use 0700 perms for etcd data dir

### DIFF
--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -306,13 +306,13 @@ func (r *renderOpts) Run() error {
 	certDir := filepath.Join(memberDir, "etcd-all-certs")
 
 	// Creating the cert dir recursively will create the base path too
-	err = os.MkdirAll(certDir, 0755)
+	err = os.MkdirAll(certDir, 0700)
 	if err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", memberDir, err)
 	}
 	// tlsDir contains the ca bundle and client cert pair for bootkube.sh and the bootstrap apiserver
 	tlsDir := filepath.Join(r.assetOutputDir, "tls")
-	err = os.MkdirAll(tlsDir, 0755)
+	err = os.MkdirAll(tlsDir, 0700)
 
 	// Write the etcd ca bundle required by the bootstrap etcd member
 	for _, bundle := range templateData.caBundles {

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -2626,7 +2626,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
+	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0700))
 	if err != nil {
 		return err
 	}

--- a/pkg/tnf/assets/bindata.go
+++ b/pkg/tnf/assets/bindata.go
@@ -585,7 +585,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
+	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0700))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently the cluster etcd operator creates `0755` permissions for `/var/lib/etcd` by default:

```
$ oc debug node/ip-10-0-22-132.ap-southeast-2.compute.internal
sh-5.1# ls -l /host/var/lib/ | grep etcd
drwxr-xr-x.  3 root root     41 Jul  4 03:09 etcd
```
Upstream etcd uses 0700: https://github.com/etcd-io/etcd/blob/866bc0717c0b56579514c7363f3f47f6cd4109c6/client/pkg/fileutil/fileutil.go#L47

And the OpenShift CIS benchmark requires that the `/var/lib/etcd` data dir is configured with `0700` file permissions: https://github.com/ComplianceAsCode/content/blob/24dba6b94757881c8d8e0dd21390fa733a7c3b70/applications/openshift/master/file_permissions_var_lib_etcd/rule.yml#L28

This change aligns the cluster etcd operator with upstream and the CIS benchmark for OpenShift.