### PR TITLE
OCPBUGS-58428: fix: update limits and priority class

### DIFF
--- a/bindata/tnfdeployment/fencingjob.yaml
+++ b/bindata/tnfdeployment/fencingjob.yaml
@@ -20,15 +20,13 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 128Mi
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
       hostIPC: false
       hostNetwork: false
       hostPID: true
+      priorityClassName: system-node-critical
       serviceAccountName: tnf-setup-manager
       terminationGracePeriodSeconds: 10
       restartPolicy: Never

--- a/pkg/tnf/assets/bindata.go
+++ b/pkg/tnf/assets/bindata.go
@@ -273,15 +273,13 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 128Mi
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
       hostIPC: false
       hostNetwork: false
       hostPID: true
+      priorityClassName: system-node-critical
       serviceAccountName: tnf-setup-manager
       terminationGracePeriodSeconds: 10
       restartPolicy: Never


### PR DESCRIPTION
updated the pirority class for fencing job to include system-node-critical since it is a node critical component 
removed limits definition per guidelines on platform pods