### PR TITLE
OCPBUGS-50488: add missing ports to svc and pod spec

### DIFF
--- a/bindata/etcd/pod.gotpl.yaml
+++ b/bindata/etcd/pod.gotpl.yaml
@@ -195,6 +195,16 @@ spec:
           --listen-peer-urls=https://{{.ListenAddress}}:2380 \
           --metrics=extensive \
           --listen-metrics-urls=https://{{.ListenAddress}}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
+    ports:
+    - containerPort: 2379
+      name: etcd
+      protocol: TCP
+    - containerPort: 2380
+      name: etcd-peer
+      protocol: TCP
+    - containerPort: 9978
+      name: etcd-metrics
+      protocol: TCP
     env:
     {{- range .EnvVars }}
     - name: {{ .Name | quote }}
@@ -274,6 +284,10 @@ spec:
           --listen-cipher-suites {{ .CipherSuites }} \
           {{ end -}}
           --tls-min-version $(ETCD_TLS_MIN_VERSION)
+    ports:
+    - containerPort: 9979
+      name: proxy-metrics
+      protocol: TCP
     env:
     {{- range .EnvVars }}
     - name: {{ .Name | quote }}

--- a/bindata/etcd/svc.yaml
+++ b/bindata/etcd/svc.yaml
@@ -17,6 +17,15 @@ spec:
     - name: etcd
       port: 2379
       protocol: TCP
+    - name: etcd-peer
+      port: 2380
+      protocol: TCP
+    - name: grpc-proxy
+      port: 9978
+      protocol: TCP
     - name: etcd-metrics
       port: 9979
+      protocol: TCP
+    - name: readyz-sidecar
+      port: 9980
       protocol: TCP

--- a/pkg/operator/etcd_assets/bindata.go
+++ b/pkg/operator/etcd_assets/bindata.go
@@ -1191,6 +1191,16 @@ spec:
           --listen-peer-urls=https://{{.ListenAddress}}:2380 \
           --metrics=extensive \
           --listen-metrics-urls=https://{{.ListenAddress}}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
+    ports:
+    - containerPort: 2379
+      name: etcd
+      protocol: TCP
+    - containerPort: 2380
+      name: etcd-peer
+      protocol: TCP
+    - containerPort: 9978
+      name: etcd-metrics
+      protocol: TCP
     env:
     {{- range .EnvVars }}
     - name: {{ .Name | quote }}
@@ -1270,6 +1280,10 @@ spec:
           --listen-cipher-suites {{ .CipherSuites }} \
           {{ end -}}
           --tls-min-version $(ETCD_TLS_MIN_VERSION)
+    ports:
+    - containerPort: 9979
+      name: proxy-metrics
+      protocol: TCP
     env:
     {{- range .EnvVars }}
     - name: {{ .Name | quote }}
@@ -2443,8 +2457,17 @@ spec:
     - name: etcd
       port: 2379
       protocol: TCP
+    - name: etcd-peer
+      port: 2380
+      protocol: TCP
+    - name: grpc-proxy
+      port: 9978
+      protocol: TCP
     - name: etcd-metrics
       port: 9979
+      protocol: TCP
+    - name: readyz-sidecar
+      port: 9980
       protocol: TCP
 `)
 


### PR DESCRIPTION
To help with the commatrix project, we were asked to document the ports that we expose to the outside world. This adds the missing ports to the service and the respective container.

Note that container ports on pod specs are just informational, they do not expose/block access.