### PR TITLE
OCPBUGS-59153: configure 30s min ready duration on static pods

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -334,6 +334,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		WithRevisionedResources("openshift-etcd", "etcd", RevisionConfigMaps, RevisionSecrets).
 		WithUnrevisionedCerts("etcd-certs", CertConfigMaps, CertSecrets).
 		WithVersioning("etcd", versionRecorder).
+		WithMinReadyDuration(30*time.Second).
 		WithPodDisruptionBudgetGuard(
 			"openshift-etcd-operator",
 			"etcd-operator",


### PR DESCRIPTION
testing whether this has a noticeable effect on the static pod failures