### PR TITLE
OCPBUGS-44570: add missing informer syncs

### DIFF
--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
@@ -52,6 +52,7 @@ func NewBootstrapTeardownController(
 	return factory.New().ResyncEvery(time.Minute).WithInformers(
 		operatorClient.Informer(),
 		kubeInformersForNamespaces.InformersFor("kube-system").Core().V1().ConfigMaps().Informer(),
+		kubeInformersForNamespaces.InformersFor("").Core().V1().Namespaces().Informer(),
 	).WithSync(syncer.Sync).ToController("BootstrapTeardownController", c.eventRecorder)
 }
 

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -96,6 +96,8 @@ func NewClusterMemberRemovalController(
 			masterNodeInformer,
 			masterMachineInformer,
 			kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer(),
+			// IsBootstrapComplete() accesses the "kube-system" namespace, so we need this informer to sync
+			kubeInformersForNamespaces.InformersFor("kube-system").Core().V1().ConfigMaps().Informer(),
 		).ToController("ClusterMemberRemovalController", eventRecorder.WithComponentSuffix("cluster-member-removal-controller"))
 }
 

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go
@@ -56,6 +56,7 @@ func NewEtcdEndpointsController(
 	return factory.New().ResyncEvery(time.Minute).WithInformers(
 		operatorClient.Informer(),
 		kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer(),
+		kubeInformers.InformersFor("kube-system").Core().V1().ConfigMaps().Informer(),
 	).WithSync(syncer.Sync).ToController("EtcdEndpointsController", eventRecorder.WithComponentSuffix("etcd-endpoints-controller"))
 }
 

--- a/pkg/operator/scriptcontroller/scriptcontroller.go
+++ b/pkg/operator/scriptcontroller/scriptcontroller.go
@@ -11,7 +11,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -22,30 +21,26 @@ import (
 
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdenvvar"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/etcd_assets"
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 )
 
 type ScriptController struct {
-	operatorClient  v1helpers.StaticPodOperatorClient
-	kubeClient      kubernetes.Interface
-	configMapLister corev1listers.ConfigMapLister
-	envVarGetter    *etcdenvvar.EnvVarController
-	enqueueFn       func()
+	operatorClient v1helpers.StaticPodOperatorClient
+	kubeClient     kubernetes.Interface
+	envVarGetter   *etcdenvvar.EnvVarController
+	enqueueFn      func()
 }
 
 func NewScriptControllerController(
 	livenessChecker *health.MultiAlivenessChecker,
 	operatorClient v1helpers.StaticPodOperatorClient,
 	kubeClient kubernetes.Interface,
-	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	envVarGetter *etcdenvvar.EnvVarController,
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &ScriptController{
-		operatorClient:  operatorClient,
-		kubeClient:      kubeClient,
-		configMapLister: kubeInformersForNamespaces.ConfigMapLister(),
-		envVarGetter:    envVarGetter,
+		operatorClient: operatorClient,
+		kubeClient:     kubeClient,
+		envVarGetter:   envVarGetter,
 	}
 	envVarGetter.AddListener(c)
 
@@ -59,7 +54,6 @@ func NewScriptControllerController(
 
 	return factory.New().WithSyncContext(syncCtx).ResyncEvery(time.Minute).WithInformers(
 		operatorClient.Informer(),
-		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Informer(),
 	).WithSync(syncer.Sync).ToController("ScriptController", syncCtx.Recorder())
 }
 

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -266,7 +266,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	)
 
 	quorumChecker := ceohelpers.NewQuorumChecker(
-		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Namespaces().Lister(),
+		kubeInformersForNamespaces.InformersFor("").Core().V1().Namespaces().Lister(),
 		configInformers.Config().V1().Infrastructures().Lister(),
 		operatorClient,
 		cachedMemberClient)
@@ -461,7 +461,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		AlivenessChecker,
 		operatorClient,
 		kubeClient,
-		kubeInformersForNamespaces,
 		envVarController,
 		controllerContext.EventRecorder,
 	)


### PR DESCRIPTION
During apiserver/etcd downtime we may have problematic error messages like "openshift-etcd not found". This is caused by the ns lister not being synchronized yet, thus having an internal empty list to serve from. Queries will return not found for namespaces that definitely exists for this brief period of time.

This fix cleans up several informers that we have missed and cleans up some that we don't need.

Be extra careful when reviewing, this PR was created with AI.