### PR TITLE
OCPBUGS-57859: Updating cluster-etcd-operator-container image to be consistent with ART for 4.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.20

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-etcd-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-etcd-operator
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/bindata/bootkube/bootstrap-manifests /usr/share/bootkube/manifests/bootstrap-manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/bindata/bootkube/manifests /usr/share/bootkube/manifests/manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-etcd-operator/cluster-etcd-operator /usr/bin/

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/cluster-etcd-operator
 
-go 1.23.0
-
-toolchain go1.23.5
+go 1.24
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/pkg/cmd/request-backup/requestbackup.go
+++ b/pkg/cmd/request-backup/requestbackup.go
@@ -96,16 +96,16 @@ func (r *requestBackupOpts) ReadEnvVars() error {
 func (r *requestBackupOpts) Run(ctx context.Context) error {
 	if r.pvcName == "" {
 		errMsg := "pvcName must be specified to execute a backup request"
-		klog.Errorf(errMsg)
-		return fmt.Errorf(errMsg)
+		klog.Error(errMsg)
+		return fmt.Errorf("%s", errMsg)
 	}
 
 	// ReadEnvVars reads the env vars necessary to populate the ownerReference
 	// and name for the EtcdBackup CR.
 	if err := r.ReadEnvVars(); err != nil {
 		errMsg := fmt.Sprintf("failed to read pod envvars %v", err)
-		klog.Errorf(errMsg)
-		return fmt.Errorf(errMsg)
+		klog.Error(errMsg)
+		return fmt.Errorf("%s", errMsg)
 	}
 
 	// handle teardown

--- a/pkg/operator/defragcontroller/defragcontroller.go
+++ b/pkg/operator/defragcontroller/defragcontroller.go
@@ -190,7 +190,7 @@ func (c *DefragController) runDefrag(ctx context.Context, recorder events.Record
 				// Defrag can timeout if defragmentation takes longer than etcdcli.DefragDialTimeout.
 				errMsg := fmt.Sprintf("failed defrag on member: %s, memberID: %x: %v", member.Name, member.ID, err)
 				recorder.Eventf("DefragControllerDefragmentFailed", errMsg)
-				errors = append(errors, fmt.Errorf(errMsg))
+				errors = append(errors, fmt.Errorf("%s", errMsg))
 				continue
 			}
 

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
@@ -88,7 +88,7 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 						actual := createAction.GetObject().(*corev1.ConfigMap)
 						expected := u.EndpointsConfigMap(endpoints...)
 						if !equality.Semantic.DeepEqual(actual, expected) {
-							ts.Errorf(diff.ObjectDiff(expected, actual))
+							ts.Errorf("%s", diff.ObjectDiff(expected, actual))
 						}
 					}
 				}
@@ -123,7 +123,7 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 						actual := updateAction.GetObject().(*corev1.ConfigMap)
 						expected := u.EndpointsConfigMap(endpoints...)
 						if !equality.Semantic.DeepEqual(actual, expected) {
-							ts.Errorf(diff.ObjectDiff(expected, actual))
+							ts.Errorf("%s", diff.ObjectDiff(expected, actual))
 						}
 						wasValidated = true
 						break
@@ -257,7 +257,7 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 						actual := updateAction.GetObject().(*corev1.ConfigMap)
 						expected := u.EndpointsConfigMap(endpoints...)
 						if !equality.Semantic.DeepEqual(actual, expected) {
-							ts.Errorf(diff.ObjectDiff(expected, actual))
+							ts.Errorf("%s", diff.ObjectDiff(expected, actual))
 						}
 						wasValidated = true
 						break
@@ -295,7 +295,7 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 						actual := createAction.GetObject().(*corev1.ConfigMap)
 						expected := u.EndpointsConfigMap(endpoints...)
 						if !equality.Semantic.DeepEqual(actual, expected) {
-							ts.Errorf(diff.ObjectDiff(expected, actual))
+							ts.Errorf("%s", diff.ObjectDiff(expected, actual))
 						}
 						wasValidated = true
 						break


### PR DESCRIPTION
replaces #1436 

Fixes the go vet issues that popped up with the go version update.
Careful review, vet issues were fixed by AI, those are in a separate commit