### PR TITLE
Bug: Fix alert generation diff on `main`

### DIFF
--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -132,9 +132,9 @@ spec:
         histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method!="Defragment", grpc_type="unary"}[10m])) without(grpc_type))
         > on () group_left (type)
         bottomk(1,
-        1.5 * group by (type) (cluster_infrastructure_provider{type="Azure"})
-        or
-        1 * group by (type) (cluster_infrastructure_provider))
+          1.5 * group by (type) (cluster_infrastructure_provider{type="Azure"})
+          or
+          1 * group by (type) (cluster_infrastructure_provider))
       for: 30m
       labels:
         severity: critical


### PR DESCRIPTION
In https://github.com/openshift/cluster-etcd-operator/pull/1422, the `etcdHighCommitDurations` alert had it's expression modified directly in the generated rules yaml file. As far as I can tell, this breaks rule generation, and should be reflected in the jsonnet instead.

This, with the help of Claude, handles this specific alert override. Albeit, it's a bit ugly, but opening this to validate if you expected this to drift or not. I am working on adding some alerts and would like to start from a clean generation on `main`.

Note: The diff in the manifests now is just from, my guess, a newer `gojsontoyaml` version.

We should probably run this diff check in CI as well?

# Diff on main right now
```diff
 git diff
diff --git a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
index 02f89a6e5..e77641e1f 100644
--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -83,12 +83,7 @@ spec:
         summary: etcd cluster 99th percentile commit durations are too high.
       expr: |
         histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
-        > on () group_left (type)
-        bottomk(0.25,
-        0.5 * group by (type) (cluster_infrastructure_provider{type="Azure"})
-        or
-        0.25 * group by (type) (cluster_infrastructure_provider)
-        )
+        > 0.25
       for: 10m
       labels:
         severity: warning
@@ -132,9 +127,9 @@ spec:
         histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method!="Defragment", grpc_type="unary"}[10m])) without(grpc_type))
         > on () group_left (type)
         bottomk(1,
-        1.5 * group by (type) (cluster_infrastructure_provider{type="Azure"})
-        or
-        1 * group by (type) (cluster_infrastructure_provider))
+          1.5 * group by (type) (cluster_infrastructure_provider{type="Azure"})
+          or
+          1 * group by (type) (cluster_infrastructure_provider))
       for: 30m
       labels:
         severity: critical
```