### PR TITLE
OCPEDGE-1998: TNF: Use `pcmk_delay_base` on 1st fence device to prevent fencing races

### DIFF
--- a/pkg/tnf/pkg/pcs/fencing_test.go
+++ b/pkg/tnf/pkg/pcs/fencing_test.go
@@ -205,6 +205,41 @@ func TestGetStonithCommand(t *testing.T) {
 			want: `/usr/sbin/pcs stonith create node2_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.2" ipport="8000" systems_uri="redfish/v1/Systems/def" pcmk_host_list="node2" ssl_insecure="1" --wait=30`,
 		},
 		{
+			name: "stonith command with pcmk_delay_base",
+			fc: fencingConfig{
+				NodeName:          "node1",
+				FencingID:         "node1_redfish",
+				FencingDeviceType: "fence_redfish",
+				FencingDeviceOptions: map[fencingOption]string{
+					Username:      "admin",
+					Password:      "pass123",
+					Ip:            "192.168.111.1",
+					IpPort:        "8000",
+					SystemsUri:    "redfish/v1/Systems/abc",
+					PcmkDelayBase: "10s",
+				},
+			},
+			want: `/usr/sbin/pcs stonith create node1_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.1" ipport="8000" systems_uri="redfish/v1/Systems/abc" pcmk_host_list="node1" pcmk_delay_base="10s" --wait=30`,
+		},
+		{
+			name: "stonith command with both ssl_insecure and pcmk_delay_base",
+			fc: fencingConfig{
+				NodeName:          "node3",
+				FencingID:         "node3_redfish",
+				FencingDeviceType: "fence_redfish",
+				FencingDeviceOptions: map[fencingOption]string{
+					Username:      "admin",
+					Password:      "pass123",
+					Ip:            "192.168.111.3",
+					IpPort:        "8000",
+					SystemsUri:    "redfish/v1/Systems/ghi",
+					SslInsecure:   "",
+					PcmkDelayBase: "10s",
+				},
+			},
+			want: `/usr/sbin/pcs stonith create node3_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.3" ipport="8000" systems_uri="redfish/v1/Systems/ghi" pcmk_host_list="node3" ssl_insecure="1" pcmk_delay_base="10s" --wait=30`,
+		},
+		{
 			name: "stonith command with existing device",
 			sc: StonithConfig{
 				Primitives: []Primitive{
@@ -487,6 +522,124 @@ func TestCanFencingConfigBeSkipped(t *testing.T) {
 									{
 										Name:  "pcmk_host_list",
 										Value: "node1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "needs update for missing pcmk_delay_base",
+			fc: fencingConfig{
+				NodeName:          "node1",
+				FencingID:         "node1_redfish",
+				FencingDeviceType: "fence_redfish",
+				FencingDeviceOptions: map[fencingOption]string{
+					Username:      "admin",
+					Password:      "pass123",
+					Ip:            "192.168.111.1",
+					IpPort:        "8000",
+					SystemsUri:    "redfish/v1/Systems/abc",
+					PcmkDelayBase: "10s",
+				},
+			},
+			sc: StonithConfig{
+				Primitives: []Primitive{
+					{
+						Id: "node1_redfish",
+						AgentName: AgentName{
+							Type: "fence_redfish",
+						},
+						InstanceAttributes: []InstanceAttributes{
+							{
+								NvPairs: []NvPair{
+									{
+										Name:  "username",
+										Value: "admin",
+									},
+									{
+										Name:  "password",
+										Value: "pass123",
+									},
+									{
+										Name:  "ip",
+										Value: "192.168.111.1",
+									},
+									{
+										Name:  "ipport",
+										Value: "8000",
+									},
+									{
+										Name:  "systems_uri",
+										Value: "redfish/v1/Systems/abc",
+									},
+									{
+										Name:  "pcmk_host_list",
+										Value: "node1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "can be skipped with pcmk_delay_base",
+			fc: fencingConfig{
+				NodeName:          "node1",
+				FencingID:         "node1_redfish",
+				FencingDeviceType: "fence_redfish",
+				FencingDeviceOptions: map[fencingOption]string{
+					Username:      "admin",
+					Password:      "pass123",
+					Ip:            "192.168.111.1",
+					IpPort:        "8000",
+					SystemsUri:    "redfish/v1/Systems/abc",
+					PcmkDelayBase: "10s",
+				},
+			},
+			sc: StonithConfig{
+				Primitives: []Primitive{
+					{
+						Id: "node1_redfish",
+						AgentName: AgentName{
+							Type: "fence_redfish",
+						},
+						InstanceAttributes: []InstanceAttributes{
+							{
+								NvPairs: []NvPair{
+									{
+										Name:  "username",
+										Value: "admin",
+									},
+									{
+										Name:  "password",
+										Value: "pass123",
+									},
+									{
+										Name:  "ip",
+										Value: "192.168.111.1",
+									},
+									{
+										Name:  "ipport",
+										Value: "8000",
+									},
+									{
+										Name:  "systems_uri",
+										Value: "redfish/v1/Systems/abc",
+									},
+									{
+										Name:  "pcmk_host_list",
+										Value: "node1",
+									},
+									{
+										Name:  "pcmk_delay_base",
+										Value: "10s",
 									},
 								},
 							},


### PR DESCRIPTION
see https://access.redhat.com/solutions/54829
