### PR TITLE
NO-JIRA: hack/generate.sh provides helpful errors when missing tools

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 set -eu
 
+if ! command -v jsonnet &> /dev/null; then
+  echo "jsonnet could not be found. See https://github.com/google/jsonnet"
+  exit 1
+fi
+
 if ! command -v jb &> /dev/null; then
   echo "jb could not be found. See https://github.com/jsonnet-bundler/jsonnet-bundler"
+  exit 1
+fi
+
+if ! command -v gojsontoyaml &> /dev/null; then
+  echo "gojsontoyaml could not be found. See https://github.com/brancz/gojsontoyaml"
   exit 1
 fi
 


### PR DESCRIPTION
Similar to what was done for `jb`, add guards for when `jsonnet` or `gojsontoyaml` are missing for template generation.