### PR TITLE
Add priority field to prevent early shutdown

### DIFF
--- a/bindata/etcd/pod.gotpl.yaml
+++ b/bindata/etcd/pod.gotpl.yaml
@@ -409,6 +409,7 @@ spec:
     - mountPath: /tmp
       name: tmp-dir
   hostNetwork: true
+  priority: 2000001000
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"


### PR DESCRIPTION
Based on the issue described here : https://github.com/kubernetes/kubernetes/issues/133442

priorityClassName is currently ignored by Kubelet for static pod files so setting this value has no impact on the gracefulShutdown order causing the static pods to start to be killed as soon as shutdown begins.

To prevent this we must set priority explicitly