### PR TITLE
NO-JIRA: Use secure cipher suites

### DIFF
--- a/manifests/0000_20_etcd-operator_03_configmap.yaml
+++ b/manifests/0000_20_etcd-operator_03_configmap.yaml
@@ -10,6 +10,16 @@ data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1
     kind: GenericOperatorConfig
+    servingInfo:
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      minTLSVersion: VersionTLS12
+
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
As the ceo log shows it uses `insecure cipher` suites:
```
I0901 17:56:20.859237       1 cmd.go:240] Using service-serving-cert provided certificates
I0901 17:56:20.859300       1 leaderelection.go:121] The leader election gives 4 retries and allows for 30s of clock skew. The kube-apiserver downtime tolerance is 78s. Worst non-graceful lease acquisition is 2m43s. Worst graceful lease acquisition is {26s}.
I0901 17:56:20.860178       1 profiler.go:21] Starting profiling endpoint at http://127.0.0.1:6060/debug/pprof/
I0901 17:56:20.860320       1 observer_polling.go:159] Starting file observer
I0901 17:56:20.860533       1 observer_polling.go:159] Starting file observer
I0901 17:56:20.899182       1 builder.go:298] openshift-cluster-etcd-operator version -
I0901 17:56:21.404722       1 secure_serving.go:57] Forcing use of http/1.1 only
W0901 17:56:21.404742       1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256' detected.
W0901 17:56:21.404747       1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256' detected.
```

maybe the ceo should run in secure cipher, just like the etcd 