### PR TITLE
[release-4.17] OCPBUGS-61235: Vendor latest mixin, including additional and modified alerts for etcdDatabaseQuotaLowSpace

### DIFF
--- a/jsonnet/custom.libsonnet
+++ b/jsonnet/custom.libsonnet
@@ -5,6 +5,42 @@
         name: 'openshift-etcd.rules',
         rules: [
           {
+            alert: 'etcdDatabaseQuotaLowSpace',
+            expr: '(last_over_time(etcd_mvcc_db_total_size_in_bytes{job=~".*etcd.*"}[5m]) / last_over_time(etcd_server_quota_backend_bytes{job=~".*etcd.*"}[5m]))*100 > 65',
+            'for': '10m',
+            labels: {
+              severity: 'info',
+            },
+            annotations: {
+              description: 'etcd cluster "{{ $labels.job }}": database size is 65% of the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.',
+              summary: 'etcd cluster database is using >= 65% of the defined quota.',
+            },
+          },
+          {
+            alert: 'etcdDatabaseQuotaLowSpace',
+            expr: '(last_over_time(etcd_mvcc_db_total_size_in_bytes{job=~".*etcd.*"}[5m]) / last_over_time(etcd_server_quota_backend_bytes{job=~".*etcd.*"}[5m]))*100 > 75',
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'etcd cluster "{{ $labels.job }}": database size is 75% of the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.',
+              summary: 'etcd cluster database is using >= 75% of the defined quota.',
+            },
+          },
+          {
+            alert: 'etcdDatabaseQuotaLowSpace',
+            expr: '(last_over_time(etcd_mvcc_db_total_size_in_bytes{job=~".*etcd.*"}[5m]) / last_over_time(etcd_server_quota_backend_bytes{job=~".*etcd.*"}[5m]))*100 > 85',
+            'for': '10m',
+            labels: {
+                severity: 'critical',
+            },
+            annotations: {
+                description: 'etcd cluster "{{ $labels.job }}": database size is 85% of the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.',
+                summary: 'etcd cluster database is running full.',
+            },
+          },
+          {
             alert: 'etcdGRPCRequestsSlow',
             expr: |||
               histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method!="Defragment", grpc_type="unary"}[10m])) without(grpc_type))
@@ -17,6 +53,18 @@
             annotations: {
               description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC requests is {{ $value }}s on etcd instance {{ $labels.instance }} for {{ $labels.grpc_method }} method.',
               summary: 'etcd grpc requests are slow',
+            },
+          },
+          {
+            alert: 'etcdHighCommitDurations',
+            expr: 'histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[5m])) > 0.5',
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.',
+              summary: 'etcd cluster 99th percentile commit durations are too high.',
             },
           },
           {
@@ -75,6 +123,27 @@
               description: 'etcd is reporting fewer instances are available than are needed ({{ $value }}). When etcd does not have a majority of instances available the Kubernetes and OpenShift APIs will reject read and write requests and operations that preserve the health of workloads cannot be performed. This can occur when multiple control plane nodes are powered off or are unable to connect to each other via the network. Check that all control plane nodes are powered on and that network connections between each machine are functional.',
               summary: 'etcd is reporting that a majority of instances are unavailable.',
             },
+            labels: {
+              severity: 'critical',
+            },
+          },
+          {
+            alert: 'etcdMembersDown',
+            annotations: {
+              description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value }}).',
+              summary: 'etcd cluster members are down.',
+            },
+            expr: |||
+              max without (endpoint) (
+                  sum without (instance) (up{job=~".*etcd.*"} == bool 0)
+              or
+                count without (To) (
+                  sum without (instance) (rate(etcd_network_peer_sent_failures_total{job=~".*etcd.*"}[120s])) > 0.01
+                )
+              )
+              > 0
+            |||,
+            'for': '20m',
             labels: {
               severity: 'critical',
             },

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "d6c0127d264d18255090b4a51e04c5b8e84d5a05",
-      "sum": "IXI3LQIT9NmTPJAk8WLUJd5+qZfcGpeNCyWIK7oEpws="
+      "version": "c218423621d0f574b709a2c5920970669e00f21c",
+      "sum": "XmXkOCriQIZmXwlIIFhqlJMa0e6qGWdxZD+ZDYaN0Po="
     },
     {
       "source": {
@@ -18,7 +18,7 @@
           "subdir": "gen/grafonnet-v10.0.0"
         }
       },
-      "version": "5a66b0f6a0f4f7caec754dd39a0e263b56a0f90a",
+      "version": "5a8f3d6aa89b7e7513528371d2d1265aedc844bc",
       "sum": "xdcrJPJlpkq4+5LpGwN4tPAuheNNLXZjE6tDcyvFjr0="
     },
     {
@@ -38,8 +38,8 @@
           "subdir": ""
         }
       },
-      "version": "63d430b69a95741061c2f7fc9d84b1a778511d9c",
-      "sum": "qiZi3axUSXCVzKUF83zSAxklwrnitMmrDK4XAfjPMdE="
+      "version": "4eee017d21cb63a303925d1dcd9fc5c496809b46",
+      "sum": "Kh0GbIycNmJPzk6IOMXn1BbtLNyaiiimclYk7+mvsns="
     }
   ],
   "legacyImports": false

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -6,7 +6,7 @@ local promRules = if std.objectHasAll(etcdMixin, 'prometheusRules') then etcdMix
 
 // Exclude rules that are either OpenShift specific or do not work for OpenShift.
 // List should be ordered!
-local excludedAlerts = ['etcdGRPCRequestsSlow', 'etcdHighNumberOfFailedGRPCRequests', 'etcdHighNumberOfLeaderChanges', 'etcdInsufficientMembers'];
+local excludedAlerts = ['etcdDatabaseQuotaLowSpace', 'etcdGRPCRequestsSlow', 'etcdHighCommitDurations', 'etcdHighNumberOfFailedGRPCRequests', 'etcdHighNumberOfLeaderChanges', 'etcdInsufficientMembers', 'etcdMembersDown'];
 local excludeRules = std.map(
   function(group) group {
     rules: std.filter(

--- a/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/alerts/alerts.libsonnet
@@ -16,9 +16,9 @@
               )
               > 0
             ||| % { etcd_instance_labels: $._config.etcd_instance_labels, etcd_selector: $._config.etcd_selector, network_failure_range: $._config.scrape_interval_seconds * 4 },
-            'for': '10m',
+            'for': '20m',
             labels: {
-              severity: 'critical',
+              severity: 'warning',
             },
             annotations: {
               description: 'etcd cluster "{{ $labels.%s }}": members are down ({{ $value }}).' % $._config.clusterLabel,

--- a/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/test.yaml
+++ b/jsonnet/vendor/github.com/etcd-io/etcd/contrib/mixin/test.yaml
@@ -5,24 +5,24 @@ tests:
   - interval: 1m
     input_series:
       - series: up{job="etcd",instance="10.10.10.0"}
-        values: 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0
       - series: up{job="etcd",instance="10.10.10.1"}
-        values: 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+        values: 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
       - series: up{job="etcd",instance="10.10.10.2"}
-        values: 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0
+        values: 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     alert_rule_test:
       - eval_time: 3m
         alertname: etcdInsufficientMembers
       - eval_time: 5m
         alertname: etcdInsufficientMembers
-      - eval_time: 12m
+      - eval_time: 22m
         alertname: etcdMembersDown
-      - eval_time: 14m
+      - eval_time: 24m
         alertname: etcdMembersDown
         exp_alerts:
           - exp_labels:
               job: etcd
-              severity: critical
+              severity: warning
             exp_annotations:
               description: 'etcd cluster "etcd": members are down (3).'
               summary: etcd cluster members are down.
@@ -55,30 +55,30 @@ tests:
       - series: up{job="etcd",instance="10.10.10.2"}
         values: 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     alert_rule_test:
-      - eval_time: 14m
+      - eval_time: 24m
         alertname: etcdMembersDown
         exp_alerts:
           - exp_labels:
               job: etcd
-              severity: critical
+              severity: warning
             exp_annotations:
               description: 'etcd cluster "etcd": members are down (3).'
               summary: etcd cluster members are down.
   - interval: 1m
     input_series:
       - series: up{job="etcd",instance="10.10.10.0"}
-        values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0
       - series: up{job="etcd",instance="10.10.10.1"}
-        values: 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
+        values: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0
       - series: etcd_network_peer_sent_failures_total{To="member-1",job="etcd",endpoint="test"}
-        values: 0 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
+        values: 0 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28
     alert_rule_test:
-      - eval_time: 13m
+      - eval_time: 23m
         alertname: etcdMembersDown
         exp_alerts:
           - exp_labels:
               job: etcd
-              severity: critical
+              severity: warning
             exp_annotations:
               description: 'etcd cluster "etcd": members are down (1).'
               summary: etcd cluster members are down.

--- a/jsonnet/vendor/github.com/jsonnet-libs/xtd/ascii.libsonnet
+++ b/jsonnet/vendor/github.com/jsonnet-libs/xtd/ascii.libsonnet
@@ -96,4 +96,37 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       fraction(expectFraction),
       exponent(expectExponent),
     ]),
+
+  '#stringToRFC1123': d.fn(
+    |||
+      `stringToRFC113` converts a strings to match RFC1123, replacing non-alphanumeric characters with dashes. It'll throw an assertion if the string is too long.
+
+      * RFC 1123. This means the string must:
+      * - contain at most 63 characters
+      * - contain only lowercase alphanumeric characters or '-'
+      * - start with an alphanumeric character
+      * - end with an alphanumeric character
+    |||,
+    [d.arg('str', d.T.string)]
+  ),
+  stringToRFC1123(str):
+    // lowercase alphabetic characters
+    local lowercase = std.asciiLower(str);
+    // replace non-alphanumeric characters with dashes
+    local alphanumeric =
+      std.join(
+        '',
+        std.map(
+          function(c)
+            if self.isLower(c)
+               || self.isNumber(c)
+            then c
+            else '-',
+          std.stringChars(lowercase)
+        )
+      );
+    // remove leading/trailing dashes
+    local return = std.stripChars(alphanumeric, '-');
+    assert std.length(return) <= 63 : 'String too long';
+    return,
 }

--- a/jsonnet/vendor/github.com/jsonnet-libs/xtd/docs/ascii.md
+++ b/jsonnet/vendor/github.com/jsonnet-libs/xtd/docs/ascii.md
@@ -17,6 +17,7 @@ local ascii = import "github.com/jsonnet-libs/xtd/ascii.libsonnet"
 * [`fn isStringJSONNumeric(str)`](#fn-isstringjsonnumeric)
 * [`fn isStringNumeric(str)`](#fn-isstringnumeric)
 * [`fn isUpper(c)`](#fn-isupper)
+* [`fn stringToRFC1123(str)`](#fn-stringtorfc1123)
 
 ## Fields
 
@@ -59,3 +60,17 @@ isUpper(c)
 ```
 
 `isUpper` reports whether ASCII character `c` is a upper case letter
+
+### fn stringToRFC1123
+
+```ts
+stringToRFC1123(str)
+```
+
+`stringToRFC113` converts a strings to match RFC1123, replacing non-alphanumeric characters with dashes. It'll throw an assertion if the string is too long.
+
+* RFC 1123. This means the string must:
+* - contain at most 63 characters
+* - contain only lowercase alphanumeric characters or '-'
+* - start with an alphanumeric character
+* - end with an alphanumeric character

--- a/jsonnet/vendor/github.com/jsonnet-libs/xtd/docs/inspect.md
+++ b/jsonnet/vendor/github.com/jsonnet-libs/xtd/docs/inspect.md
@@ -12,12 +12,22 @@ local inspect = import "github.com/jsonnet-libs/xtd/inspect.libsonnet"
 
 ## Index
 
+* [`fn deepMap(func, x)`](#fn-deepmap)
 * [`fn diff(input1, input2)`](#fn-diff)
 * [`fn filterKubernetesObjects(object, kind='')`](#fn-filterkubernetesobjects)
 * [`fn filterObjects(filter_func, x)`](#fn-filterobjects)
 * [`fn inspect(object, maxDepth)`](#fn-inspect)
 
 ## Fields
+
+### fn deepMap
+
+```ts
+deepMap(func, x)
+```
+
+`deepMap` traverses the whole tree of `x` and applies `func(item)` indiscriminately.
+
 
 ### fn diff
 

--- a/jsonnet/vendor/github.com/jsonnet-libs/xtd/inspect.libsonnet
+++ b/jsonnet/vendor/github.com/jsonnet-libs/xtd/inspect.libsonnet
@@ -206,4 +206,22 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
         function(o) o.kind == kind,
         objects
       ),
+
+  '#deepMap':: d.fn(
+    |||
+      `deepMap` traverses the whole tree of `x` and applies `func(item)` indiscriminately.
+    |||,
+    args=[
+      d.arg('func', d.T.func),
+      d.arg('x', d.T.any),
+    ]
+  ),
+  deepMap(func, x):
+    func(
+      if std.isObject(x)
+      then std.mapWithKey(function(_, y) self.deepMap(func, y), x)
+      else if std.isArray(x)
+      then std.map(function(y) self.deepMap(func, y), x)
+      else x
+    ),
 }

--- a/jsonnet/vendor/github.com/jsonnet-libs/xtd/test/inspect_test.jsonnet
+++ b/jsonnet/vendor/github.com/jsonnet-libs/xtd/test/inspect_test.jsonnet
@@ -150,3 +150,42 @@ test.new(std.thisFile)
     )
   )
 )
++ (
+  local originalObj = {
+    key1: {
+      key1a: 'replace me',
+      key1b: [
+        { key1bNested: 'replace me' },
+      ],
+    },
+    key2: [
+      { key2a: 'replace me' },
+    ],
+  };
+
+  test.case.new(
+    name='deepmap',
+    test=
+    test.expect.eq(
+      actual=xtd.inspect.deepMap(
+        function(item)
+          if std.isString(item)
+             && item == 'replace me'
+          then 'REPLACED'
+          else item,
+        originalObj,
+      ),
+      expected={
+        key1: {
+          key1a: 'REPLACED',
+          key1b: [
+            { key1bNested: 'REPLACED' },
+          ],
+        },
+        key2: [
+          { key2a: 'REPLACED' },
+        ],
+      }
+    )
+  )
+)

--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -10,23 +10,6 @@ spec:
   groups:
   - name: etcd
     rules:
-    - alert: etcdMembersDown
-      annotations:
-        description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value }}).'
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdMembersDown.md
-        summary: etcd cluster members are down.
-      expr: |
-        max without (endpoint) (
-          sum without (instance) (up{job=~".*etcd.*"} == bool 0)
-        or
-          count without (To) (
-            sum without (instance) (rate(etcd_network_peer_sent_failures_total{job=~".*etcd.*"}[120s])) > 0.01
-          )
-        )
-        > 0
-      for: 10m
-      labels:
-        severity: critical
     - alert: etcdNoLeader
       annotations:
         description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
@@ -77,26 +60,6 @@ spec:
       for: 10m
       labels:
         severity: critical
-    - alert: etcdHighCommitDurations
-      annotations:
-        description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
-        summary: etcd cluster 99th percentile commit durations are too high.
-      expr: |
-        histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
-        > 0.25
-      for: 10m
-      labels:
-        severity: warning
-    - alert: etcdDatabaseQuotaLowSpace
-      annotations:
-        description: 'etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdDatabaseQuotaLowSpace.md
-        summary: etcd cluster database is running full.
-      expr: |
-        (last_over_time(etcd_mvcc_db_total_size_in_bytes{job=~".*etcd.*"}[5m]) / last_over_time(etcd_server_quota_backend_bytes{job=~".*etcd.*"}[5m]))*100 > 95
-      for: 10m
-      labels:
-        severity: critical
     - alert: etcdExcessiveDatabaseGrowth
       annotations:
         description: 'etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
@@ -118,6 +81,31 @@ spec:
         severity: warning
   - name: openshift-etcd.rules
     rules:
+    - alert: etcdDatabaseQuotaLowSpace
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": database size is 65% of the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        summary: etcd cluster database is using >= 65% of the defined quota.
+      expr: (last_over_time(etcd_mvcc_db_total_size_in_bytes{job=~".*etcd.*"}[5m]) / last_over_time(etcd_server_quota_backend_bytes{job=~".*etcd.*"}[5m]))*100 > 65
+      for: 10m
+      labels:
+        severity: info
+    - alert: etcdDatabaseQuotaLowSpace
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": database size is 75% of the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        summary: etcd cluster database is using >= 75% of the defined quota.
+      expr: (last_over_time(etcd_mvcc_db_total_size_in_bytes{job=~".*etcd.*"}[5m]) / last_over_time(etcd_server_quota_backend_bytes{job=~".*etcd.*"}[5m]))*100 > 75
+      for: 10m
+      labels:
+        severity: warning
+    - alert: etcdDatabaseQuotaLowSpace
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": database size is 85% of the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdDatabaseQuotaLowSpace.md
+        summary: etcd cluster database is running full.
+      expr: (last_over_time(etcd_mvcc_db_total_size_in_bytes{job=~".*etcd.*"}[5m]) / last_over_time(etcd_server_quota_backend_bytes{job=~".*etcd.*"}[5m]))*100 > 85
+      for: 10m
+      labels:
+        severity: critical
     - alert: etcdGRPCRequestsSlow
       annotations:
         description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC requests is {{ $value }}s on etcd instance {{ $labels.instance }} for {{ $labels.grpc_method }} method.'
@@ -125,10 +113,22 @@ spec:
         summary: etcd grpc requests are slow
       expr: |
         histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method!="Defragment", grpc_type="unary"}[10m])) without(grpc_type))
-        > 1
+        > on () group_left (type)
+        bottomk(1,
+          1.5 * group by (type) (cluster_infrastructure_provider{type="Azure"})
+          or
+          1 * group by (type) (cluster_infrastructure_provider))
       for: 30m
       labels:
         severity: critical
+    - alert: etcdHighCommitDurations
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        summary: etcd cluster 99th percentile commit durations are too high.
+      expr: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[5m])) > 0.5
+      for: 10m
+      labels:
+        severity: warning
     - alert: etcdHighNumberOfFailedGRPCRequests
       annotations:
         description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.'
@@ -170,6 +170,23 @@ spec:
         summary: etcd is reporting that a majority of instances are unavailable.
       expr: sum(up{job="etcd"} == bool 1 and etcd_server_has_leader{job="etcd"} == bool 1) without (instance,pod) < ((count(up{job="etcd"}) without (instance,pod) + 1) / 2)
       for: 3m
+      labels:
+        severity: critical
+    - alert: etcdMembersDown
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value }}).'
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdMembersDown.md
+        summary: etcd cluster members are down.
+      expr: |
+        max without (endpoint) (
+            sum without (instance) (up{job=~".*etcd.*"} == bool 0)
+        or
+          count without (To) (
+            sum without (instance) (rate(etcd_network_peer_sent_failures_total{job=~".*etcd.*"}[120s])) > 0.01
+          )
+        )
+        > 0
+      for: 20m
       labels:
         severity: critical
     - alert: etcdSignerCAExpirationWarning


### PR DESCRIPTION
Manually cherry pick of https://github.com/openshift/cluster-etcd-operator/pull/1471 onto `release-4.17` to resolve conflicts.