### PR TITLE
OCPEDGE-2183: Updating Quorum detection logic to absolve TNF of quorum loss reports.

### DIFF
--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller_test.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller_test.go
@@ -371,7 +371,7 @@ func TestRemoveBootstrap(t *testing.T) {
 			fakeNamespaceLister := corev1listers.NewNamespaceLister(indexer)
 			fakeConfigmapLister := corev1listers.NewConfigMapLister(indexer)
 			fakeInfraLister := configv1listers.NewInfrastructureLister(indexer)
-			fakeStaticPodClient := v1helpers.NewFakeStaticPodOperatorClient(&operatorv1.StaticPodOperatorSpec{}, &operatorv1.StaticPodOperatorStatus{}, nil, nil)
+			fakeStaticPodClient := v1helpers.NewFakeStaticPodOperatorClient(&operatorv1.StaticPodOperatorSpec{}, u.StaticPodOperatorStatus(), nil, nil)
 			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient([]*etcdserverpb.Member{u.FakeEtcdBootstrapMember(1)})
 			require.NoError(t, err)
 			fakeKubeClient := fake.NewClientset([]runtime.Object{}...)

--- a/pkg/operator/ceohelpers/common_test.go
+++ b/pkg/operator/ceohelpers/common_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	u "github.com/openshift/cluster-etcd-operator/pkg/testutils"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -57,7 +58,7 @@ func TestReadDesiredControlPlaneReplicaCount(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			// test data
-			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(&scenario.operatorSpec, &operatorv1.StaticPodOperatorStatus{}, nil, nil)
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(&scenario.operatorSpec, u.StaticPodOperatorStatus(), nil, nil)
 
 			// act
 			actualReplicaCount, err := ReadDesiredControlPlaneReplicasCount(fakeOperatorClient)

--- a/pkg/operator/ceohelpers/external_etcd_status_test.go
+++ b/pkg/operator/ceohelpers/external_etcd_status_test.go
@@ -6,6 +6,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/testutils"
@@ -111,7 +112,7 @@ func TestIsReadyForEtcdTransition(t *testing.T) {
 			operatorClient := testutils.FakeStaticPodOperatorClient(t, tt.operatorConditions)
 
 			// Test the function
-			result, err := IsReadyForEtcdTransition(context.Background(), operatorClient)
+			result, err := IsReadyForEtcdTransition(operatorClient)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -178,33 +179,112 @@ func TestIsEtcdRunningInCluster(t *testing.T) {
 	}
 }
 
-func TestGetExternalEtcdClusterStatus(t *testing.T) {
+func TestHasExternalEtcdCompletedTransition(t *testing.T) {
 	tests := []struct {
-		name                         string
-		topology                     configv1.TopologyMode
-		operatorConditions           []operatorv1.OperatorCondition
-		expectedExternalEtcd         bool
-		expectedEtcdRunningInCluster bool
-		expectedReadyForTransition   bool
-		expectError                  bool
+		name           string
+		operatorStatus func(*operatorv1.StaticPodOperatorStatus)
+		expectedResult bool
+		expectError    bool
 	}{
 		{
-			name:                         "HighlyAvailable topology - not external etcd",
-			topology:                     configv1.HighlyAvailableTopologyMode,
-			operatorConditions:           []operatorv1.OperatorCondition{},
-			expectedExternalEtcd:         false,
-			expectedEtcdRunningInCluster: false,
-			expectedReadyForTransition:   false,
-			expectError:                  false,
+			name:           "No conditions - transition not completed",
+			operatorStatus: nil,
+			expectedResult: false,
+			expectError:    false,
 		},
 		{
-			name:                         "DualReplica topology with no conditions",
-			topology:                     configv1.DualReplicaTopologyMode,
-			operatorConditions:           []operatorv1.OperatorCondition{},
-			expectedExternalEtcd:         true,
-			expectedEtcdRunningInCluster: false,
-			expectedReadyForTransition:   false,
-			expectError:                  false,
+			name: "ExternalEtcdHasCompletedTransition condition true - transition completed",
+			operatorStatus: testutils.WithConditions(operatorv1.OperatorCondition{
+				Type:   etcd.OperatorConditionExternalEtcdHasCompletedTransition,
+				Status: operatorv1.ConditionTrue,
+			}),
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "ExternalEtcdHasCompletedTransition condition false - transition not completed",
+			operatorStatus: testutils.WithConditions(operatorv1.OperatorCondition{
+				Type:   etcd.OperatorConditionExternalEtcdHasCompletedTransition,
+				Status: operatorv1.ConditionFalse,
+			}),
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "Other conditions present but not ExternalEtcdHasCompletedTransition - transition not completed",
+			operatorStatus: testutils.WithConditions(
+				operatorv1.OperatorCondition{
+					Type:   etcd.OperatorConditionEtcdRunningInCluster,
+					Status: operatorv1.ConditionTrue,
+				},
+				operatorv1.OperatorCondition{
+					Type:   etcd.OperatorConditionExternalEtcdReadyForTransition,
+					Status: operatorv1.ConditionTrue,
+				},
+			),
+			expectedResult: false,
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake operator client
+			var operatorClient v1helpers.StaticPodOperatorClient
+			if tt.operatorStatus != nil {
+				operatorClient = v1helpers.NewFakeStaticPodOperatorClient(
+					&operatorv1.StaticPodOperatorSpec{},
+					testutils.StaticPodOperatorStatus(tt.operatorStatus),
+					nil,
+					nil,
+				)
+			} else {
+				operatorClient = testutils.FakeStaticPodOperatorClient(t, []operatorv1.OperatorCondition{})
+			}
+
+			// Test the function
+			result, err := HasExternalEtcdCompletedTransition(context.Background(), operatorClient)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestGetExternalEtcdClusterStatus(t *testing.T) {
+	tests := []struct {
+		name                           string
+		topology                       configv1.TopologyMode
+		operatorConditions             []operatorv1.OperatorCondition
+		expectedExternalEtcd           bool
+		expectedEtcdRunningInCluster   bool
+		expectedReadyForTransition     bool
+		expectedHasCompletedTransition bool
+		expectError                    bool
+	}{
+		{
+			name:                           "HighlyAvailable topology - not external etcd",
+			topology:                       configv1.HighlyAvailableTopologyMode,
+			operatorConditions:             []operatorv1.OperatorCondition{},
+			expectedExternalEtcd:           false,
+			expectedEtcdRunningInCluster:   false,
+			expectedReadyForTransition:     false,
+			expectedHasCompletedTransition: false,
+			expectError:                    false,
+		},
+		{
+			name:                           "DualReplica topology with no conditions",
+			topology:                       configv1.DualReplicaTopologyMode,
+			operatorConditions:             []operatorv1.OperatorCondition{},
+			expectedExternalEtcd:           true,
+			expectedEtcdRunningInCluster:   false,
+			expectedReadyForTransition:     false,
+			expectedHasCompletedTransition: false,
+			expectError:                    false,
 		},
 		{
 			name:     "DualReplica topology with bootstrap completed",
@@ -215,10 +295,11 @@ func TestGetExternalEtcdClusterStatus(t *testing.T) {
 					Status: operatorv1.ConditionTrue,
 				},
 			},
-			expectedExternalEtcd:         true,
-			expectedEtcdRunningInCluster: true,
-			expectedReadyForTransition:   false,
-			expectError:                  false,
+			expectedExternalEtcd:           true,
+			expectedEtcdRunningInCluster:   true,
+			expectedReadyForTransition:     false,
+			expectedHasCompletedTransition: false,
+			expectError:                    false,
 		},
 		{
 			name:     "DualReplica topology with bootstrap completed and ready for transition",
@@ -233,10 +314,49 @@ func TestGetExternalEtcdClusterStatus(t *testing.T) {
 					Status: operatorv1.ConditionTrue,
 				},
 			},
-			expectedExternalEtcd:         true,
-			expectedEtcdRunningInCluster: true,
-			expectedReadyForTransition:   true,
-			expectError:                  false,
+			expectedExternalEtcd:           true,
+			expectedEtcdRunningInCluster:   true,
+			expectedReadyForTransition:     true,
+			expectedHasCompletedTransition: false,
+			expectError:                    false,
+		},
+		{
+			name:     "DualReplica topology with transition completed",
+			topology: configv1.DualReplicaTopologyMode,
+			operatorConditions: []operatorv1.OperatorCondition{
+				{
+					Type:   etcd.OperatorConditionEtcdRunningInCluster,
+					Status: operatorv1.ConditionTrue,
+				},
+				{
+					Type:   etcd.OperatorConditionExternalEtcdReadyForTransition,
+					Status: operatorv1.ConditionTrue,
+				},
+				{
+					Type:   etcd.OperatorConditionExternalEtcdHasCompletedTransition,
+					Status: operatorv1.ConditionTrue,
+				},
+			},
+			expectedExternalEtcd:           true,
+			expectedEtcdRunningInCluster:   true,
+			expectedReadyForTransition:     true,
+			expectedHasCompletedTransition: true,
+			expectError:                    false,
+		},
+		{
+			name:     "DualReplica topology with only transition completed (full lifecycle)",
+			topology: configv1.DualReplicaTopologyMode,
+			operatorConditions: []operatorv1.OperatorCondition{
+				{
+					Type:   etcd.OperatorConditionExternalEtcdHasCompletedTransition,
+					Status: operatorv1.ConditionTrue,
+				},
+			},
+			expectedExternalEtcd:           true,
+			expectedEtcdRunningInCluster:   false,
+			expectedReadyForTransition:     false,
+			expectedHasCompletedTransition: true,
+			expectError:                    false,
 		},
 	}
 
@@ -256,10 +376,148 @@ func TestGetExternalEtcdClusterStatus(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.expectedExternalEtcd, externalEtcdStatus.IsExternalEtcdCluster)
-				require.Equal(t, tt.expectedEtcdRunningInCluster, externalEtcdStatus.IsEtcdRunningInCluster)
-				require.Equal(t, tt.expectedReadyForTransition, externalEtcdStatus.IsReadyForEtcdTransition)
+				require.Equal(t, tt.expectedExternalEtcd, externalEtcdStatus.IsExternalEtcdCluster,
+					"IsExternalEtcdCluster mismatch")
+				require.Equal(t, tt.expectedEtcdRunningInCluster, externalEtcdStatus.IsEtcdRunningInCluster,
+					"IsEtcdRunningInCluster mismatch")
+				require.Equal(t, tt.expectedReadyForTransition, externalEtcdStatus.IsReadyForEtcdTransition,
+					"IsReadyForEtcdTransition mismatch")
+				require.Equal(t, tt.expectedHasCompletedTransition, externalEtcdStatus.HasExternalEtcdCompletedTransition,
+					"HasExternalEtcdCompletedTransition mismatch")
 			}
 		})
 	}
+}
+
+// TestExternalEtcdTransitionLifecycle validates the complete state progression
+// for external etcd clusters from initial state through transition completion.
+func TestExternalEtcdTransitionLifecycle(t *testing.T) {
+	// State 1: Initial state - external etcd cluster detected, no bootstrap yet
+	t.Run("State 1: External etcd cluster detected", func(t *testing.T) {
+		infraLister := testutils.FakeInfrastructureLister(t, configv1.DualReplicaTopologyMode)
+		operatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+			&operatorv1.StaticPodOperatorSpec{},
+			testutils.StaticPodOperatorStatus(),
+			nil,
+			nil,
+		)
+
+		status, err := GetExternalEtcdClusterStatus(context.Background(), operatorClient, infraLister)
+		require.NoError(t, err)
+		require.True(t, status.IsExternalEtcdCluster, "Should detect external etcd cluster")
+		require.False(t, status.IsEtcdRunningInCluster, "Bootstrap should not be complete")
+		require.False(t, status.IsReadyForEtcdTransition, "Should not be ready for transition")
+		require.False(t, status.HasExternalEtcdCompletedTransition, "Transition should not be complete")
+	})
+
+	// State 2: Bootstrap completed - etcd running in cluster
+	t.Run("State 2: Bootstrap completed", func(t *testing.T) {
+		infraLister := testutils.FakeInfrastructureLister(t, configv1.DualReplicaTopologyMode)
+		operatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+			&operatorv1.StaticPodOperatorSpec{},
+			testutils.StaticPodOperatorStatus(
+				testutils.WithConditions(operatorv1.OperatorCondition{
+					Type:   etcd.OperatorConditionEtcdRunningInCluster,
+					Status: operatorv1.ConditionTrue,
+				}),
+			),
+			nil,
+			nil,
+		)
+
+		status, err := GetExternalEtcdClusterStatus(context.Background(), operatorClient, infraLister)
+		require.NoError(t, err)
+		require.True(t, status.IsExternalEtcdCluster, "Should detect external etcd cluster")
+		require.True(t, status.IsEtcdRunningInCluster, "Bootstrap should be complete")
+		require.False(t, status.IsReadyForEtcdTransition, "Should not yet be ready for transition")
+		require.False(t, status.HasExternalEtcdCompletedTransition, "Transition should not be complete")
+	})
+
+	// State 3: Ready for transition - TNF setup complete
+	t.Run("State 3: Ready for transition", func(t *testing.T) {
+		infraLister := testutils.FakeInfrastructureLister(t, configv1.DualReplicaTopologyMode)
+		operatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+			&operatorv1.StaticPodOperatorSpec{},
+			testutils.StaticPodOperatorStatus(
+				testutils.WithConditions(
+					operatorv1.OperatorCondition{
+						Type:   etcd.OperatorConditionEtcdRunningInCluster,
+						Status: operatorv1.ConditionTrue,
+					},
+					operatorv1.OperatorCondition{
+						Type:   etcd.OperatorConditionExternalEtcdReadyForTransition,
+						Status: operatorv1.ConditionTrue,
+					},
+				),
+			),
+			nil,
+			nil,
+		)
+
+		status, err := GetExternalEtcdClusterStatus(context.Background(), operatorClient, infraLister)
+		require.NoError(t, err)
+		require.True(t, status.IsExternalEtcdCluster, "Should detect external etcd cluster")
+		require.True(t, status.IsEtcdRunningInCluster, "Bootstrap should be complete")
+		require.True(t, status.IsReadyForEtcdTransition, "Should be ready for transition")
+		require.False(t, status.HasExternalEtcdCompletedTransition, "Transition should not yet be complete")
+	})
+
+	// State 4: Transition completed - etcd running externally under pacemaker
+	t.Run("State 4: Transition completed", func(t *testing.T) {
+		infraLister := testutils.FakeInfrastructureLister(t, configv1.DualReplicaTopologyMode)
+		operatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+			&operatorv1.StaticPodOperatorSpec{},
+			testutils.StaticPodOperatorStatus(
+				testutils.WithConditions(
+					operatorv1.OperatorCondition{
+						Type:   etcd.OperatorConditionEtcdRunningInCluster,
+						Status: operatorv1.ConditionTrue,
+					},
+					operatorv1.OperatorCondition{
+						Type:   etcd.OperatorConditionExternalEtcdReadyForTransition,
+						Status: operatorv1.ConditionTrue,
+					},
+					operatorv1.OperatorCondition{
+						Type:   etcd.OperatorConditionExternalEtcdHasCompletedTransition,
+						Status: operatorv1.ConditionTrue,
+					},
+				),
+			),
+			nil,
+			nil,
+		)
+
+		status, err := GetExternalEtcdClusterStatus(context.Background(), operatorClient, infraLister)
+		require.NoError(t, err)
+		require.True(t, status.IsExternalEtcdCluster, "Should detect external etcd cluster")
+		require.True(t, status.IsEtcdRunningInCluster, "Bootstrap should remain complete")
+		require.True(t, status.IsReadyForEtcdTransition, "Should remain ready for transition")
+		require.True(t, status.HasExternalEtcdCompletedTransition, "Transition should be complete")
+	})
+
+	// Negative test: Transition not complete, no automatic quorum recovery
+	t.Run("Negative: No auto recovery without transition completion", func(t *testing.T) {
+		operatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+			&operatorv1.StaticPodOperatorSpec{},
+			testutils.StaticPodOperatorStatus(
+				testutils.WithConditions(
+					operatorv1.OperatorCondition{
+						Type:   etcd.OperatorConditionEtcdRunningInCluster,
+						Status: operatorv1.ConditionTrue,
+					},
+					operatorv1.OperatorCondition{
+						Type:   etcd.OperatorConditionExternalEtcdReadyForTransition,
+						Status: operatorv1.ConditionTrue,
+					},
+				),
+			),
+			nil,
+			nil,
+		)
+
+		// Test that HasExternalEtcdCompletedTransition returns false when transition is not complete
+		hasCompletedTransition, err := HasExternalEtcdCompletedTransition(context.Background(), operatorClient)
+		require.NoError(t, err)
+		require.False(t, hasCompletedTransition, "Should not report transition as completed before condition is set")
+	})
 }

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
@@ -1045,7 +1045,7 @@ func TestAttemptToScaleDown(t *testing.T) {
 				OperatorSpec: operatorv1.OperatorSpec{
 					ObservedConfig: runtime.RawExtension{Raw: []byte(scenario.initialObservedConfigInput)},
 				},
-			}, &operatorv1.StaticPodOperatorStatus{}, nil, nil)
+			}, u.StaticPodOperatorStatus(), nil, nil)
 
 			// act
 			target := clusterMemberRemovalController{

--- a/pkg/operator/etcdmemberscontroller/etcdmemberscontroller_test.go
+++ b/pkg/operator/etcdmemberscontroller/etcdmemberscontroller_test.go
@@ -1,0 +1,228 @@
+package etcdmemberscontroller
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"k8s.io/utils/clock"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
+	u "github.com/openshift/cluster-etcd-operator/pkg/testutils"
+	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/etcd"
+)
+
+var (
+	defaultOperatorStatus = func(status *operatorv1.StaticPodOperatorStatus) {}
+)
+
+func TestEtcdMembersController_ReportEtcdMembers(t *testing.T) {
+	scenarios := []struct {
+		name                    string
+		etcdMembers             []*etcdserverpb.Member
+		memberHealthConfig      *etcdcli.FakeMemberHealth
+		infrastructureTopology  configv1.TopologyMode
+		operatorSpec            *operatorv1.StaticPodOperatorSpec
+		expectedAvailableStatus operatorv1.ConditionStatus
+		expectedAvailableReason string
+		description             string
+		operatorStatus          func(*operatorv1.StaticPodOperatorStatus)
+	}{
+		{
+			name: "HA cluster with quorum - status available",
+			etcdMembers: []*etcdserverpb.Member{
+				u.FakeEtcdMemberWithoutServer(1),
+				u.FakeEtcdMemberWithoutServer(2),
+				u.FakeEtcdMemberWithoutServer(3),
+			},
+			memberHealthConfig: &etcdcli.FakeMemberHealth{
+				Healthy:   3,
+				Unhealthy: 0,
+			},
+			infrastructureTopology:  configv1.HighlyAvailableTopologyMode,
+			operatorSpec:            &operatorv1.StaticPodOperatorSpec{},
+			expectedAvailableStatus: operatorv1.ConditionTrue,
+			expectedAvailableReason: "EtcdQuorate",
+			description:             "Regular HA cluster with 3/3 healthy nodes should report available",
+			operatorStatus:          defaultOperatorStatus,
+		},
+		{
+			name: "HA cluster without quorum - status unavailable",
+			etcdMembers: []*etcdserverpb.Member{
+				u.FakeEtcdMemberWithoutServer(1),
+				u.FakeEtcdMemberWithoutServer(2),
+				u.FakeEtcdMemberWithoutServer(3),
+			},
+			memberHealthConfig: &etcdcli.FakeMemberHealth{
+				Healthy:   1,
+				Unhealthy: 2,
+			},
+			infrastructureTopology:  configv1.HighlyAvailableTopologyMode,
+			operatorSpec:            &operatorv1.StaticPodOperatorSpec{},
+			expectedAvailableStatus: operatorv1.ConditionFalse,
+			expectedAvailableReason: "NoQuorum",
+			description:             "Regular HA cluster with 1/3 healthy nodes should report unavailable",
+			operatorStatus:          defaultOperatorStatus,
+		},
+		{
+			name: "TNF cluster without quorum - status available due to auto recovery",
+			etcdMembers: []*etcdserverpb.Member{
+				u.FakeEtcdMemberWithoutServer(1),
+				u.FakeEtcdMemberWithoutServer(2),
+			},
+			memberHealthConfig: &etcdcli.FakeMemberHealth{
+				Healthy:   1,
+				Unhealthy: 1,
+			},
+			infrastructureTopology:  configv1.DualReplicaTopologyMode,
+			operatorSpec:            &operatorv1.StaticPodOperatorSpec{},
+			expectedAvailableStatus: operatorv1.ConditionTrue,
+			expectedAvailableReason: "EtcdQuorate",
+			description:             "TNF cluster with 1/2 healthy nodes should report available due to automatic quorum recovery",
+			operatorStatus: u.WithConditions(operatorv1.OperatorCondition{
+				Type:   etcd.OperatorConditionExternalEtcdHasCompletedTransition,
+				Status: operatorv1.ConditionTrue,
+			}),
+		},
+		{
+			name: "TNF cluster without quorum - status unavailable because external etcd is not yet ready",
+			etcdMembers: []*etcdserverpb.Member{
+				u.FakeEtcdMemberWithoutServer(1),
+				u.FakeEtcdMemberWithoutServer(2),
+			},
+			memberHealthConfig: &etcdcli.FakeMemberHealth{
+				Healthy:   1,
+				Unhealthy: 1,
+			},
+			infrastructureTopology:  configv1.DualReplicaTopologyMode,
+			operatorSpec:            &operatorv1.StaticPodOperatorSpec{},
+			expectedAvailableStatus: operatorv1.ConditionFalse,
+			expectedAvailableReason: "NoQuorum",
+			description:             "TNF cluster with 1/2 healthy nodes should report unavailable when automatic quorum recovery is not yet available",
+			operatorStatus:          defaultOperatorStatus,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// Create fake etcd client with member health configuration
+			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(
+				scenario.etcdMembers,
+				etcdcli.WithFakeClusterHealth(scenario.memberHealthConfig),
+			)
+			require.NoError(t, err)
+
+			// Create fake operator client
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				scenario.operatorSpec,
+				u.StaticPodOperatorStatus(scenario.operatorStatus),
+				nil,
+				nil,
+			)
+
+			// Create fake infrastructure lister
+			fakeInfrastructureLister := u.FakeInfrastructureLister(t, scenario.infrastructureTopology)
+
+			// Create the controller
+			controller := &EtcdMembersController{
+				operatorClient:       fakeOperatorClient,
+				etcdClient:           fakeEtcdClient,
+				infrastructureLister: fakeInfrastructureLister,
+			}
+
+			// Create fake event recorder
+			eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+
+			// Execute the reportEtcdMembers method
+			err = controller.reportEtcdMembers(context.Background(), eventRecorder)
+			require.NoError(t, err)
+
+			// Verify the EtcdMembersAvailable condition
+			_, status, _, err := fakeOperatorClient.GetStaticPodOperatorState()
+			require.NoError(t, err)
+
+			var availableCondition *operatorv1.OperatorCondition
+			for i := range status.Conditions {
+				if status.Conditions[i].Type == "EtcdMembersAvailable" {
+					availableCondition = &status.Conditions[i]
+					break
+				}
+			}
+
+			require.NotNil(t, availableCondition, "EtcdMembersAvailable condition should be set")
+			require.Equal(t, scenario.expectedAvailableStatus, availableCondition.Status,
+				"EtcdMembersAvailable status should match expected for %s", scenario.description)
+			require.Equal(t, scenario.expectedAvailableReason, availableCondition.Reason,
+				"EtcdMembersAvailable reason should match expected for %s", scenario.description)
+
+			t.Logf("✓ %s", scenario.description)
+		})
+	}
+}
+
+func TestEtcdMembersController_ReportEtcdMembers_AdditionalConditions(t *testing.T) {
+	// Test that other conditions are also properly set
+	etcdMembers := []*etcdserverpb.Member{
+		u.FakeEtcdMemberWithoutServer(1),
+		u.FakeEtcdMemberWithoutServer(2),
+		u.FakeEtcdMemberWithoutServer(3),
+	}
+
+	fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(
+		etcdMembers,
+		etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 0}),
+	)
+	require.NoError(t, err)
+
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{},
+		u.StaticPodOperatorStatus(),
+		nil,
+		nil,
+	)
+
+	fakeInfrastructureLister := u.FakeInfrastructureLister(t, configv1.HighlyAvailableTopologyMode)
+
+	controller := &EtcdMembersController{
+		operatorClient:       fakeOperatorClient,
+		etcdClient:           fakeEtcdClient,
+		infrastructureLister: fakeInfrastructureLister,
+	}
+
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+
+	err = controller.reportEtcdMembers(context.Background(), eventRecorder)
+	require.NoError(t, err)
+
+	_, status, _, err := fakeOperatorClient.GetStaticPodOperatorState()
+	require.NoError(t, err)
+
+	// Verify EtcdMembersDegraded condition
+	var degradedCondition *operatorv1.OperatorCondition
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == "EtcdMembersDegraded" {
+			degradedCondition = &status.Conditions[i]
+			break
+		}
+	}
+	require.NotNil(t, degradedCondition)
+	require.Equal(t, operatorv1.ConditionFalse, degradedCondition.Status)
+	require.Equal(t, "AsExpected", degradedCondition.Reason)
+
+	// Verify EtcdMembersProgressing condition
+	var progressingCondition *operatorv1.OperatorCondition
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == "EtcdMembersProgressing" {
+			progressingCondition = &status.Conditions[i]
+			break
+		}
+	}
+	require.NotNil(t, progressingCondition)
+	require.Equal(t, operatorv1.ConditionFalse, progressingCondition.Status)
+	require.Equal(t, "AsExpected", progressingCondition.Reason)
+}

--- a/pkg/operator/periodicbackupcontroller/periodicbackupcontroller_test.go
+++ b/pkg/operator/periodicbackupcontroller/periodicbackupcontroller_test.go
@@ -10,6 +10,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-etcd-operator/pkg/backuphelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+	u "github.com/openshift/cluster-etcd-operator/pkg/testutils"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"github.com/stretchr/testify/require"
@@ -41,7 +42,7 @@ func TestSyncLoopHappyPath(t *testing.T) {
 	client := k8sfakeclient.NewClientset()
 	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
 		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
-		&operatorv1.StaticPodOperatorStatus{}, nil, nil)
+		u.StaticPodOperatorStatus(), nil, nil)
 
 	controller := PeriodicBackupController{
 		operatorClient:        fakeOperatorClient,
@@ -73,7 +74,7 @@ func TestSyncLoopExistingCronJob(t *testing.T) {
 	client := k8sfakeclient.NewClientset([]runtime.Object{&cronJob}...)
 	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
 		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
-		&operatorv1.StaticPodOperatorStatus{}, nil, nil)
+		u.StaticPodOperatorStatus(), nil, nil)
 
 	controller := PeriodicBackupController{
 		operatorClient:        fakeOperatorClient,
@@ -108,7 +109,7 @@ func TestSyncLoopFailsDegradesOperator(t *testing.T) {
 
 	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
 		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
-		&operatorv1.StaticPodOperatorStatus{}, nil, nil)
+		u.StaticPodOperatorStatus(), nil, nil)
 
 	controller := PeriodicBackupController{
 		operatorClient:        fakeOperatorClient,

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -453,6 +453,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		AlivenessChecker,
 		operatorClient,
 		cachedMemberClient,
+		configInformers.Config().V1().Infrastructures(),
 		controllerContext.EventRecorder,
 	)
 

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -241,6 +241,12 @@ func WithBootstrapIP(ip string) func(*corev1.ConfigMap) {
 	}
 }
 
+func WithConditions(conditions ...operatorv1.OperatorCondition) func(*operatorv1.StaticPodOperatorStatus) {
+	return func(status *operatorv1.StaticPodOperatorStatus) {
+		status.Conditions = append(status.Conditions, conditions...)
+	}
+}
+
 func WithEndpoint(memberID uint64, peerURl string) func(*corev1.ConfigMap) {
 	if !strings.HasPrefix(peerURl, "https://") {
 		peerURl = "https://" + peerURl

--- a/pkg/tnf/operator/starter_test.go
+++ b/pkg/tnf/operator/starter_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdenvvar"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+	u "github.com/openshift/cluster-etcd-operator/pkg/testutils"
 )
 
 type args struct {
@@ -131,7 +132,7 @@ func getArgs(t *testing.T, dualReplicaControlPlaneEnabled bool) args {
 
 	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
 		&operatorv1.StaticPodOperatorSpec{},
-		&operatorv1.StaticPodOperatorStatus{},
+		u.StaticPodOperatorStatus(),
 		nil,
 		nil,
 	)


### PR DESCRIPTION
This patch fixes an edge case we see for TNF when if a node is absent from the cluster, etcd goes unavailable because of quorum loss. This is not true in the case of TNF because we have automatic quorum recovery. This relaxes the logic to allow for TNF to be treated like a cluster with quorum even when it's missing a node.

Depends on https://github.com/openshift/cluster-etcd-operator/pull/1484