### PR TITLE
[WIP] disruptive fencing validation TNF

### DIFF
--- a/pkg/tnf/pkg/pcs/fencing.go
+++ b/pkg/tnf/pkg/pcs/fencing.go
@@ -5,19 +5,19 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
+	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/config"
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/exec"
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/tools"
 )
 
-var (
-	addressRegEx = regexp.MustCompile(`.*//(.*):(.*)(/redfish.*)`)
-)
+var addressRegEx = regexp.MustCompile(`.*//(.*):(.*)(/redfish.*)`)
 
 const (
 	// defaultPcmkDelayBase is the delay applied to the first fence device to prevent simultaneous fencing
@@ -117,11 +117,9 @@ func ConfigureFencing(ctx context.Context, kubeClient kubernetes.Interface, cfg 
 
 	klog.Info("Fencing configuration succeeded!")
 	return nil
-
 }
 
 func getFencingConfig(nodeName string, secret *corev1.Secret) (*fencingConfig, error) {
-
 	address := string(secret.Data["address"])
 	if !strings.Contains(address, "redfish") {
 		klog.Errorf("Secret %s does not contain redfish address", secret.Name)
@@ -184,7 +182,6 @@ func getStatusCommand(fc fencingConfig) string {
 }
 
 func getStonithCommand(sc StonithConfig, fc fencingConfig) string {
-
 	stonithAction := "create"
 	// check if device already exists
 	for _, p := range sc.Primitives {
@@ -292,5 +289,154 @@ func deleteObsoleteStonithDevices(ctx context.Context, stonithConfig StonithConf
 			return fmt.Errorf("failed to delete stonith device %q: %v", p.Id, err)
 		}
 	}
+	return nil
+}
+
+func peerOf(cfg config.ClusterConfig, local string) (string, error) {
+	switch local {
+	case cfg.NodeName1:
+		return cfg.NodeName2, nil
+	case cfg.NodeName2:
+		return cfg.NodeName1, nil
+	default:
+		return "", fmt.Errorf("local node %q not in cluster config (%q, %q)", local, cfg.NodeName1, cfg.NodeName2)
+	}
+}
+
+func localHostname(ctx context.Context) (string, error) {
+	out, _, err := exec.Execute(ctx, "hostname -f || hostname")
+	if err != nil {
+		return "", fmt.Errorf("hostname query failed: %v", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func pcsNodesOnline(ctx context.Context) (string, error) {
+	out, _, err := exec.Execute(ctx, "/usr/sbin/pcs status nodes 2>/dev/null || /usr/sbin/crm_mon -1 2>/dev/null || true")
+	return out, err
+}
+
+func isOnline(output, name string) bool {
+	short := name
+	if i := strings.IndexByte(name, '.'); i > 0 {
+		short = name[:i]
+	}
+	return strings.Contains(output, name) || strings.Contains(output, short)
+}
+
+func waitPacemakerOffline(ctx context.Context, name string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		out, pcsErr := pcsNodesOnline(ctx)
+		if pcsErr != nil {
+			return fmt.Errorf("pcs status failed while waiting OFFLINE: %w", pcsErr)
+		}
+		if !isOnline(out, name) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+	}
+	return fmt.Errorf("timeout waiting for %s to go OFFLINE (pcs)", name)
+}
+
+func waitPacemakerOnline(ctx context.Context, name string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		out, pcsErr := pcsNodesOnline(ctx)
+		if pcsErr != nil {
+			return fmt.Errorf("pcs status failed while waiting ONLINE: %w", pcsErr)
+		}
+		if isOnline(out, name) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+	}
+	return fmt.Errorf("timeout waiting for %s to become ONLINE (pcs)", name)
+}
+
+func waitEtcdHealthy(ctx context.Context, timeout time.Duration, ec etcdcli.EtcdClient) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ok, fatal := etcdTwoStarted(ctx, ec)
+		if fatal != nil {
+			return fmt.Errorf("etcdctl check failed: %v", fatal)
+		}
+		if ok {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+	}
+	return fmt.Errorf("timeout waiting for etcd to report 2 started non-learner voters")
+}
+
+func etcdTwoStarted(ctx context.Context, ec etcdcli.EtcdClient) (bool, error) {
+	members, err := ec.VotingMemberList(ctx)
+	if err != nil {
+		return false, fmt.Errorf("list voters: %w", err)
+	}
+	if len(members) < 2 {
+		return false, nil
+	}
+	healthy := 0
+	for _, m := range members {
+		ok, err := ec.IsMemberHealthy(ctx, m)
+		if err != nil {
+			return false, fmt.Errorf("member %s health: %w", m.Name, err)
+		}
+		if ok {
+			healthy++
+		}
+	}
+	return healthy >= 2, nil
+}
+
+func ValidateFencingPeerOnly(ctx context.Context, cfg config.ClusterConfig, ec etcdcli.EtcdClient) error {
+	klog.Info("Validating Fencing (disruptive, peer-only)")
+
+	local, err := localHostname(ctx)
+	if err != nil {
+		return err
+	}
+	target, err := peerOf(cfg, local)
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("Fencing peer node %q from local %q", target, local)
+
+	out, _ := pcsNodesOnline(ctx)
+	if !isOnline(out, target) {
+		return fmt.Errorf("peer %q is not ONLINE before fencing", target)
+	}
+
+	cmd := fmt.Sprintf("/usr/sbin/pcs stonith fence %q --wait=300", target)
+	_, stdErr, fenceErr := exec.Execute(ctx, cmd)
+	if fenceErr != nil {
+		klog.Error(fenceErr, "pcs stonith fence failed", "stderr", stdErr)
+		return fmt.Errorf("pcs stonith fence %q failed: %w", target, fenceErr)
+	}
+	if err := waitPacemakerOffline(ctx, target, 10*time.Minute); err != nil {
+		return err
+	}
+	if err := waitPacemakerOnline(ctx, target, 15*time.Minute); err != nil {
+		return err
+	}
+	if err := waitEtcdHealthy(ctx, 10*time.Minute, ec); err != nil {
+		return err
+	}
+
+	klog.Infof(" peer-only fencing validation passed for peer %q", target)
 	return nil
 }

--- a/pkg/tnf/setup/runner.go
+++ b/pkg/tnf/setup/runner.go
@@ -3,8 +3,11 @@ package setup
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,17 +15,30 @@ import (
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	utilclock "k8s.io/utils/clock"
 
+	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/config"
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/etcd"
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/pcs"
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/tools"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 func RunTnfSetup() error {
-
 	klog.Info("Setting up clients etc. for TNF setup")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	shutdownHandler := server.SetupSignalHandler()
+	go func() {
+		defer cancel()
+		<-shutdownHandler
+		klog.Info("Received SIGTERM or SIGINT signal, terminating")
+	}()
 
 	clientConfig, err := rest.InClusterConfig()
 	if err != nil {
@@ -39,18 +55,51 @@ func RunTnfSetup() error {
 		return err
 	}
 
+	// CRD clients
+	configClient, err := configclient.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+	kubeInformers := v1helpers.NewKubeInformersForNamespaces(
+		kubeClient,
+		operatorclient.TargetNamespace,
+		"",
+	)
+	nodes := kubeInformers.InformersFor("").Core().V1().Nodes()
+
+	cfgInformers := configv1informers.NewSharedInformerFactory(configClient, 0)
+	networkInformer := cfgInformers.Config().V1().Networks()
+
+	recorder := events.NewInMemoryRecorder("tnf-fencing", utilclock.RealClock{})
+
+	stopCh := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(stopCh)
+	}()
+	kubeInformers.Start(stopCh)
+	cfgInformers.Start(stopCh)
+
+	if ok := cache.WaitForCacheSync(
+		ctx.Done(),
+		nodes.Informer().HasSynced,
+		networkInformer.Informer().HasSynced,
+	); !ok {
+		return fmt.Errorf("failed to sync informers for etcd client")
+	}
+
+	ec := etcdcli.NewEtcdClient(
+		kubeInformers,
+		nodes.Informer(),
+		nodes.Lister(),
+		networkInformer,
+		recorder,
+	)
+
 	operatorConfigClient, err := operatorversionedclient.NewForConfig(clientConfig)
 	if err != nil {
 		return err
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	shutdownHandler := server.SetupSignalHandler()
-	go func() {
-		defer cancel()
-		<-shutdownHandler
-		klog.Info("Received SIGTERM or SIGINT signal, terminating")
-	}()
 
 	klog.Info("Waiting for completed auth jobs")
 	authDone := func(context.Context) (done bool, err error) {
@@ -131,6 +180,11 @@ func RunTnfSetup() error {
 		return err
 	}
 
+	if os.Getenv("TNF_VALIDATE_PEER_ONLY") == "true" {
+		if err := pcs.ValidateFencingPeerOnly(ctx, cfg, ec); err != nil {
+			return fmt.Errorf("peer-only disruptive validation failed: %w", err)
+		}
+	}
 	klog.Infof("HA setup done! CIB:\n%s", cib)
 
 	return nil


### PR DESCRIPTION
ValidateDisruptivePeerOnly flow to test fencing a peer node in DualReplica topologies.

Adds fencing validation logic (pcs stonith + etcd quorum check)

Integrates into TNF setup runner behind an environment gate (TNF_VALIDATE_PEER_ONLY)

Improves safety with self-fence guard, explicit error handling, and pcs/etcd health waits