### PR TITLE
NO-JIRA: remove etcd-backup-server from static pod lists

### DIFF
--- a/bindata/etcd/cluster-restore.sh
+++ b/bindata/etcd/cluster-restore.sh
@@ -68,7 +68,7 @@ BACKUP_FILE=$(ls -vd "${BACKUP_DIR}"/static_kuberesources*.tar.gz | tail -1) || 
 SNAPSHOT_FILE=$(ls -vd "${BACKUP_DIR}"/snapshot*.db | tail -1) || true
 
 ETCD_STATIC_POD_LIST=("etcd-pod.yaml")
-ETCD_STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "etcd-readyz" "etcd-rev" "etcd-backup-server")
+ETCD_STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "etcd-readyz" "etcd-rev")
 
 if [ ! -f "${SNAPSHOT_FILE}" ]; then
   echo "etcd snapshot ${SNAPSHOT_FILE} does not exist"

--- a/bindata/etcd/disable-etcd.sh
+++ b/bindata/etcd/disable-etcd.sh
@@ -29,7 +29,7 @@ source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/confi
 source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
 
 ETCD_STATIC_POD_LIST=("etcd-pod.yaml")
-ETCD_STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "etcd-readyz" "etcd-rev" "etcd-backup-server")
+ETCD_STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "etcd-readyz" "etcd-rev")
 
 # always move etcd pod and wait for all containers to exit
 mv_static_pods "${ETCD_STATIC_POD_LIST[@]}"

--- a/bindata/etcd/quorum-restore.sh
+++ b/bindata/etcd/quorum-restore.sh
@@ -28,7 +28,7 @@ source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/confi
 source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
 
 ETCD_STATIC_POD_LIST=("etcd-pod.yaml")
-ETCD_STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "etcd-readyz" "etcd-rev" "etcd-backup-server")
+ETCD_STATIC_POD_CONTAINERS=("etcd" "etcdctl" "etcd-metrics" "etcd-readyz" "etcd-rev")
 
 # always move etcd pod and wait for all containers to exit
 mv_static_pods "${ETCD_STATIC_POD_LIST[@]}"

--- a/pkg/operator/periodicbackupcontroller/periodicbackupcontroller.go
+++ b/pkg/operator/periodicbackupcontroller/periodicbackupcontroller.go
@@ -30,11 +30,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	backupJobLabel                = "backup-name"
-	defaultBackupCRName           = "default"
-	etcdBackupServerContainerName = "etcd-backup-server"
-)
+const backupJobLabel = "backup-name"
 
 type PeriodicBackupController struct {
 	operatorClient        v1helpers.OperatorClient

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -177,21 +177,19 @@ func TestTargetConfigController(t *testing.T) {
 			})
 
 			expectedEnv := map[string][]corev1.EnvVar{
-				"etcdctl":            envWithRevision,
-				"etcd":               envWithRevision,
-				"etcd-metrics":       envWithRevision,
-				"etcd-readyz":        envWithoutRevision,
-				"etcd-rev":           envWithoutRevision,
-				"etcd-backup-server": envWithoutRevision,
+				"etcdctl":      envWithRevision,
+				"etcd":         envWithRevision,
+				"etcd-metrics": envWithRevision,
+				"etcd-readyz":  envWithoutRevision,
+				"etcd-rev":     envWithoutRevision,
 			}
 
 			expectedImage := map[string]string{
-				"etcdctl":            etcdPullSpec,
-				"etcd":               etcdPullSpec,
-				"etcd-metrics":       etcdPullSpec,
-				"etcd-readyz":        operatorPullSpec,
-				"etcd-rev":           operatorPullSpec,
-				"etcd-backup-server": operatorPullSpec,
+				"etcdctl":      etcdPullSpec,
+				"etcd":         etcdPullSpec,
+				"etcd-metrics": etcdPullSpec,
+				"etcd-readyz":  operatorPullSpec,
+				"etcd-rev":     operatorPullSpec,
 			}
 
 			etcdContainerFound := false


### PR DESCRIPTION
As we use `disable-etcd.sh` to disable etcd , it shows as 
```
...stopping etcd-pod.yaml
Waiting for container etcd to stop
.complete
Waiting for container etcdctl to stop
............................complete
Waiting for container etcd-metrics to stop
complete
Waiting for container etcd-readyz to stop
complete
Waiting for container etcd-rev to stop
complete
Waiting for container etcd-backup-server to stop
complete
```

However, the `etcd-backup-server` is not existed in the static pods, which is removed by https://github.com/openshift/cluster-etcd-operator/pull/1358