### PR TITLE
change restore pod readinessProbe to 9980

### DIFF
--- a/bindata/etcd/quorum-restore-pod.yaml
+++ b/bindata/etcd/quorum-restore-pod.yaml
@@ -64,8 +64,10 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      tcpSocket:
-        port: 2380
+      httpGet:
+        port: 9980
+        path: readyz
+        scheme: HTTPS
       failureThreshold: 3
       initialDelaySeconds: 3
       periodSeconds: 5

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -120,8 +120,10 @@ ${COMPUTED_ENV_VARS}
         memory: 600Mi
         cpu: 300m
     readinessProbe:
-      tcpSocket:
-        port: 2380
+      httpGet:
+        port: 9980
+        path: readyz
+        scheme: HTTPS
       failureThreshold: 3
       initialDelaySeconds: 3
       periodSeconds: 5


### PR DESCRIPTION
Since PR [#1367](https://github.com/openshift/cluster-etcd-operator/pull/1367) was merged, we should consider changing the restore pod's readiness probe from tcpSocket: 2380 to httpGet: 9980. This would allow the probe to actually check etcd's readiness status, rather than just verifying that port 2380 is listening