### PR TITLE
certrotation: add configurable PKI support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -159,3 +159,5 @@ replace (
 	github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12
 	vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
 )
+
+replace github.com/openshift/library-go => github.com/sanchezl/library-go v0.0.0-20260408145132-8d5ab9b3d36c

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,6 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7 h1:5GSoQlywIwYsRCw3qN+ZDmN6HrXTMZfI33bdRNm2jRQ=
 github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7/go.mod h1:HhXTUIMhgzxR3Ln/zEkr4QjTL0NN7A+t9Py/we9j2ug=
-github.com/openshift/library-go v0.0.0-20260304110309-c56f4c30de58 h1:3RQXdeYCfbQazMJ/iRr3DL81IGPh/OTN6nGLNsFeRfA=
-github.com/openshift/library-go v0.0.0-20260304110309-c56f4c30de58/go.mod h1:K3FoNLgNBFYbFuG+Kr8usAnQxj1w84XogyUp2M8rK8k=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12 h1:AKx/w1qpS8We43bsRgf8Nll3CGlDHpr/WAXvuedTNZI=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -229,6 +227,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sanchezl/library-go v0.0.0-20260408145132-8d5ab9b3d36c h1:iaZAiw9vpH7MF4Zf8yvvFBkdJKVMOqfL7zR1wTTAERY=
+github.com/sanchezl/library-go v0.0.0-20260408145132-8d5ab9b3d36c/go.mod h1:3bi4pLpYRdVd1aEhsHfRTJkwxwPLfRZ+ZePn3RmJd2k=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/pkg/cmd/render/certs.go
+++ b/pkg/cmd/render/certs.go
@@ -64,7 +64,8 @@ func createCertSecrets(nodes []*corev1.Node, enabledFeatureGates, disabledFeatur
 		recorder,
 		metrics.NewKubeRegistry(),
 		true,
-		featureGateAccessor)
+		featureGateAccessor,
+		nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not run etcdCertSignerController control loop: %w", err)
 	}

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -23,10 +23,12 @@ import (
 	apiannotations "github.com/openshift/api/annotations"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/health"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/pki"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
@@ -85,6 +87,10 @@ type EtcdCertSignerController struct {
 
 	certConfig *certConfig
 
+	// pkiProfileProvider is set when the ConfigurablePKI feature gate is enabled.
+	// It is used to resolve key algorithms for per-node certificates created at sync time.
+	pkiProfileProvider pki.PKIProfileProvider
+
 	// metrics
 	signerExpirationGauge *metrics.GaugeVec
 
@@ -108,6 +114,7 @@ func NewEtcdCertSignerController(
 	metricsRegistry metrics.KubeRegistry,
 	forceSkipRollout bool,
 	featureGateAccessor featuregates.FeatureGateAccess,
+	configInformer configinformers.SharedInformerFactory,
 ) (factory.Controller, error) {
 	eventRecorder = eventRecorder.WithComponentSuffix("etcd-cert-signer-controller")
 	cmInformer := kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps()
@@ -160,11 +167,26 @@ func NewEtcdCertSignerController(
 		}
 	}
 
+	var pkiProfileProvider pki.PKIProfileProvider
+	if featureGates.Enabled(features.FeatureGateConfigurablePKI) && configInformer != nil {
+		pkiProfileProvider = pki.NewClusterPKIProfileProvider(configInformer.Config().V1alpha1().PKIs().Lister())
+	}
+
 	signerCert := tlshelpers.CreateSignerCert(secretInformer, secretLister, secretClient, eventRecorder, signerValidity)
+	signerCert.CertificateName = "etcd.etcd-signer"
+	signerCert.PKIProfileProvider = pkiProfileProvider
+
 	etcdClientCert := tlshelpers.CreateEtcdClientCert(secretInformer, secretLister, secretClient, eventRecorder, certValidity)
+	etcdClientCert.CertificateName = "etcd.etcd-client"
+	etcdClientCert.PKIProfileProvider = pkiProfileProvider
 
 	metricsSignerCert := tlshelpers.CreateMetricsSignerCert(secretInformer, secretLister, secretClient, eventRecorder, signerValidity)
+	metricsSignerCert.CertificateName = "etcd.etcd-metric-signer"
+	metricsSignerCert.PKIProfileProvider = pkiProfileProvider
+
 	metricsClientCert := tlshelpers.CreateMetricsClientCert(secretInformer, secretLister, secretClient, eventRecorder, certValidity)
+	metricsClientCert.CertificateName = "etcd.etcd-metric-client"
+	metricsClientCert.PKIProfileProvider = pkiProfileProvider
 
 	certCfg := &certConfig{
 		signerCaBundle: signerCaBundle,
@@ -195,6 +217,7 @@ func NewEtcdCertSignerController(
 		// this one can go through the informers, it's only used for bootstrap checks
 		configmapLister:       kubeInformers.InformersFor(operatorclient.KubeSystemNamespace).Core().V1().ConfigMaps().Lister(),
 		certConfig:            certCfg,
+		pkiProfileProvider:    pkiProfileProvider,
 		signerExpirationGauge: signerExpirationGauge,
 		forceSkipRollout:      forceSkipRollout,
 		signerValidity:        signerValidity,
@@ -519,6 +542,8 @@ func (c *EtcdCertSignerController) createNodeCertConfigs() ([]*nodeCertConfigs, 
 		if err != nil {
 			return cfgs, fmt.Errorf("error creating peer cert for node [%s]: %w", node.Name, err)
 		}
+		peerCert.CertificateName = "etcd.etcd-peer"
+		peerCert.PKIProfileProvider = c.pkiProfileProvider
 
 		servingCert, err := tlshelpers.CreateServingCertificate(node,
 			c.secretInformer,
@@ -529,6 +554,8 @@ func (c *EtcdCertSignerController) createNodeCertConfigs() ([]*nodeCertConfigs, 
 		if err != nil {
 			return cfgs, fmt.Errorf("error creating serving cert for node [%s]: %w", node.Name, err)
 		}
+		servingCert.CertificateName = "etcd.etcd-serving"
+		servingCert.PKIProfileProvider = c.pkiProfileProvider
 
 		metricsCert, err := tlshelpers.CreateMetricsServingCertificate(node,
 			c.secretInformer,
@@ -539,6 +566,8 @@ func (c *EtcdCertSignerController) createNodeCertConfigs() ([]*nodeCertConfigs, 
 		if err != nil {
 			return cfgs, fmt.Errorf("error creating metrics cert for node [%s]: %w", node.Name, err)
 		}
+		metricsCert.CertificateName = "etcd.etcd-serving-metrics"
+		metricsCert.PKIProfileProvider = c.pkiProfileProvider
 
 		cfgs = append(cfgs, &nodeCertConfigs{
 			node:        node.DeepCopy(),

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -606,7 +606,7 @@ func setupController(t *testing.T, objects []runtime.Object, forceSkipRollout bo
 	legacyregistry.DefaultGatherer = registry
 
 	enabledFeatureGates := sets.New(features.FeatureShortCertRotation)
-	disabledFeatureGates := sets.New[configv1.FeatureGateName]()
+	disabledFeatureGates := sets.New[configv1.FeatureGateName](features.FeatureGateConfigurablePKI)
 	featureGateAccessor := featuregates.NewHardcodedFeatureGateAccess(enabledFeatureGates.UnsortedList(), disabledFeatureGates.UnsortedList())
 	controller, err := NewEtcdCertSignerController(
 		health.NewMultiAlivenessChecker(),
@@ -619,7 +619,8 @@ func setupController(t *testing.T, objects []runtime.Object, forceSkipRollout bo
 		recorder,
 		registry,
 		forceSkipRollout,
-		featureGateAccessor)
+		featureGateAccessor,
+		nil)
 	require.NoError(t, err)
 
 	stopChan := make(chan struct{})

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -440,6 +440,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		legacyregistry.DefaultGatherer.(metrics.KubeRegistry),
 		false,
 		featureGateAccessor,
+		configInformers,
 	)
 	if err != nil {
 		return fmt.Errorf("could not start etcdCertSignerController, aborting controller start: %w", err)

--- a/pkg/tlshelpers/target_cert_creator_test.go
+++ b/pkg/tlshelpers/target_cert_creator_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/openshift/library-go/pkg/operator/certrotation"
+	"github.com/openshift/library-go/pkg/pki"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
@@ -32,7 +33,7 @@ type testEmbed struct {
 	result string
 }
 
-func (t *testEmbed) NewCertificate(_ *crypto.CA, _ time.Duration) (*crypto.TLSCertificateConfig, error) {
+func (t *testEmbed) NewCertificate(_ *crypto.CA, _ time.Duration, _ crypto.KeyPairGenerator) (*crypto.TLSCertificateConfig, error) {
 	panic("implement me")
 }
 
@@ -42,6 +43,10 @@ func (t *testEmbed) SetAnnotations(_ *crypto.TLSCertificateConfig, _ map[string]
 
 func (t *testEmbed) NeedNewTargetCertKeyPair(_ *corev1.Secret, _ *crypto.CA, _ []*x509.Certificate, _ time.Duration, _ bool, _ bool) string {
 	return t.result
+}
+
+func (t *testEmbed) CertificateType() pki.CertificateType {
+	return pki.CertificateTypeServing
 }
 
 func TestEmbeddedStructHasPriority(t *testing.T) {

--- a/pkg/tlshelpers/tlshelpers.go
+++ b/pkg/tlshelpers/tlshelpers.go
@@ -239,15 +239,12 @@ func createCertForNode(description, secretName string, node *corev1.Node,
 	hostNames := getServerHostNames(ipAddresses)
 
 	creator := &CARotatingTargetCertCreator{
-		&certrotation.ServingRotation{
+		&certrotation.PeerRotation{
 			Hostnames: func() []string {
 				return hostNames
 			},
-			CertificateExtensionFn: []crypto.CertificateExtensionFunc{
-				func(certificate *x509.Certificate) error {
-					certificate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
-					return nil
-				},
+			UserInfo: &user.DefaultInfo{
+				Name: hostNames[0],
 			},
 		},
 	}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/cert_config.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/cert_config.go
@@ -1,0 +1,225 @@
+package crypto
+
+import (
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// KeyPairGenerator generates a cryptographic key pair.
+type KeyPairGenerator interface {
+	GenerateKeyPair() (crypto.PublicKey, crypto.PrivateKey, error)
+}
+
+// NewSigningCertificate creates a CA certificate.
+// By default it creates a self-signed root CA. Use WithSigner to create an
+// intermediate CA signed by a parent CA.
+// The name parameter is used as the CommonName unless overridden with WithSubject.
+// Optional: WithSigner, WithSubject, WithLifetime (defaults to DefaultCACertificateLifetimeDuration).
+func NewSigningCertificate(name string, keyGen KeyPairGenerator, opts ...CertificateOption) (*TLSCertificateConfig, error) {
+	o := &CertificateOptions{
+		lifetime: DefaultCACertificateLifetimeDuration,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	subject := pkix.Name{CommonName: name}
+	if o.subject != nil {
+		subject = *o.subject
+	}
+
+	publicKey, privateKey, err := keyGen.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+	subjectKeyId, err := SubjectKeyIDFromPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute subject key ID: %w", err)
+	}
+
+	if o.signer != nil {
+		// Intermediate CA signed by the provided signer.
+		authorityKeyId := o.signer.Config.Certs[0].SubjectKeyId
+		template := newSigningCertificateTemplateForDuration(subject, o.lifetime, time.Now, authorityKeyId, subjectKeyId)
+		template.SignatureAlgorithm = 0
+		template.KeyUsage = KeyUsageForPublicKey(publicKey) | x509.KeyUsageCertSign
+
+		cert, err := o.signer.SignCertificate(template, publicKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign certificate: %w", err)
+		}
+
+		return &TLSCertificateConfig{
+			Certs: append([]*x509.Certificate{cert}, o.signer.Config.Certs...),
+			Key:   privateKey,
+		}, nil
+	}
+
+	// Self-signed root CA. AuthorityKeyId and SubjectKeyId match.
+	template := newSigningCertificateTemplateForDuration(subject, o.lifetime, time.Now, subjectKeyId, subjectKeyId)
+	template.SignatureAlgorithm = 0
+	template.KeyUsage = KeyUsageForPublicKey(publicKey) | x509.KeyUsageCertSign
+
+	cert, err := signCertificate(template, publicKey, template, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign certificate: %w", err)
+	}
+
+	return &TLSCertificateConfig{
+		Certs: []*x509.Certificate{cert},
+		Key:   privateKey,
+	}, nil
+}
+
+// NewServerCertificate creates a server/serving certificate signed by this CA.
+// Optional: WithLifetime (defaults to DefaultCertificateLifetimeDuration), WithExtensions.
+func (ca *CA) NewServerCertificate(hostnames sets.Set[string], keyGen KeyPairGenerator, opts ...CertificateOption) (*TLSCertificateConfig, error) {
+	o := &CertificateOptions{
+		lifetime: DefaultCertificateLifetimeDuration,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	publicKey, privateKey, err := keyGen.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+	subjectKeyId, err := SubjectKeyIDFromPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute subject key ID: %w", err)
+	}
+
+	sortedHostnames := sets.List(hostnames)
+	authorityKeyId := ca.Config.Certs[0].SubjectKeyId
+	template := newServerCertificateTemplateForDuration(
+		pkix.Name{CommonName: sortedHostnames[0]},
+		sortedHostnames,
+		o.lifetime,
+		time.Now,
+		authorityKeyId,
+		subjectKeyId,
+	)
+	// Let x509.CreateCertificate auto-detect the signature algorithm from the CA's key.
+	template.SignatureAlgorithm = 0
+	template.KeyUsage = KeyUsageForPublicKey(publicKey)
+
+	for _, fn := range o.extensionFns {
+		if err := fn(template); err != nil {
+			return nil, fmt.Errorf("failed to apply certificate extension: %w", err)
+		}
+	}
+
+	cert, err := ca.SignCertificate(template, publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign certificate: %w", err)
+	}
+
+	return &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{cert}, ca.Config.Certs...),
+		Key:   privateKey,
+	}, nil
+}
+
+// NewClientCertificate creates a client certificate signed by this CA.
+// Optional: WithLifetime (defaults to DefaultCertificateLifetimeDuration).
+func (ca *CA) NewClientCertificate(u user.Info, keyGen KeyPairGenerator, opts ...CertificateOption) (*TLSCertificateConfig, error) {
+	o := &CertificateOptions{
+		lifetime: DefaultCertificateLifetimeDuration,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	publicKey, privateKey, err := keyGen.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+	subjectKeyId, err := SubjectKeyIDFromPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute subject key ID: %w", err)
+	}
+
+	authorityKeyId := ca.Config.Certs[0].SubjectKeyId
+	template := NewClientCertificateTemplateForDuration(UserToSubject(u), o.lifetime, time.Now)
+	template.AuthorityKeyId = authorityKeyId
+	template.SubjectKeyId = subjectKeyId
+	// Let x509.CreateCertificate auto-detect the signature algorithm from the CA's key.
+	template.SignatureAlgorithm = 0
+	template.KeyUsage = KeyUsageForPublicKey(publicKey)
+
+	cert, err := ca.SignCertificate(template, publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign certificate: %w", err)
+	}
+
+	return &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{cert}, ca.Config.Certs...),
+		Key:   privateKey,
+	}, nil
+}
+
+// NewPeerCertificate creates a peer certificate (both server and client auth)
+// signed by this CA.
+// Optional: WithLifetime (defaults to DefaultCertificateLifetimeDuration), WithExtensions.
+func (ca *CA) NewPeerCertificate(hostnames sets.Set[string], u user.Info, keyGen KeyPairGenerator, opts ...CertificateOption) (*TLSCertificateConfig, error) {
+	o := &CertificateOptions{
+		lifetime: DefaultCertificateLifetimeDuration,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	publicKey, privateKey, err := keyGen.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+	subjectKeyId, err := SubjectKeyIDFromPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute subject key ID: %w", err)
+	}
+
+	sortedHostnames := sets.List(hostnames)
+	authorityKeyId := ca.Config.Certs[0].SubjectKeyId
+
+	// Start from a server certificate template for the hostnames.
+	template := newServerCertificateTemplateForDuration(
+		pkix.Name{CommonName: sortedHostnames[0]},
+		sortedHostnames,
+		o.lifetime,
+		time.Now,
+		authorityKeyId,
+		subjectKeyId,
+	)
+	// Let x509.CreateCertificate auto-detect the signature algorithm from the CA's key.
+	template.SignatureAlgorithm = 0
+	template.KeyUsage = KeyUsageForPublicKey(publicKey)
+
+	// Set subject from user info for client authentication.
+	template.Subject = UserToSubject(u)
+
+	// Enable both server and client authentication.
+	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+
+	for _, fn := range o.extensionFns {
+		if err := fn(template); err != nil {
+			return nil, fmt.Errorf("failed to apply certificate extension: %w", err)
+		}
+	}
+
+	cert, err := ca.SignCertificate(template, publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign certificate: %w", err)
+	}
+
+	return &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{cert}, ca.Config.Certs...),
+		Key:   privateKey,
+	}, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/keygen.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/keygen.go
@@ -1,0 +1,118 @@
+package crypto
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"fmt"
+)
+
+// KeyAlgorithm identifies the key generation algorithm.
+type KeyAlgorithm string
+
+const (
+	// RSAKeyAlgorithm specifies RSA key generation.
+	RSAKeyAlgorithm KeyAlgorithm = "RSA"
+	// ECDSAKeyAlgorithm specifies ECDSA key generation.
+	ECDSAKeyAlgorithm KeyAlgorithm = "ECDSA"
+)
+
+// ECDSACurve identifies a named ECDSA curve.
+type ECDSACurve string
+
+const (
+	// P256 specifies the NIST P-256 curve (secp256r1), providing 128-bit security.
+	P256 ECDSACurve = "P256"
+	// P384 specifies the NIST P-384 curve (secp384r1), providing 192-bit security.
+	P384 ECDSACurve = "P384"
+	// P521 specifies the NIST P-521 curve (secp521r1), providing 256-bit security.
+	P521 ECDSACurve = "P521"
+)
+
+// RSAKeyPairGenerator generates RSA key pairs.
+type RSAKeyPairGenerator struct {
+	// Bits is the RSA key size in bits. Must be >= 2048.
+	Bits int
+}
+
+func (g RSAKeyPairGenerator) GenerateKeyPair() (crypto.PublicKey, crypto.PrivateKey, error) {
+	bits := g.Bits
+	if bits == 0 {
+		bits = keyBits
+	}
+	privateKey, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &privateKey.PublicKey, privateKey, nil
+}
+
+// ECDSAKeyPairGenerator generates ECDSA key pairs.
+type ECDSAKeyPairGenerator struct {
+	// Curve is the named ECDSA curve.
+	Curve ECDSACurve
+}
+
+func (g ECDSAKeyPairGenerator) GenerateKeyPair() (crypto.PublicKey, crypto.PrivateKey, error) {
+	curve, err := g.ellipticCurve()
+	if err != nil {
+		return nil, nil, err
+	}
+	privateKey, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &privateKey.PublicKey, privateKey, nil
+}
+
+func (g ECDSAKeyPairGenerator) ellipticCurve() (elliptic.Curve, error) {
+	switch g.Curve {
+	case P256:
+		return elliptic.P256(), nil
+	case P384:
+		return elliptic.P384(), nil
+	case P521:
+		return elliptic.P521(), nil
+	default:
+		return nil, fmt.Errorf("unsupported ECDSA curve: %q", g.Curve)
+	}
+}
+
+// KeyUsageForPublicKey returns the x509.KeyUsage flags appropriate for the
+// given public key type. ECDSA keys use DigitalSignature only; RSA keys also
+// include KeyEncipherment.
+func KeyUsageForPublicKey(pub crypto.PublicKey) x509.KeyUsage {
+	switch pub.(type) {
+	case *ecdsa.PublicKey:
+		return x509.KeyUsageDigitalSignature
+	default:
+		return x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
+	}
+}
+
+// SubjectKeyIDFromPublicKey computes a truncated SHA-256 hash suitable for
+// use as a certificate SubjectKeyId from any supported public key type.
+// This uses the first 160 bits of the SHA-256 hash per RFC 7093, consistent
+// with the Go standard library since Go 1.25 (go.dev/issue/71746) and
+// Let's Encrypt. Prior Go versions used SHA-1 which is not FIPS-compatible.
+func SubjectKeyIDFromPublicKey(pub crypto.PublicKey) ([]byte, error) {
+	var rawBytes []byte
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		rawBytes = pub.N.Bytes()
+	case *ecdsa.PublicKey:
+		ecdhKey, err := pub.ECDH()
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert ECDSA public key: %w", err)
+		}
+		rawBytes = ecdhKey.Bytes()
+	default:
+		return nil, fmt.Errorf("unsupported public key type: %T", pub)
+	}
+	hash := sha256.Sum256(rawBytes)
+	return hash[:20], nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/options.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/options.go
@@ -1,0 +1,49 @@
+package crypto
+
+import (
+	"crypto/x509/pkix"
+	"time"
+)
+
+// CertificateOptions holds optional configuration collected from functional options.
+type CertificateOptions struct {
+	lifetime     time.Duration
+	subject      *pkix.Name
+	extensionFns []CertificateExtensionFunc
+	signer       *CA
+}
+
+// CertificateOption is a functional option for certificate creation.
+type CertificateOption func(*CertificateOptions)
+
+// WithLifetime sets the certificate lifetime duration.
+func WithLifetime(d time.Duration) CertificateOption {
+	return func(o *CertificateOptions) {
+		o.lifetime = d
+	}
+}
+
+// WithSubject overrides the certificate subject. For signing certificates,
+// this overrides the default subject derived from the name parameter.
+func WithSubject(s pkix.Name) CertificateOption {
+	return func(o *CertificateOptions) {
+		o.subject = &s
+	}
+}
+
+// WithSigner specifies a CA to sign the certificate. When used with
+// NewSigningCertificate, this creates an intermediate CA signed by the
+// given CA instead of a self-signed root CA.
+func WithSigner(ca *CA) CertificateOption {
+	return func(o *CertificateOptions) {
+		o.signer = ca
+	}
+}
+
+// WithExtensions adds certificate extension functions that are called
+// to modify the certificate template before signing.
+func WithExtensions(fns ...CertificateExtensionFunc) CertificateOption {
+	return func(o *CertificateOptions) {
+		o.extensionFns = append(o.extensionFns, fns...)
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/tls_adherence.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/tls_adherence.go
@@ -1,0 +1,23 @@
+package crypto
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// ShouldHonorClusterTLSProfile returns true if the component should honor the
+// cluster-wide TLS security profile settings from apiserver.config.openshift.io/cluster.
+//
+// When this returns true (StrictAllComponents mode), components must honor the
+// cluster-wide TLS profile unless they have a component-specific TLS configuration
+// that overrides it.
+//
+// Unknown enum values are treated as StrictAllComponents for forward compatibility
+// and to default to the more secure behavior.
+func ShouldHonorClusterTLSProfile(tlsAdherence configv1.TLSAdherencePolicy) bool {
+	switch tlsAdherence {
+	case configv1.TLSAdherencePolicyNoOpinion, configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly:
+		return false
+	default:
+		return true
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -6,13 +6,12 @@ import (
 	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -80,6 +79,7 @@ func NewCertRotationController(
 		RotatedSelfSignedCertKeySecret: rotatedSelfSignedCertKeySecret,
 		StatusReporter:                 reporter,
 	}
+
 	return factory.New().
 		ResyncEvery(time.Minute).
 		WithSync(c.Sync).

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+	"github.com/openshift/library-go/pkg/pki"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,6 +48,13 @@ type RotatedSigningCASecret struct {
 
 	// AdditionalAnnotations is a collection of annotations set for the secret
 	AdditionalAnnotations AdditionalAnnotations
+
+	// CertificateName is the logical name of this certificate for PKI profile resolution.
+	CertificateName string
+
+	// PKIProfileProvider, when non-nil, enables ConfigurablePKI certificate
+	// key algorithm resolution. When nil, legacy certificate generation is used.
+	PKIProfileProvider pki.PKIProfileProvider
 
 	// Plumbing:
 	Informer      corev1informers.SecretInformer
@@ -87,12 +95,12 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 
 	// run Update if signer content needs changing
 	signerUpdated := false
-	if needed, reason := needNewSigningCertKeyPair(signingCertKeyPairSecret, c.Refresh, c.RefreshOnlyWhenExpired); needed || creationRequired {
+	if needed, reason := c.needNewSigningCertKeyPair(signingCertKeyPairSecret); needed || creationRequired {
 		if creationRequired {
 			reason = "secret doesn't exist"
 		}
 		c.EventRecorder.Eventf("SignerUpdateRequired", "%q in %q requires a new signing cert/key pair: %v", c.Name, c.Namespace, reason)
-		if err = setSigningCertKeyPairSecretAndTLSAnnotations(signingCertKeyPairSecret, c.Validity, c.Refresh, c.AdditionalAnnotations); err != nil {
+		if err = c.setSigningCertKeyPairSecretAndTLSAnnotations(signingCertKeyPairSecret); err != nil {
 			return nil, false, err
 		}
 
@@ -149,7 +157,7 @@ func ensureOwnerReference(meta *metav1.ObjectMeta, owner *metav1.OwnerReference)
 	return false
 }
 
-func needNewSigningCertKeyPair(secret *corev1.Secret, refresh time.Duration, refreshOnlyWhenExpired bool) (bool, string) {
+func (c RotatedSigningCASecret) needNewSigningCertKeyPair(secret *corev1.Secret) (bool, string) {
 	annotations := secret.Annotations
 	notBefore, notAfter, reason := getValidityFromAnnotations(annotations)
 	if len(reason) > 0 {
@@ -160,7 +168,7 @@ func needNewSigningCertKeyPair(secret *corev1.Secret, refresh time.Duration, ref
 		return true, "already expired"
 	}
 
-	if refreshOnlyWhenExpired {
+	if c.RefreshOnlyWhenExpired {
 		return false, ""
 	}
 
@@ -170,7 +178,7 @@ func needNewSigningCertKeyPair(secret *corev1.Secret, refresh time.Duration, ref
 		return true, fmt.Sprintf("past refresh time (80%% of validity): %v", at80Percent)
 	}
 
-	developerSpecifiedRefresh := notBefore.Add(refresh)
+	developerSpecifiedRefresh := notBefore.Add(c.Refresh)
 	if time.Now().After(developerSpecifiedRefresh) {
 		return true, fmt.Sprintf("past its refresh time %v", developerSpecifiedRefresh)
 	}
@@ -199,22 +207,67 @@ func getValidityFromAnnotations(annotations map[string]string) (notBefore time.T
 	return notBefore, notAfter, ""
 }
 
+func (c RotatedSigningCASecret) resolveKeyPairGenerator() (crypto.KeyPairGenerator, error) {
+	return resolveKeyPairGeneratorWithFallback(c.PKIProfileProvider, pki.CertificateTypeSigner, c.CertificateName)
+}
+
+// resolveKeyPairGeneratorWithFallback resolves the key pair generator from the
+// PKI profile provider. Returns nil for Unmanaged mode (no key override).
+//
+// TODO(sanchezl): Remove the fallback to DefaultPKIProfile() once installer
+// support for the PKI resource is in place. Until then, the PKI resource may
+// not exist in TechPreview clusters. Once removed, callers can use
+// pki.ResolveCertificateConfig directly.
+func resolveKeyPairGeneratorWithFallback(provider pki.PKIProfileProvider, certType pki.CertificateType, name string) (crypto.KeyPairGenerator, error) {
+	cfg, err := pki.ResolveCertificateConfig(provider, certType, name)
+	if err != nil {
+		klog.Warningf("Failed to resolve PKI config for %s %q, falling back to default profile: %v", certType, name, err)
+		defaultProfile := pki.DefaultPKIProfile()
+		cfg, err = pki.ResolveCertificateConfig(pki.NewStaticPKIProfileProvider(&defaultProfile), certType, name)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if cfg == nil {
+		return nil, nil
+	}
+	return cfg.Key, nil
+}
+
 // setSigningCertKeyPairSecretAndTLSAnnotations generates a new signing certificate and key pair,
 // stores them in the specified secret, and adds predefined TLS annotations to that secret.
-func setSigningCertKeyPairSecretAndTLSAnnotations(signingCertKeyPairSecret *corev1.Secret, validity, refresh time.Duration, tlsAnnotations AdditionalAnnotations) error {
-	ca, err := setSigningCertKeyPairSecret(signingCertKeyPairSecret, validity)
+func (c RotatedSigningCASecret) setSigningCertKeyPairSecretAndTLSAnnotations(signingCertKeyPairSecret *corev1.Secret) error {
+	ca, err := c.setSigningCertKeyPairSecret(signingCertKeyPairSecret)
 	if err != nil {
 		return err
 	}
 
-	setTLSAnnotationsOnSigningCertKeyPairSecret(signingCertKeyPairSecret, ca, refresh, tlsAnnotations)
+	c.setTLSAnnotationsOnSigningCertKeyPairSecret(signingCertKeyPairSecret, ca)
 	return nil
 }
 
-// setSigningCertKeyPairSecret creates a new signing cert/key pair and sets them in the secret
-func setSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+// setSigningCertKeyPairSecret creates a new signing cert/key pair and sets them in the secret.
+func (c RotatedSigningCASecret) setSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret) (*crypto.TLSCertificateConfig, error) {
 	signerName := fmt.Sprintf("%s_%s@%d", signingCertKeyPairSecret.Namespace, signingCertKeyPairSecret.Name, time.Now().Unix())
-	ca, err := crypto.MakeSelfSignedCAConfigForDuration(signerName, validity)
+
+	var ca *crypto.TLSCertificateConfig
+	var err error
+	if c.PKIProfileProvider != nil {
+		keyGen, err := c.resolveKeyPairGenerator()
+		if err != nil {
+			return nil, err
+		}
+		if keyGen != nil {
+			ca, err = crypto.NewSigningCertificate(signerName, keyGen, crypto.WithLifetime(c.Validity))
+			if err != nil {
+				return nil, err
+			}
+		}
+		// nil keyGen means Unmanaged: fall through to legacy cert generation
+	}
+	if ca == nil {
+		ca, err = crypto.MakeSelfSignedCAConfigForDuration(signerName, c.Validity)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -243,11 +296,12 @@ func setSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, validi
 //
 // These assumptions are safe because this function is only called after the secret
 // has been initialized in setSigningCertKeyPairSecret.
-func setTLSAnnotationsOnSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, ca *crypto.TLSCertificateConfig, refresh time.Duration, tlsAnnotations AdditionalAnnotations) {
+func (c RotatedSigningCASecret) setTLSAnnotationsOnSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, ca *crypto.TLSCertificateConfig) {
 	signingCertKeyPairSecret.Annotations[CertificateIssuer] = ca.Certs[0].Issuer.CommonName
 
+	tlsAnnotations := c.AdditionalAnnotations
 	tlsAnnotations.NotBefore = ca.Certs[0].NotBefore.Format(time.RFC3339)
 	tlsAnnotations.NotAfter = ca.Certs[0].NotAfter.Format(time.RFC3339)
-	tlsAnnotations.RefreshPeriod = refresh.String()
+	tlsAnnotations.RefreshPeriod = c.Refresh.String()
 	_ = tlsAnnotations.EnsureTLSMetadataUpdate(&signingCertKeyPairSecret.ObjectMeta)
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+	"github.com/openshift/library-go/pkg/pki"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -64,6 +65,13 @@ type RotatedSelfSignedCertKeySecret struct {
 	// CertCreator does the actual cert generation.
 	CertCreator TargetCertCreator
 
+	// CertificateName is the logical name of this certificate for PKI profile resolution.
+	CertificateName string
+
+	// PKIProfileProvider, when non-nil, enables ConfigurablePKI certificate
+	// key algorithm resolution. When nil, legacy certificate generation is used.
+	PKIProfileProvider pki.PKIProfileProvider
+
 	// Plumbing:
 	Informer      corev1informers.SecretInformer
 	Lister        corev1listers.SecretLister
@@ -72,12 +80,15 @@ type RotatedSelfSignedCertKeySecret struct {
 }
 
 type TargetCertCreator interface {
-	// NewCertificate creates a new key-cert pair with the given signer.
-	NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error)
+	// NewCertificate creates a new key-cert pair with the given signer. If keyGen
+	// is non-nil, it is used to generate the key pair; otherwise legacy defaults are used.
+	NewCertificate(signer *crypto.CA, validity time.Duration, keyGen crypto.KeyPairGenerator) (*crypto.TLSCertificateConfig, error)
 	// NeedNewTargetCertKeyPair decides whether a new cert-key pair is needed. It returns a non-empty reason if it is the case.
 	NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, creationRequired bool) string
 	// SetAnnotations gives an option to override or set additional annotations
 	SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string
+	// CertificateType returns the category of certificate this creator produces.
+	CertificateType() pki.CertificateType
 }
 
 // TargetCertRechecker is an optional interface to be implemented by the TargetCertCreator to enforce
@@ -121,7 +132,7 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 
 	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired, creationRequired); len(reason) > 0 {
 		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair: %v", c.Name, c.Namespace, reason)
-		if err = setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret, c.Validity, c.Refresh, signingCertKeyPair, c.CertCreator, c.AdditionalAnnotations); err != nil {
+		if err = c.setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret, signingCertKeyPair); err != nil {
 			return nil, err
 		}
 
@@ -239,19 +250,19 @@ func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *cryp
 
 // setTargetCertKeyPairSecretAndTLSAnnotations generates a new cert/key pair,
 // stores them in the specified secret, and adds predefined TLS annotations to that secret.
-func setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret *corev1.Secret, validity, refresh time.Duration, signer *crypto.CA, certCreator TargetCertCreator, tlsAnnotations AdditionalAnnotations) error {
-	certKeyPair, err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, validity, signer, certCreator)
+func (c RotatedSelfSignedCertKeySecret) setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret *corev1.Secret, signer *crypto.CA) error {
+	certKeyPair, err := c.setTargetCertKeyPairSecret(targetCertKeyPairSecret, signer)
 	if err != nil {
 		return err
 	}
 
-	setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret, certKeyPair, certCreator, refresh, tlsAnnotations)
+	c.setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret, certKeyPair)
 	return nil
 }
 
 // setTargetCertKeyPairSecret creates a new cert/key pair and sets them in the secret.  Only one of client, serving, or signer rotation may be specified.
 // TODO refactor with an interface for actually signing and move the one-of check higher in the stack.
-func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, certCreator TargetCertCreator) (*crypto.TLSCertificateConfig, error) {
+func (c RotatedSelfSignedCertKeySecret) setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, signer *crypto.CA) (*crypto.TLSCertificateConfig, error) {
 	if targetCertKeyPairSecret.Annotations == nil {
 		targetCertKeyPairSecret.Annotations = map[string]string{}
 	}
@@ -260,13 +271,22 @@ func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity
 	}
 
 	// our annotation is based on our cert validity, so we want to make sure that we don't specify something past our signer
-	targetValidity := validity
+	targetValidity := c.Validity
 	remainingSignerValidity := signer.Config.Certs[0].NotAfter.Sub(time.Now())
-	if remainingSignerValidity < validity {
+	if remainingSignerValidity < targetValidity {
 		targetValidity = remainingSignerValidity
 	}
 
-	certKeyPair, err := certCreator.NewCertificate(signer, targetValidity)
+	var keyGen crypto.KeyPairGenerator
+	if c.PKIProfileProvider != nil {
+		var err error
+		keyGen, err = c.resolveKeyPairGenerator()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	certKeyPair, err := c.CertCreator.NewCertificate(signer, targetValidity, keyGen)
 	if err != nil {
 		return nil, err
 	}
@@ -282,22 +302,34 @@ func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity
 //
 // These assumptions are safe because this function is only called after the secret
 // has been initialized in setTargetCertKeyPairSecret.
-func setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, certKeyPair *crypto.TLSCertificateConfig, certCreator TargetCertCreator, refresh time.Duration, tlsAnnotations AdditionalAnnotations) {
+func (c RotatedSelfSignedCertKeySecret) setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, certKeyPair *crypto.TLSCertificateConfig) {
 	targetCertKeyPairSecret.Annotations[CertificateIssuer] = certKeyPair.Certs[0].Issuer.CommonName
 
+	tlsAnnotations := c.AdditionalAnnotations
 	tlsAnnotations.NotBefore = certKeyPair.Certs[0].NotBefore.Format(time.RFC3339)
 	tlsAnnotations.NotAfter = certKeyPair.Certs[0].NotAfter.Format(time.RFC3339)
-	tlsAnnotations.RefreshPeriod = refresh.String()
+	tlsAnnotations.RefreshPeriod = c.Refresh.String()
 	_ = tlsAnnotations.EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta)
 
-	certCreator.SetAnnotations(certKeyPair, targetCertKeyPairSecret.Annotations)
+	c.CertCreator.SetAnnotations(certKeyPair, targetCertKeyPairSecret.Annotations)
+}
+
+func (c RotatedSelfSignedCertKeySecret) resolveKeyPairGenerator() (crypto.KeyPairGenerator, error) {
+	return resolveKeyPairGeneratorWithFallback(c.PKIProfileProvider, c.CertCreator.CertificateType(), c.CertificateName)
 }
 
 type ClientRotation struct {
 	UserInfo user.Info
 }
 
-func (r *ClientRotation) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+func (r *ClientRotation) CertificateType() pki.CertificateType {
+	return pki.CertificateTypeClient
+}
+
+func (r *ClientRotation) NewCertificate(signer *crypto.CA, validity time.Duration, keyGen crypto.KeyPairGenerator) (*crypto.TLSCertificateConfig, error) {
+	if keyGen != nil {
+		return signer.NewClientCertificate(r.UserInfo, keyGen, crypto.WithLifetime(validity))
+	}
 	return signer.MakeClientCertificateForDuration(r.UserInfo, validity)
 }
 
@@ -315,9 +347,20 @@ type ServingRotation struct {
 	HostnamesChanged       <-chan struct{}
 }
 
-func (r *ServingRotation) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+func (r *ServingRotation) CertificateType() pki.CertificateType {
+	return pki.CertificateTypeServing
+}
+
+func (r *ServingRotation) NewCertificate(signer *crypto.CA, validity time.Duration, keyGen crypto.KeyPairGenerator) (*crypto.TLSCertificateConfig, error) {
 	if len(r.Hostnames()) == 0 {
 		return nil, fmt.Errorf("no hostnames set")
+	}
+	if keyGen != nil {
+		return signer.NewServerCertificate(
+			sets.New(r.Hostnames()...), keyGen,
+			crypto.WithLifetime(validity),
+			crypto.WithExtensions(r.CertificateExtensionFn...),
+		)
 	}
 	return signer.MakeServerCertForDuration(sets.New(r.Hostnames()...), validity, r.CertificateExtensionFn...)
 }
@@ -336,18 +379,25 @@ func (r *ServingRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Sec
 }
 
 func (r *ServingRotation) missingHostnames(annotations map[string]string) string {
+	return missingHostnames(annotations, r.Hostnames())
+}
+
+func (r *ServingRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
+	return setHostnameAnnotations(cert, annotations)
+}
+
+func missingHostnames(annotations map[string]string, hostnames []string) string {
 	existingHostnames := sets.New(strings.Split(annotations[CertificateHostnames], ",")...)
-	requiredHostnames := sets.New(r.Hostnames()...)
+	requiredHostnames := sets.New(hostnames...)
 	if !existingHostnames.Equal(requiredHostnames) {
 		existingNotRequired := existingHostnames.Difference(requiredHostnames)
 		requiredNotExisting := requiredHostnames.Difference(existingHostnames)
 		return fmt.Sprintf("%q are existing and not required, %q are required and not existing", strings.Join(sets.List(existingNotRequired), ","), strings.Join(sets.List(requiredNotExisting), ","))
 	}
-
 	return ""
 }
 
-func (r *ServingRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
+func setHostnameAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
 	hostnames := sets.Set[string]{}
 	for _, ip := range cert.Certs[0].IPAddresses {
 		hostnames.Insert(ip.String())
@@ -355,7 +405,6 @@ func (r *ServingRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, anno
 	for _, dnsName := range cert.Certs[0].DNSNames {
 		hostnames.Insert(dnsName)
 	}
-
 	// List does a sort so that we have a consistent representation
 	annotations[CertificateHostnames] = strings.Join(sets.List(hostnames), ",")
 	return annotations
@@ -367,9 +416,78 @@ type SignerRotation struct {
 	SignerName string
 }
 
-func (r *SignerRotation) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+func (r *SignerRotation) CertificateType() pki.CertificateType {
+	return pki.CertificateTypeSigner
+}
+
+func (r *SignerRotation) NewCertificate(signer *crypto.CA, validity time.Duration, keyGen crypto.KeyPairGenerator) (*crypto.TLSCertificateConfig, error) {
 	signerName := fmt.Sprintf("%s_@%d", r.SignerName, time.Now().Unix())
+	if keyGen != nil {
+		return crypto.NewSigningCertificate(signerName, keyGen,
+			crypto.WithSigner(signer),
+			crypto.WithLifetime(validity),
+		)
+	}
 	return crypto.MakeCAConfigForDuration(signerName, validity, signer)
+}
+
+// PeerRotation creates certificates used for both server and client authentication
+// (e.g., etcd peer certificates). It uses CertificateTypePeer for PKI profile
+// resolution, which selects the stronger of the serving and client key configurations.
+//
+// When keyGen is non-nil (ConfigurablePKI enabled), it calls NewPeerCertificate
+// which requires UserInfo for the client identity. When keyGen is nil (legacy),
+// it falls back to MakeServerCertForDuration with an extension function that
+// sets both ClientAuth and ServerAuth ExtKeyUsages.
+type PeerRotation struct {
+	Hostnames              ServingHostnameFunc
+	UserInfo               user.Info
+	CertificateExtensionFn []crypto.CertificateExtensionFunc
+	HostnamesChanged       <-chan struct{}
+}
+
+func (r *PeerRotation) CertificateType() pki.CertificateType {
+	return pki.CertificateTypePeer
+}
+
+func (r *PeerRotation) NewCertificate(signer *crypto.CA, validity time.Duration, keyGen crypto.KeyPairGenerator) (*crypto.TLSCertificateConfig, error) {
+	if len(r.Hostnames()) == 0 {
+		return nil, fmt.Errorf("no hostnames set")
+	}
+	if keyGen != nil {
+		if r.UserInfo == nil {
+			return nil, fmt.Errorf("PeerRotation requires UserInfo for configurable PKI certificates")
+		}
+		return signer.NewPeerCertificate(
+			sets.New(r.Hostnames()...), r.UserInfo, keyGen,
+			crypto.WithLifetime(validity),
+			crypto.WithExtensions(r.CertificateExtensionFn...),
+		)
+	}
+	// Legacy path: use server cert template with extension fn to add both ExtKeyUsages.
+	// The subject CN comes from the first hostname (preserves current behavior).
+	peerExtFn := func(cert *x509.Certificate) error {
+		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+		return nil
+	}
+	extensions := append(r.CertificateExtensionFn, peerExtFn)
+	return signer.MakeServerCertForDuration(sets.New(r.Hostnames()...), validity, extensions...)
+}
+
+func (r *PeerRotation) RecheckChannel() <-chan struct{} {
+	return r.HostnamesChanged
+}
+
+func (r *PeerRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, creationRequired bool) string {
+	reason := needNewTargetCertKeyPair(currentCertSecret, signer, caBundleCerts, refresh, refreshOnlyWhenExpired, creationRequired)
+	if len(reason) > 0 {
+		return reason
+	}
+	return missingHostnames(currentCertSecret.Annotations, r.Hostnames())
+}
+
+func (r *PeerRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
+	return setHostnameAnnotations(cert, annotations)
 }
 
 func (r *SignerRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, exists bool) string {

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -123,11 +123,22 @@ type UpdateOperatorSpecFunc func(spec *operatorv1.OperatorSpec) error
 func UpdateSpec(ctx context.Context, client OperatorClient, updateFuncs ...UpdateOperatorSpecFunc) (*operatorv1.OperatorSpec, bool, error) {
 	updated := false
 	var operatorSpec *operatorv1.OperatorSpec
+	previousResourceVersion := ""
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		oldSpec, _, resourceVersion, err := client.GetOperatorState()
 		if err != nil {
 			return err
 		}
+		if resourceVersion == previousResourceVersion {
+			// Lister is stale (e.g. after a conflict or restart); do a live GET to get the current resourceVersion.
+			listerResourceVersion := resourceVersion
+			oldSpec, _, resourceVersion, err = client.GetOperatorStateWithQuorum(ctx)
+			if err != nil {
+				return err
+			}
+			klog.V(2).Infof("lister was stale at resourceVersion=%v, live get showed resourceVersion=%v", listerResourceVersion, resourceVersion)
+		}
+		previousResourceVersion = resourceVersion
 
 		newSpec := oldSpec.DeepCopy()
 		for _, update := range updateFuncs {

--- a/vendor/github.com/openshift/library-go/pkg/pki/profile.go
+++ b/vendor/github.com/openshift/library-go/pkg/pki/profile.go
@@ -1,0 +1,114 @@
+package pki
+
+import (
+	"fmt"
+
+	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+// DefaultPKIProfile returns the default PKIProfile for OpenShift.
+func DefaultPKIProfile() configv1alpha1.PKIProfile {
+	return configv1alpha1.PKIProfile{
+		Defaults: configv1alpha1.DefaultCertificateConfig{
+			Key: configv1alpha1.KeyConfig{
+				Algorithm: configv1alpha1.KeyAlgorithmECDSA,
+				ECDSA:     configv1alpha1.ECDSAKeyConfig{Curve: configv1alpha1.ECDSACurveP256},
+			},
+		},
+		SignerCertificates: configv1alpha1.CertificateConfig{
+			Key: configv1alpha1.KeyConfig{
+				Algorithm: configv1alpha1.KeyAlgorithmECDSA,
+				ECDSA:     configv1alpha1.ECDSAKeyConfig{Curve: configv1alpha1.ECDSACurveP384},
+			},
+		},
+	}
+}
+
+// KeyPairGeneratorFromAPI converts a configv1alpha1.KeyConfig to a
+// crypto.KeyPairGenerator.
+func KeyPairGeneratorFromAPI(apiKey configv1alpha1.KeyConfig) (crypto.KeyPairGenerator, error) {
+	switch apiKey.Algorithm {
+	case configv1alpha1.KeyAlgorithmRSA:
+		return crypto.RSAKeyPairGenerator{
+			Bits: int(apiKey.RSA.KeySize),
+		}, nil
+	case configv1alpha1.KeyAlgorithmECDSA:
+		curve, err := ecdsaCurveFromAPI(apiKey.ECDSA.Curve)
+		if err != nil {
+			return nil, err
+		}
+		return crypto.ECDSAKeyPairGenerator{
+			Curve: curve,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown key algorithm: %q", apiKey.Algorithm)
+	}
+}
+
+// ecdsaCurveFromAPI converts an API ECDSA curve name to the crypto package's ECDSACurve.
+func ecdsaCurveFromAPI(c configv1alpha1.ECDSACurve) (crypto.ECDSACurve, error) {
+	switch c {
+	case configv1alpha1.ECDSACurveP256:
+		return crypto.P256, nil
+	case configv1alpha1.ECDSACurveP384:
+		return crypto.P384, nil
+	case configv1alpha1.ECDSACurveP521:
+		return crypto.P521, nil
+	default:
+		return "", fmt.Errorf("unknown ECDSA curve: %q", c)
+	}
+}
+
+// securityBits returns the NIST security strength in bits for a given
+// KeyPairGenerator. For RSA, values come from the rsaSecurityStrength table.
+// For ECDSA, security strength is half the key size (fixed per curve).
+func securityBits(g crypto.KeyPairGenerator) int {
+	switch g := g.(type) {
+	case crypto.RSAKeyPairGenerator:
+		return rsaSecurityStrength[g.Bits]
+	case crypto.ECDSAKeyPairGenerator:
+		switch g.Curve {
+		case crypto.P256:
+			return 128
+		case crypto.P384:
+			return 192
+		case crypto.P521:
+			return 256
+		}
+	}
+	return 0
+}
+
+// rsaSecurityStrength maps RSA key sizes (2048-8192 in 1024-bit increments)
+// to their security strengths from NIST SP 800-56B Rev 2 Table 2 or
+// pre-calculated from the GNFS complexity estimate.
+var rsaSecurityStrength = map[int]int{
+	2048: 112,
+	3072: 128,
+	4096: 152,
+	5120: 168,
+	6144: 176,
+	7168: 192,
+	8192: 200,
+}
+
+// strongerKeyPairGenerator returns whichever of a or b provides higher NIST
+// security strength. In case of a tie, ECDSA is preferred over RSA.
+func strongerKeyPairGenerator(a, b crypto.KeyPairGenerator) crypto.KeyPairGenerator {
+	sa, sb := securityBits(a), securityBits(b)
+	if sb > sa {
+		return b
+	}
+	if sa > sb {
+		return a
+	}
+	// Equal strength: prefer ECDSA over RSA.
+	if _, ok := a.(crypto.ECDSAKeyPairGenerator); ok {
+		return a
+	}
+	if _, ok := b.(crypto.ECDSAKeyPairGenerator); ok {
+		return b
+	}
+	return a
+}

--- a/vendor/github.com/openshift/library-go/pkg/pki/provider.go
+++ b/vendor/github.com/openshift/library-go/pkg/pki/provider.go
@@ -1,0 +1,75 @@
+package pki
+
+import (
+	"fmt"
+
+	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
+	configv1alpha1listers "github.com/openshift/client-go/config/listers/config/v1alpha1"
+)
+
+// PKIProfileProvider provides the PKIProfile that determines certificate key
+// configuration. A nil profile indicates Unmanaged mode where the caller
+// should use its own defaults.
+type PKIProfileProvider interface {
+	PKIProfile() (*configv1alpha1.PKIProfile, error)
+}
+
+// StaticPKIProfileProvider is a PKIProfileProvider backed by a fixed PKIProfile.
+type StaticPKIProfileProvider struct {
+	profile *configv1alpha1.PKIProfile
+}
+
+// NewStaticPKIProfileProvider returns a PKIProfileProvider backed by the given
+// profile. A nil profile signals Unmanaged mode.
+func NewStaticPKIProfileProvider(profile *configv1alpha1.PKIProfile) *StaticPKIProfileProvider {
+	return &StaticPKIProfileProvider{profile: profile}
+}
+
+// PKIProfile returns the static PKIProfile.
+func (s *StaticPKIProfileProvider) PKIProfile() (*configv1alpha1.PKIProfile, error) {
+	return s.profile, nil
+}
+
+// ListerPKIProfileProvider is a PKIProfileProvider that reads a named
+// cluster-scoped PKI resource via a lister.
+type ListerPKIProfileProvider struct {
+	lister       configv1alpha1listers.PKILister
+	resourceName string
+}
+
+// NewClusterPKIProfileProvider creates a PKIProfileProvider that resolves the
+// PKIProfile from the OpenShift cluster configuration PKI resource.
+func NewClusterPKIProfileProvider(lister configv1alpha1listers.PKILister) *ListerPKIProfileProvider {
+	return NewListerPKIProfileProvider(lister, "cluster")
+}
+
+// NewListerPKIProfileProvider returns a PKIProfileProvider that reads the
+// named cluster-scoped PKI resource via a lister.
+func NewListerPKIProfileProvider(lister configv1alpha1listers.PKILister, resourceName string) *ListerPKIProfileProvider {
+	return &ListerPKIProfileProvider{
+		lister:       lister,
+		resourceName: resourceName,
+	}
+}
+
+// PKIProfile reads the PKI resource and returns the profile based on its
+// certificate management mode. Returns nil for Unmanaged mode.
+func (l *ListerPKIProfileProvider) PKIProfile() (*configv1alpha1.PKIProfile, error) {
+	pki, err := l.lister.Get(l.resourceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get PKI resource %q: %w", l.resourceName, err)
+	}
+
+	switch pki.Spec.CertificateManagement.Mode {
+	case configv1alpha1.PKICertificateManagementModeUnmanaged:
+		return nil, nil
+	case configv1alpha1.PKICertificateManagementModeDefault:
+		profile := DefaultPKIProfile()
+		return &profile, nil
+	case configv1alpha1.PKICertificateManagementModeCustom:
+		profile := pki.Spec.CertificateManagement.Custom.PKIProfile
+		return &profile, nil
+	default:
+		return nil, fmt.Errorf("unknown PKI certificate management mode: %q", pki.Spec.CertificateManagement.Mode)
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/pki/resolve.go
+++ b/vendor/github.com/openshift/library-go/pkg/pki/resolve.go
@@ -1,0 +1,77 @@
+package pki
+
+import (
+	"fmt"
+
+	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+// CertificateConfig holds the resolved configuration for a specific certificate.
+// Currently contains key configuration; will grow as the PKI API expands to
+// include additional certificate properties.
+type CertificateConfig struct {
+	// Key is the resolved key pair generator.
+	Key crypto.KeyPairGenerator
+}
+
+// ResolveCertificateConfig resolves the effective certificate configuration
+// for a given certificate type and name from the PKI profile.
+//
+// Returns nil if the provider returns a nil profile (Unmanaged mode),
+// indicating that the caller should use its own default behavior.
+//
+// The name parameter is reserved for future per-certificate overrides and
+// can be used for metrics and logging.
+func ResolveCertificateConfig(provider PKIProfileProvider, certType CertificateType, name string) (*CertificateConfig, error) {
+	profile, err := provider.PKIProfile()
+	if err != nil {
+		return nil, fmt.Errorf("resolving PKI profile for %s certificate %q: %w", certType, name, err)
+	}
+	if profile == nil {
+		return nil, nil
+	}
+
+	switch certType {
+	case CertificateTypeSigner:
+		return resolveKeyConfig(profile.Defaults, profile.SignerCertificates)
+	case CertificateTypeServing:
+		return resolveKeyConfig(profile.Defaults, profile.ServingCertificates)
+	case CertificateTypeClient:
+		return resolveKeyConfig(profile.Defaults, profile.ClientCertificates)
+	case CertificateTypePeer:
+		return resolvePeerKeyConfig(profile)
+	default:
+		return nil, fmt.Errorf("unknown certificate type: %q", certType)
+	}
+}
+
+// resolveKeyConfig returns the override KeyConfig if its Algorithm is set,
+// otherwise falls back to the default.
+func resolveKeyConfig(defaults configv1alpha1.DefaultCertificateConfig, override configv1alpha1.CertificateConfig) (*CertificateConfig, error) {
+	apiKey := defaults.Key
+	if override.Key.Algorithm != "" {
+		apiKey = override.Key
+	}
+	g, err := KeyPairGeneratorFromAPI(apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return &CertificateConfig{Key: g}, nil
+}
+
+// resolvePeerKeyConfig resolves both the serving and client configs and
+// returns whichever has higher NIST security strength.
+func resolvePeerKeyConfig(profile *configv1alpha1.PKIProfile) (*CertificateConfig, error) {
+	servingCfg, err := resolveKeyConfig(profile.Defaults, profile.ServingCertificates)
+	if err != nil {
+		return nil, fmt.Errorf("resolving serving config for peer: %w", err)
+	}
+	clientCfg, err := resolveKeyConfig(profile.Defaults, profile.ClientCertificates)
+	if err != nil {
+		return nil, fmt.Errorf("resolving client config for peer: %w", err)
+	}
+	return &CertificateConfig{
+		Key: strongerKeyPairGenerator(servingCfg.Key, clientCfg.Key),
+	}, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/pki/types.go
+++ b/vendor/github.com/openshift/library-go/pkg/pki/types.go
@@ -1,0 +1,23 @@
+package pki
+
+// CertificateType identifies the category of a certificate for profile resolution.
+type CertificateType string
+
+const (
+	// CertificateTypeSigner identifies certificate authority (CA) certificates
+	// that sign other certificates.
+	CertificateTypeSigner CertificateType = "signer"
+
+	// CertificateTypeServing identifies TLS server certificates used to serve
+	// HTTPS endpoints.
+	CertificateTypeServing CertificateType = "serving"
+
+	// CertificateTypeClient identifies client authentication certificates used
+	// to authenticate to servers.
+	CertificateTypeClient CertificateType = "client"
+
+	// CertificateTypePeer identifies certificates used for both server and client
+	// authentication. The resolved key configuration is the stronger of the
+	// serving and client configurations.
+	CertificateTypePeer CertificateType = "peer"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -413,8 +413,8 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20260304110309-c56f4c30de58
-## explicit; go 1.24.0
+# github.com/openshift/library-go v0.0.0-20260304110309-c56f4c30de58 => github.com/sanchezl/library-go v0.0.0-20260408145132-8d5ab9b3d36c
+## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
@@ -476,6 +476,7 @@ github.com/openshift/library-go/pkg/operator/staticresourcecontroller
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller
 github.com/openshift/library-go/pkg/operator/v1helpers
+github.com/openshift/library-go/pkg/pki
 github.com/openshift/library-go/pkg/serviceability
 github.com/openshift/library-go/test/library
 # github.com/pkg/errors v0.9.1
@@ -1787,3 +1788,4 @@ sigs.k8s.io/yaml
 # github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 # github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12
 # vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
+# github.com/openshift/library-go => github.com/sanchezl/library-go v0.0.0-20260408145132-8d5ab9b3d36c


### PR DESCRIPTION
## Summary

- Vendor updated library-go with certrotation interface changes (exported `PKIProfileProvider`, `TargetCertCreator.CertificateType()`, `NewCertificate` keyGen param, `PeerRotation` type)
- Switch per-node certs from `ServingRotation` + `CertificateExtensionFn` to `PeerRotation` which handles dual ClientAuth+ServerAuth ExtKeyUsages internally
- Wire `ConfigurablePKI` feature gate into the cert signer controller: when enabled, creates a `PKIProfileProvider` from the cluster PKI resource and sets it (along with `CertificateName`) on all cert rotation configs

### Known limitation

The render path (`pkg/cmd/render/certs.go`) passes `nil` for the config informer. If the `ConfigurablePKI` feature gate is enabled during render, PKI profile resolution will be silently skipped and legacy cert generation will be used.

Depends on openshift/library-go#2145

[CNTRLPLANE-2014](https://redhat.atlassian.net/browse/CNTRLPLANE-2014)

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./pkg/tlshelpers/...`
- [ ] `go test ./pkg/operator/etcdcertsigner/...`
- [ ] Verify etcd certs are generated correctly on a TechPreview cluster with ConfigurablePKI enabled