### PR TITLE
NO-JIRA: Add control-plane-approvers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,14 @@
 reviewers:
+  - control-plane-approvers
   - dusk125
   - ironcladlou
   - hasbro17
-  - tjungblu
   - jubittajohn
   - lance5890
 approvers:
+  - control-plane-approvers
   - deads2k
   - hasbro17
   - sttts
   - dusk125
-  - tjungblu
 component: "Etcd"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -15,3 +15,18 @@ aliases:
     - clobrano
     - fonta-rh
     - eggfoobar
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - rh-roman
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan


### PR DESCRIPTION
Add control-plane-approvers to OWNERS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review and approval configurations for the Etcd component to include a newly established approver group, expanding the team responsible for reviewing and approving infrastructure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->