### PR TITLE
OCPBUGS-82190: fixed release machine deletion hooks for etcd learner nodes

### DIFF
--- a/pkg/operator/machinedeletionhooks/machinedeletionhooks.go
+++ b/pkg/operator/machinedeletionhooks/machinedeletionhooks.go
@@ -124,9 +124,9 @@ func (c *machineDeletionHooksController) attemptToDeleteMachineDeletionHook(ctx 
 		return nil
 	}
 
-	// get the members, issue a live call instead of reading from the config map
-	// because we need to take into account learners
-	members, err := c.etcdClient.MemberList(ctx)
+	// only voting members should block machine deletion — learners do not participate
+	// in quorum, so a learner-only match should not keep the preDrain hook
+	members, err := c.etcdClient.VotingMemberList(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/machinedeletionhooks/machinedeletionhooks_test.go
+++ b/pkg/operator/machinedeletionhooks/machinedeletionhooks_test.go
@@ -394,6 +394,92 @@ func TestAttemptToDeleteMachineDeletionHook(t *testing.T) {
 			initialEtcdMemberList: wellKnownEtcdMemberList(),
 		},
 		{
+			name: "machine pending deletion with only a learner member should remove hook",
+			initialObjectsForMachineLister: func() []runtime.Object {
+				m1 := machineWithHooksFor("m-1", "10.0.139.78")
+				m1.DeletionTimestamp = &metav1.Time{}
+				return []runtime.Object{
+					m1,
+					machineWithHooksFor("m-2", "10.0.139.79"),
+					machineWithHooksFor("m-3", "10.0.139.80"),
+				}
+			}(),
+			initialEtcdMemberList: []*etcdserverpb.Member{
+				{
+					Name:      "",
+					ID:        1,
+					PeerURLs:  []string{"https://10.0.139.78:2380"},
+					IsLearner: true,
+				},
+				{
+					Name:     "m-2",
+					ID:       2,
+					PeerURLs: []string{"https://10.0.139.79:2380"},
+				},
+				{
+					Name:     "m-3",
+					ID:       3,
+					PeerURLs: []string{"https://10.0.139.80:2380"},
+				},
+			},
+			expectedActions: []string{"update:machines:"},
+			validateFunc: func(t *testing.T, machineClientActions []clientgotesting.Action) {
+				wasMachineUpdated := false
+				for _, action := range machineClientActions {
+					if action.Matches("update", "machines") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						updatedMachine := updateAction.GetObject().(*machinev1beta1.Machine)
+						if updatedMachine.Name != "m-1" {
+							t.Fatalf("expected machine m-1 to be updated, got %v", updatedMachine.Name)
+						}
+						if hasMachineDeletionHook(updatedMachine) {
+							t.Fatalf("machine %v should have had its deletion hook removed (learner-only member)", updatedMachine)
+						}
+						wasMachineUpdated = true
+					}
+				}
+				if !wasMachineUpdated {
+					t.Errorf("expected to see an updated machine but didn't get any, fake machine client actions: %v", machineClientActions)
+				}
+			},
+		},
+		{
+			name: "machine pending deletion with a voting member should keep hook",
+			initialObjectsForMachineLister: func() []runtime.Object {
+				m1 := machineWithHooksFor("m-1", "10.0.139.78")
+				m1.DeletionTimestamp = &metav1.Time{}
+				return []runtime.Object{
+					m1,
+					machineWithHooksFor("m-2", "10.0.139.79"),
+					machineWithHooksFor("m-3", "10.0.139.80"),
+				}
+			}(),
+			initialEtcdMemberList: []*etcdserverpb.Member{
+				{
+					Name:     "m-1",
+					ID:       1,
+					PeerURLs: []string{"https://10.0.139.78:2380"},
+				},
+				{
+					Name:     "m-2",
+					ID:       2,
+					PeerURLs: []string{"https://10.0.139.79:2380"},
+				},
+				{
+					Name:     "m-3",
+					ID:       3,
+					PeerURLs: []string{"https://10.0.139.80:2380"},
+				},
+			},
+			validateFunc: func(t *testing.T, machineClientActions []clientgotesting.Action) {
+				for _, action := range machineClientActions {
+					if action.Matches("update", "machines") {
+						t.Fatalf("expected no machine updates, but got: %v", machineClientActions)
+					}
+				}
+			},
+		},
+		{
 			name: "two excessive, the first one with pending deletion and without the hooks, the second pending deletion without a member",
 			initialObjectsForMachineLister: func() []runtime.Object {
 				machines := wellKnownMasterMachines()


### PR DESCRIPTION
### Summary:

- Changed `attemptToDeleteMachineDeletionHook` to use `VotingMemberList()` instead of `MemberList()` so that learner-only etcd members no longer block machine deletion. Learners don't participate in quorum, so their presence shouldn't keep the preDrain hook active.
- Added two test cases: one verifying the hook is removed when only a learner matches the machine, and one confirming a voting member still keeps the hook


I have validated the change by pushing this updated CEO code in a Two Node Fencing cluster and I wasn't able to reproduce the issue [OCPBUGS-82190 ](https://redhat.atlassian.net/browse/OCPBUGS-82190) anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine deletion eligibility checks to more accurately assess cluster membership status, distinguishing between different membership types for safer machine removal decisions.

* **Tests**
  * Added comprehensive test scenarios to validate machine deletion behavior with varied cluster membership configurations, improving coverage for removal eligibility logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->