### PR TITLE
OCPBUGS-79662 - Modify ETCDCTL_RESTORE_FLAGS to include --skip-hash-check

### DIFF
--- a/bindata/etcd/cluster-restore-tnf.sh
+++ b/bindata/etcd/cluster-restore-tnf.sh
@@ -112,6 +112,7 @@ function setup_pacemaker_restore() {
     --name="$NODENAME"
     --initial-cluster="$NODENAME=https://$IP:2380"
     --initial-advertise-peer-urls="https://$IP:2380"
+    --skip-hash-check
   )
 
   if ! pcs resource disable etcd; then


### PR DESCRIPTION
There is a failure to restore learners. This fix will allow learners to be restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified ETCD cluster snapshot restore to skip hash verification during the restoration process, streamlining the restore operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->