### PR TITLE
NO-JIRA: separate grpc from http server

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml
@@ -60,6 +60,7 @@ spec:
         --peer-client-cert-auth=true \
         --advertise-client-urls=https://{{ .EtcdAddress.EscapedBootstrapIP }}:2379 \
         --listen-client-urls=https://{{ .EtcdAddress.ListenClient }} \
+        --listen-client-http-urls=https://{{ .EtcdAddress.ListenClientHTTP }} \
         --listen-peer-urls=https://{{ .EtcdAddress.ListenPeer }} \
         --listen-metrics-urls=https://{{ .EtcdAddress.ListenMetricServer }} \
     resources:
@@ -82,6 +83,9 @@ spec:
       protocol: TCP
     - name: server
       containerPort: 2379
+      protocol: TCP
+    - name: etcd-http
+      containerPort: 2381
       protocol: TCP
   hostNetwork: true
   priorityClassName: system-node-critical

--- a/bindata/etcd/pod.gotpl.yaml
+++ b/bindata/etcd/pod.gotpl.yaml
@@ -176,8 +176,8 @@ spec:
 
         # we cannot use the "normal" port conflict initcontainer because when we upgrade, the existing static pod will never yield,
         # so we do the detection in etcd container itself.
-        echo -n "Waiting for ports 2379, 2380 and 9978 to be released."
-        time while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 or sport = 9978 )')" ]; do
+        echo -n "Waiting for ports 2379, 2380, 2381 and 9978 to be released."
+        time while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 or sport = 2381 or sport = 9978 )')" ]; do
           echo -n "."
           sleep 1
         done
@@ -202,12 +202,16 @@ spec:
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
           --listen-client-urls=https://{{.ListenAddress}}:2379 \
+          --listen-client-http-urls=https://{{.ListenAddress}}:2381 \
           --listen-peer-urls=https://{{.ListenAddress}}:2380 \
           --metrics=extensive \
           --listen-metrics-urls=https://{{.ListenAddress}}:9978 ||  mv /etc/kubernetes/etcd-backup-dir/etcd-member.yaml /etc/kubernetes/manifests
     ports:
     - containerPort: 2379
       name: etcd
+      protocol: TCP
+    - containerPort: 2381
+      name: etcd-http
       protocol: TCP
     - containerPort: 2380
       name: etcd-peer

--- a/bindata/etcd/quorum-restore-pod.yaml
+++ b/bindata/etcd/quorum-restore-pod.yaml
@@ -52,6 +52,7 @@ spec:
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
           --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379 \
+          --listen-client-http-urls=https://${LISTEN_ON_ALL_IPS}:2381 \
           --listen-peer-urls=https://${LISTEN_ON_ALL_IPS}:2380 \
           --metrics=extensive \
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978

--- a/bindata/etcd/restore-pod.yaml
+++ b/bindata/etcd/restore-pod.yaml
@@ -108,6 +108,7 @@ spec:
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2379 \
           --listen-client-urls=https://${LISTEN_ON_ALL_IPS}:2379 \
+          --listen-client-http-urls=https://${LISTEN_ON_ALL_IPS}:2381 \
           --listen-peer-urls=https://${LISTEN_ON_ALL_IPS}:2380 \
           --metrics=extensive \
           --listen-metrics-urls=https://${LISTEN_ON_ALL_IPS}:9978

--- a/bindata/etcd/svc.yaml
+++ b/bindata/etcd/svc.yaml
@@ -17,6 +17,9 @@ spec:
     - name: etcd
       port: 2379
       protocol: TCP
+    - name: etcd-http
+      port: 2381
+      protocol: TCP
     - name: etcd-peer
       port: 2380
       protocol: TCP

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -112,6 +112,7 @@ func (r *renderOpts) Validate() error {
 // pod spec
 type etcdAddress struct {
 	ListenClient       string
+	ListenClientHTTP   string
 	ListenPeer         string
 	ListenMetricServer string
 	ListenMetricProxy  string
@@ -440,6 +441,7 @@ func (t *TemplateData) setEtcdAddress(ipv6 bool, bootstrapIP string) {
 
 	t.EtcdAddress = etcdAddress{
 		ListenClient:       net.JoinHostPort(allAddresses, "2379"),
+		ListenClientHTTP:   net.JoinHostPort(allAddresses, "2381"),
 		ListenPeer:         net.JoinHostPort(allAddresses, "2380"),
 		LocalHost:          localhost,
 		ListenMetricServer: net.JoinHostPort(allAddresses, "9978"),


### PR DESCRIPTION
This change will cause the http server to run under :2381 instead of the existing :2379 grpc port.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP client endpoint for etcd on port 2381, providing an alternative connection method alongside the existing HTTPS endpoint on port 2379.

* **Configuration Updates**
  * Updated etcd service and pod specifications to expose and configure the new HTTP listener across all deployment configurations, bootstrap operations, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->