### PR TITLE
NO-JIRA: Replace bash env var validator with go implementation

### DIFF
--- a/bindata/etcd/pod.gotpl.yaml
+++ b/bindata/etcd/pod.gotpl.yaml
@@ -39,34 +39,14 @@ spec:
         - mountPath: /var/lib/etcd-auto-backup
           name: etcd-auto-backup-dir
     - name: etcd-ensure-env-vars
-      image: {{.Image}}
+      image: {{.OperatorImage}}
       imagePullPolicy: IfNotPresent
       terminationMessagePolicy: FallbackToLogsOnError
-      command:
-        - /bin/sh
-        - -c
-        - |
-          #!/bin/sh
-          set -euo pipefail
-
-          : "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST?not set}"
-          : "${NODE_NODE_ENVVAR_NAME_ETCD_NAME?not set}"
-          : "${NODE_NODE_ENVVAR_NAME_IP?not set}"
-
-          # check for ipv4 addresses as well as ipv6 addresses with extra square brackets
-          if [[ "${NODE_NODE_ENVVAR_NAME_IP}" != "${NODE_IP}" && "${NODE_NODE_ENVVAR_NAME_IP}" != "[${NODE_IP}]" ]]; then
-            # echo the error message to stderr
-            echo "Expected node IP to be ${NODE_IP} got ${NODE_NODE_ENVVAR_NAME_IP}" >&2
-            exit 1
-          fi
-
-          # check for ipv4 addresses as well as ipv6 addresses with extra square brackets
-          if [[ "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" != "${NODE_IP}" && "${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" != "[${NODE_IP}]" ]]; then
-            # echo the error message to stderr
-            echo "Expected etcd url host to be ${NODE_IP} got ${NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST}" >&2
-            exit 1
-          fi
-
+      command: [ "cluster-etcd-operator", "ensure-env" ]
+      args:
+        - --node-ip=$(NODE_IP)
+        - --check-set-and-not-empty=NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST,NODE_NODE_ENVVAR_NAME_ETCD_NAME,NODE_NODE_ENVVAR_NAME_IP
+        - --check-equals-node-ip=NODE_NODE_ENVVAR_NAME_IP,NODE_NODE_ENVVAR_NAME_ETCD_URL_HOST
       resources:
         requests:
           memory: 60Mi

--- a/cmd/cluster-etcd-operator/main.go
+++ b/cmd/cluster-etcd-operator/main.go
@@ -12,6 +12,7 @@ import (
 	prune_backups "github.com/openshift/cluster-etcd-operator/pkg/cmd/prune-backups"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/backuprestore"
+	"github.com/openshift/cluster-etcd-operator/pkg/cmd/ensureenv"
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/monitor"
 	operatorcmd "github.com/openshift/cluster-etcd-operator/pkg/cmd/operator"
 	"github.com/openshift/cluster-etcd-operator/pkg/cmd/readyz"
@@ -78,6 +79,7 @@ func NewSSCSCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(requestbackup.NewRequestBackupCommand(ctx))
 	cmd.AddCommand(rev.NewRevCommand(ctx))
 	cmd.AddCommand(backuprestore.NewBackupServer(ctx))
+	cmd.AddCommand(ensureenv.NewEnsureEnvCommand())
 
 	return cmd
 }

--- a/pkg/cmd/ensureenv/ensureenv.go
+++ b/pkg/cmd/ensureenv/ensureenv.go
@@ -1,0 +1,75 @@
+package ensureenv
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type ensureOpts struct {
+	nodeIP       string
+	notEmpty     []string
+	equalsNodeIP []string
+}
+
+func NewEnsureEnvCommand() *cobra.Command {
+	ensure := &ensureOpts{}
+
+	cmd := &cobra.Command{
+		Use:          "ensure-env",
+		Short:        "Ensures that the IP address related environment variables are correct",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ensure.run()
+		},
+	}
+
+	ensure.addFlags(cmd.Flags())
+	return cmd
+}
+
+func (e *ensureOpts) addFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&e.nodeIP, "node-ip", "", "The internal IP of the node provided by the downward API.")
+	fs.StringSliceVar(&e.notEmpty, "check-set-and-not-empty", []string{}, "Validate that the given environment variable(s) are set and have non-empty values.")
+	fs.StringSliceVar(&e.equalsNodeIP, "check-equals-node-ip", []string{}, "Validate that the given environment variable(s) are equal to --node-ip.")
+}
+
+func (e *ensureOpts) run() error {
+	if e.nodeIP == "" {
+		return fmt.Errorf("--node-ip must be set to a non-empty value")
+	}
+
+	normalizedNodeIP := stripBrackets(e.nodeIP)
+
+	for _, ev := range e.notEmpty {
+		value, has := os.LookupEnv(ev)
+		if !has {
+			return fmt.Errorf("environment variable %s must be set", ev)
+		}
+		if value == "" {
+			return fmt.Errorf("environment variable %s must not be empty", ev)
+		}
+	}
+
+	for _, ev := range e.equalsNodeIP {
+		value, has := os.LookupEnv(ev)
+		if !has {
+			return fmt.Errorf("environment variable %s must be set", ev)
+		}
+		if stripBrackets(value) != normalizedNodeIP {
+			return fmt.Errorf("expected %s to be %s, got %s", ev, e.nodeIP, value)
+		}
+	}
+
+	return nil
+}
+
+func stripBrackets(ip string) string {
+	if strings.HasPrefix(ip, "[") && strings.HasSuffix(ip, "]") {
+		return ip[1 : len(ip)-1]
+	}
+	return ip
+}

--- a/pkg/cmd/ensureenv/ensureenv_test.go
+++ b/pkg/cmd/ensureenv/ensureenv_test.go
@@ -1,0 +1,129 @@
+package ensureenv
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnsureEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "missing node-ip",
+			args:     []string{},
+			expected: "--node-ip must be set to a non-empty value",
+		},
+		{
+			name: "env var not set",
+			args: []string{
+				"--node-ip=10.0.0.1",
+				"--check-set-and-not-empty=MISSING_VAR",
+			},
+			expected: "environment variable MISSING_VAR must be set",
+		},
+		{
+			name: "env var empty",
+			args: []string{
+				"--node-ip=10.0.0.1",
+				"--check-set-and-not-empty=EMPTY_VAR",
+			},
+			envVars:  map[string]string{"EMPTY_VAR": ""},
+			expected: "environment variable EMPTY_VAR must not be empty",
+		},
+		{
+			name: "env var set and not empty",
+			args: []string{
+				"--node-ip=10.0.0.1",
+				"--check-set-and-not-empty=GOOD_VAR",
+			},
+			envVars: map[string]string{"GOOD_VAR": "value"},
+		},
+		{
+			name: "env var equals node ip",
+			args: []string{
+				"--node-ip=10.0.0.1",
+				"--check-equals-node-ip=IP_VAR",
+			},
+			envVars: map[string]string{"IP_VAR": "10.0.0.1"},
+		},
+		{
+			name: "env var does not equal node ip",
+			args: []string{
+				"--node-ip=10.0.0.1",
+				"--check-equals-node-ip=IP_VAR",
+			},
+			envVars:  map[string]string{"IP_VAR": "10.0.0.2"},
+			expected: "expected IP_VAR to be 10.0.0.1, got 10.0.0.2",
+		},
+		{
+			name: "ipv6 with brackets matches bare",
+			args: []string{
+				"--node-ip=fd00::1",
+				"--check-equals-node-ip=IP_VAR",
+			},
+			envVars: map[string]string{"IP_VAR": "[fd00::1]"},
+		},
+		{
+			name: "bare ipv6 matches bracketed node-ip",
+			args: []string{
+				"--node-ip=[fd00::1]",
+				"--check-equals-node-ip=IP_VAR",
+			},
+			envVars: map[string]string{"IP_VAR": "fd00::1"},
+		},
+		{
+			name: "malformed ipv6 double brackets rejected",
+			args: []string{
+				"--node-ip=fd00::1",
+				"--check-equals-node-ip=IP_VAR",
+			},
+			envVars:  map[string]string{"IP_VAR": "[[fd00::1]]"},
+			expected: "expected IP_VAR to be fd00::1, got [[fd00::1]]",
+		},
+		{
+			name: "full bash-equivalent invocation",
+			args: []string{
+				"--node-ip=10.0.0.1",
+				"--check-set-and-not-empty=ETCD_URL_HOST,ETCD_NAME,NODE_IP_VAR",
+				"--check-equals-node-ip=NODE_IP_VAR,ETCD_URL_HOST",
+			},
+			envVars: map[string]string{
+				"ETCD_URL_HOST": "10.0.0.1",
+				"ETCD_NAME":     "etcd-member-0",
+				"NODE_IP_VAR":   "10.0.0.1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range tt.envVars {
+					os.Unsetenv(k)
+				}
+			}()
+
+			c := NewEnsureEnvCommand()
+			c.SetArgs(tt.args)
+			err := c.Execute()
+
+			if tt.expected != "" {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tt.expected)
+				}
+				if err.Error() != tt.expected {
+					t.Fatalf("expected error %q, got %q", tt.expected, err.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Init container now runs from the operator image and uses a dedicated ensure-env command to validate required environment variables.
  * Enforces presence/non-empty checks and ensures specified vars equal the node IP, with correct IPv6 bracket handling.

* **Tests**
  * Added tests covering missing/empty vars, mismatches, and IPv6 normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->