### PR TITLE
OCPEDGE-2604, OCPEDGE-2605: feat: add update-fencing-credentials.sh script for TNF fencing credentials rotation

### DIFF
--- a/bindata/etcd/update-fencing-credentials.sh
+++ b/bindata/etcd/update-fencing-credentials.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+
+### Created by cluster-etcd-operator. DO NOT edit.
+
+set -o errexit
+set -o pipefail
+set -o errtrace
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root"
+    exit 1
+fi
+
+function source_required_dependency {
+    local src_path="$1"
+    if [ ! -f "${src_path}" ]; then
+        echo "required dependencies not found, please ensure this script is run on a node with a functional etcd static pod"
+        exit 1
+    fi
+    # shellcheck disable=SC1090
+    source "${src_path}"
+}
+
+source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
+source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
+
+function usage {
+    echo "Usage: update-fencing-credentials.sh --node <name> --username <user> --password <password> --address <redfish-url> [--ssl-insecure]"
+    exit 1
+}
+
+function redact_credentials {
+    local input
+    input=$(cat)
+    input="${input//${USERNAME}/****}"
+    input="${input//${PASSWORD}/****}"
+    printf '%s\n' "${input}"
+}
+
+NODE=""
+USERNAME=""
+PASSWORD=""
+ADDRESS=""
+SSL_INSECURE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --node)     NODE="$2";      shift 2 ;;
+        --username) USERNAME="$2";  shift 2;;
+        --password) PASSWORD="$2";  shift 2;;
+        --address)  ADDRESS="$2";   shift 2;;
+        --ssl-insecure) SSL_INSECURE=true;  shift ;;
+        *) usage ;;
+    esac
+done
+
+if [ -z "${NODE}" ] || [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ] || [ -z "${ADDRESS}" ]; then
+    usage
+fi
+
+# mirrors getFencingConfig in pkg/tnf/pkg/pcs/fencing.go
+if [[ "${ADDRESS}" != *redfish* ]]; then
+    echo "Address does not contain a valid redfish URL: ${ADDRESS}"
+    exit 1
+fi
+
+# strip the redfish+ prefix scheme (e.g. redfish+https://... -> https://..)
+PARSED_URL="${ADDRESS#redfish+}"
+
+# Parse IPv6 (bracketed) vs IPv4/hostname
+if [[ "${PARSED_URL}" =~ ^https?://\[([^]]+)\](:([0-9]+))?(/.*)? ]]; then
+    REDFISH_HOST="${BASH_REMATCH[1]}"
+    REDFISH_PORT="${BASH_REMATCH[3]}"
+    REDFISH_PATH="${BASH_REMATCH[4]}"
+    REDFISH_IP="[${REDFISH_HOST}]"
+else
+    REDFISH_HOST=$(echo "${PARSED_URL}" | sed -E 's|https?://([^/:]+).*|\1|')
+    REDFISH_PORT=$(echo "${PARSED_URL}" | sed -E 's|https?://[^/:]+:([0-9]+).*|\1|')
+    REDFISH_PATH=$(echo "${PARSED_URL}" | sed -E 's|https?://[^/]+(/.*)|\1|')
+    REDFISH_IP="${REDFISH_HOST}"
+fi
+
+# infer port from scheme if not explicitly provided
+if [ -z "${REDFISH_PORT}" ] || [ "${REDFISH_PORT}" = "${PARSED_URL}" ]; then
+    if [[ "${PARSED_URL}" == https://* ]]; then
+        REDFISH_PORT="443"
+    else
+        REDFISH_PORT="80"
+    fi
+fi
+
+if "${SSL_INSECURE}"; then
+    SSL_INSECURE_VAL="1"
+    CERT_VERIFICATION="Disabled"
+else
+    SSL_INSECURE_VAL="0"
+    CERT_VERIFICATION="Enabled"
+fi
+
+DEVICE_ID="${NODE}_redfish"
+
+echo "Validating new credentials against Redfish endpoint ${REDFISH_IP}:${REDFISH_PORT}${REDFISH_PATH}..."
+
+FENCE_ARGS=(--username "${USERNAME}" --password "${PASSWORD}" --ip "${REDFISH_IP}" --ipport "${REDFISH_PORT}" --systems-uri "${REDFISH_PATH}" --action status)
+if "${SSL_INSECURE}"; then
+    FENCE_ARGS+=(--ssl-insecure)
+fi
+
+if ! PREFLIGHT_OUTPUT=$(/usr/sbin/fence_redfish "${FENCE_ARGS[@]}" 2>&1); then
+    echo "Pre-flight validation failed: new credentials do not work against the Redfish endpoint"
+    echo "${PREFLIGHT_OUTPUT}" | redact_credentials
+    echo "No changes were made to stonith device or Kubernetes secret"
+    exit 1
+fi
+echo "Pre-flight validation passed: new credentials are valid"
+
+echo "Updating stonith device ${DEVICE_ID}"
+# matches getStonithCommand() format from fencing.go
+STDERR=$(/usr/sbin/pcs stonith update "${DEVICE_ID}" \
+    username="${USERNAME}" \
+    password="${PASSWORD}" \
+    ip="${REDFISH_IP}" \
+    ipport="${REDFISH_PORT}" \
+    systems_uri="${REDFISH_PATH}" \
+    ssl_insecure="${SSL_INSECURE_VAL}" \
+    --wait=120 2>&1 > /dev/null) || true
+
+# stderr must contain "is running"
+if [[ "${STDERR}" != *"is running"* ]]; then
+    echo "Failed to update stonith device ${DEVICE_ID}: $(echo "${STDERR}" | redact_credentials)"
+    exit 1
+fi
+echo "Stonith device ${DEVICE_ID} updated successfully"
+
+SECRET_NAME="fencing-credentials-${NODE}"
+NAMESPACE="openshift-etcd"
+
+echo "Updating secret ${SECRET_NAME} in namespace ${NAMESPACE}"
+# KUBECONFIG is set by etcd-common-tools
+if ! oc create secret generic "${SECRET_NAME}" \
+    --namespace="${NAMESPACE}" \
+    --from-literal=address="${ADDRESS}" \
+    --from-literal=username="${USERNAME}" \
+    --from-literal=password="${PASSWORD}" \
+    --from-literal=certificateVerification="${CERT_VERIFICATION}" \
+    --dry-run=client -o yaml | oc apply -f -; then
+    echo "WARNING: Stonith device ${DEVICE_ID} was updated successfully,"
+    echo "but the Kubernetes secret could not be updated."
+    echo "The CEO operator may revert the stonith device on next reconciliation."
+    echo "When API access is restored, re-run this script to update the secret."
+    exit 1
+fi
+
+echo "Secret ${SECRET_NAME} updated successfully"
+
+echo "Checking pacemaker cluster health..."
+if ! PCS_STATUS=$(pcs status xml 2>&1); then
+    echo "Failed to get pacemaker status: ${PCS_STATUS}"
+    exit 1
+fi
+
+# check for fencing failures in pacemaker status
+if echo "${PCS_STATUS}" | grep -q 'resource_agent="stonith:.*blocked="true"\|blocked="true".*resource_agent="stonith:'; then
+    echo "Warning: pacemaker reports blocked stonith resources"
+    exit 1
+fi
+
+
+echo "Pacemaker cluster health verified"
+
+echo ""
+echo "Fencing credentials update completed successfully:"
+echo "Stonith device:   ${DEVICE_ID}"
+echo "Secret:           ${NAMESPACE}/${SECRET_NAME}"
+echo "Address:          ${ADDRESS}"
+echo "Username:         ${USERNAME}"
+echo "SSL insecure:     ${SSL_INSECURE}"

--- a/docs/update-fencing-credentials.md
+++ b/docs/update-fencing-credentials.md
@@ -1,0 +1,104 @@
+# update-fencing-credentials.sh
+
+## Overview
+
+`update-fencing-credentials.sh` rotates Redfish BMC fencing credentials on Two-Node with Fencing (TNF) clusters. It updates both the Pacemaker
+stonith device configuration and the corresponding Kubernetes secret in a single operation.
+
+The script is deployed automatically by the cluster-etcd-operator's scriptcontroller when the cluster topology is TNF. It is not present on
+standard or arbiter topology clusters.
+
+## Location
+
+The script is embedded in the `etcd-scripts` ConfigMap and mounted on each control plane node at:
+
+```
+/etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/update-fencing-credentials.sh
+```
+
+## Usage
+
+```bash
+update-fencing-credentials.sh \
+--node <node-name> \
+--username <bmc-username> \
+--password <bmc-password> \
+--address <redfish-url> \
+[--ssl-insecure]
+```
+
+The script must be run as root on a TNF control plane node.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--node` | Yes | Node name as it appears in `oc get nodes`.|
+| `--username` | Yes | Redfish BMC username. |
+| `--password` | Yes | Redfish BMC password. |
+| `--address` | Yes | Full Redfish URL. Must contain `redfish` in the string (e.g. `redfish+https://192.168.1.10:443/redfish/v1/Systems/1`). |
+| `--ssl-insecure` | No | Disable TLS certificate verification when communicating with the BMC. |
+
+### Address format
+
+The `--address` value must include the `redfish` scheme prefix and the full API path:
+
+```
+redfish+https://<host>:<port>/redfish/v1/Systems/1
+```
+
+For IPv6 addresses, use bracket notation:
+
+```
+redfish+https://[fd00::10]:443/redfish/v1/Systems/1
+```
+
+The script parses host, port, and path from this URL. If no port is specified, it defaults to 443 (https) or 80 (http).
+
+## What the script does
+
+1. **Validates prerequisites** -- checks root privileges, required dependency files (`etcd.env`, `etcd-common-tools`), and all required
+arguments.
+
+2. **Parses the Redfish URL** -- extracts host, port, and API path from the `--address` value; strips the `redfish+` scheme prefix.
+
+3. **Pre-flight validation** -- runs `fence_redfish` with the new credentials to confirm the BMC is reachable and responds correctly. If
+validation fails, the script exits without making any changes to the stonith device or Kubernetes secret.
+
+4. **Updates the Pacemaker stonith device** -- runs `pcs stonith update <node>_redfish` with the new credentials (username, password, ip, ipport,
+systems_uri, ssl_insecure) and waits up to 120 seconds for the update to apply.
+
+5. **Creates or updates the Kubernetes secret** -- writes a secret named `fencing-credentials-<node>` in the `openshift-etcd` namespace
+containing the address, username, password, and certificate verification setting. Uses `--dry-run=client -o yaml | oc apply` for idempotency.
+
+6. **Checks Pacemaker health** -- parses `pcs status xml` to ensure no stonith resources are in a blocked state.
+
+## Running the script
+
+### Via oc debug (from outside the cluster)
+
+```bash
+oc debug node/<node-name> -- chroot /host \
+/etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/update-fencing-credentials.sh \
+--node <target-node> \
+--username admin \
+--password 'new-password' \
+--address 'redfish+https://192.168.1.10:443/redfish/v1/Systems/1' \
+--ssl-insecure
+```
+
+### Directly on a node (via SSH)
+
+```bash
+sudo /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/update-fencing-credentials.sh \
+--node master-0.example.com \
+--username admin \
+--password 'new-password' \
+--address 'redfish+https://192.168.1.10:443/redfish/v1/Systems/1'
+```
+
+## Security considerations
+
+- The script requires root access on the node.
+- The BMC password is passed as a command-line argument and will be visible in the process list while the script runs.
+- The password is stored in a Kubernetes secret (`fencing-credentials-<node>`) in the `openshift-etcd` namespace.

--- a/pkg/operator/scriptcontroller/scriptcontroller.go
+++ b/pkg/operator/scriptcontroller/scriptcontroller.go
@@ -135,6 +135,7 @@ func (c *ScriptController) manageScriptConfigMap(ctx context.Context, recorder e
 	} else if isTNF {
 		clusterRestoreScript = "etcd/cluster-restore-tnf.sh"
 		disableEtcdScript = "etcd/disable-etcd-tnf.sh"
+		scriptConfigMap.Data["update-fencing-credentials.sh"] = string(bindata.MustAsset("etcd/update-fencing-credentials.sh"))
 	} else {
 		clusterRestoreScript = "etcd/cluster-restore.sh"
 		disableEtcdScript = "etcd/disable-etcd.sh"

--- a/pkg/operator/scriptcontroller/scriptcontroller_test.go
+++ b/pkg/operator/scriptcontroller/scriptcontroller_test.go
@@ -42,6 +42,7 @@ func TestManageScriptConfigMap(t *testing.T) {
 		expectedDisableContent   string
 		unexpectedRestoreContent string
 		unexpectedDisableContent string
+		expectedFencingScript    bool
 	}{
 		{
 			name:                     "TNF topology deploys TNF-specific scripts",
@@ -50,6 +51,7 @@ func TestManageScriptConfigMap(t *testing.T) {
 			expectedDisableContent:   "pcs resource disable etcd",
 			unexpectedRestoreContent: "wait_for_containers_to_stop",
 			unexpectedDisableContent: "restore_static_pods",
+			expectedFencingScript:    true,
 		},
 		{
 			name:                     "HighlyAvailable topology deploys standard scripts",
@@ -58,6 +60,7 @@ func TestManageScriptConfigMap(t *testing.T) {
 			expectedDisableContent:   "mv_static_pods",
 			unexpectedRestoreContent: "pcs resource disable etcd",
 			unexpectedDisableContent: "podman container exists",
+			expectedFencingScript:    false,
 		},
 		{
 			name:                     "SingleReplica topology deploys standard scripts",
@@ -66,6 +69,7 @@ func TestManageScriptConfigMap(t *testing.T) {
 			expectedDisableContent:   "mv_static_pods",
 			unexpectedRestoreContent: "crm_attribute",
 			unexpectedDisableContent: "ensure_etcd_container_stopped",
+			expectedFencingScript:    false,
 		},
 	}
 
@@ -109,6 +113,13 @@ func TestManageScriptConfigMap(t *testing.T) {
 			require.Contains(t, scriptCM.Data, "cluster-backup.sh", "cluster-backup.sh should be in ConfigMap")
 			require.Contains(t, scriptCM.Data, "etcd-common-tools", "etcd-common-tools should be in ConfigMap")
 			require.Contains(t, scriptCM.Data, "etcd.env", "etcd.env should be in ConfigMap")
+			if tc.expectedFencingScript {
+				require.Contains(t, scriptCM.Data, "update-fencing-credentials.sh",
+					"update-fencing-credentials.sh should be in ConfigMap for TNF topology")
+			} else {
+				require.NotContains(t, scriptCM.Data, "update-fencing-credentials.sh",
+					"update-fencing-credentials.sh should not be in ConfigMap for non TNF topology")
+			}
 
 			// Verify etcd.env has correct content
 			require.Contains(t, scriptCM.Data["etcd.env"], "ETCD_IMAGE", "etcd.env should contain environment variables")


### PR DESCRIPTION
Introduces a bash script to update fencing credentials (BMC username, password, address) in both pacemaker stonith devices and the corresponding Kubernetes secret. Registered in ScriptController for TNF-only deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated fencing credential update utility for supported etcd topologies to update Pacemaker stonith settings, upsert fencing credentials, verify access, and check Pacemaker health.

* **Tests**
  * Expanded tests to validate topology-dependent inclusion of the fencing credential utility in generated script bundles.

* **Documentation**
  * Added user-facing guidance on running the utility, parameters, usage methods, and security considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->