### PR TITLE
OCPBUGS-81500: fix: udpate healthcheck previous state only after successful operator status update

### DIFF
--- a/pkg/tnf/pkg/pacemaker/healthcheck.go
+++ b/pkg/tnf/pkg/pacemaker/healthcheck.go
@@ -245,6 +245,13 @@ func (c *HealthCheck) sync(ctx context.Context, syncCtx factory.SyncContext) err
 
 	c.recordHealthCheckEvents(currentStatus, previousStatus)
 
+	// Only mark as processed after status was successfully updated
+	if currentStatus.OverallStatus != statusUnknown {
+		c.previousMu.Lock()
+		c.previous = currentStatus
+		c.previousMu.Unlock()
+	}
+
 	return nil
 }
 
@@ -323,13 +330,6 @@ func (c *HealthCheck) getPacemakerStatus(ctx context.Context) (*HealthStatus, *H
 	// Build health status from the CRD status fields
 	currentStatus := c.buildHealthStatusFromCR(pacemakerCR)
 	currentStatus.CRLastUpdated = crLastUpdated
-
-	// Only update previous for non-Unknown status (preserves last valid for grace period)
-	if currentStatus.OverallStatus != statusUnknown {
-		c.previousMu.Lock()
-		c.previous = currentStatus
-		c.previousMu.Unlock()
-	}
 
 	return currentStatus, previous, nil
 }

--- a/pkg/tnf/pkg/pacemaker/healthcheck.go
+++ b/pkg/tnf/pkg/pacemaker/healthcheck.go
@@ -265,6 +265,12 @@ func (c *HealthCheck) sync(ctx context.Context, syncCtx factory.SyncContext) err
 
 	c.recordHealthCheckEvents(currentStatus, previousStatus)
 
+	// Only mark as processed after status was successfully updated
+	if currentStatus.OverallStatus != StatusUnknown {
+		c.previousMu.Lock()
+		c.previous = currentStatus
+		c.previousMu.Unlock()
+	}
 	return nil
 }
 
@@ -304,13 +310,9 @@ func (c *HealthCheck) getPacemakerStatus(ctx context.Context) (*HealthStatus, *H
 		return nil, nil, nil
 	}
 
+	// Build health status from the CRD status fields
 	currentStatus := BuildHealthStatusFromCR(pacemakerCR)
-
-	if currentStatus.OverallStatus != StatusUnknown {
-		c.previousMu.Lock()
-		c.previous = currentStatus
-		c.previousMu.Unlock()
-	}
+	currentStatus.CRLastUpdated = pacemakerCR.Status.LastUpdated.Time
 
 	return currentStatus, previous, nil
 }

--- a/pkg/tnf/pkg/pacemaker/healthcheck_test.go
+++ b/pkg/tnf/pkg/pacemaker/healthcheck_test.go
@@ -347,6 +347,9 @@ func TestHealthCheck_getPacemakerStatus_UnchangedTimestamp(t *testing.T) {
 	require.NotNil(t, current1, "First call should return a status")
 	require.Equal(t, statusHealthy, current1.OverallStatus, "First call should return healthy status")
 
+	// Simulate what sync() does after successful updateOperatorStatus
+	controller.previous = current1
+
 	// Second call with same timestamp should return nil (no change)
 	current2, _, err2 := controller.getPacemakerStatus(ctx)
 	require.NoError(t, err2, "Second getPacemakerStatus should not return an error")

--- a/pkg/tnf/pkg/pacemaker/healthcheck_test.go
+++ b/pkg/tnf/pkg/pacemaker/healthcheck_test.go
@@ -298,6 +298,9 @@ func TestHealthCheck_getPacemakerStatus_UnchangedTimestamp(t *testing.T) {
 	require.NotNil(t, current1, "First call should return a status")
 	require.Equal(t, StatusHealthy, current1.OverallStatus, "First call should return healthy status")
 
+	// Simulate what sync() does after successful updateOperatorStatus
+	controller.previous = current1
+
 	// Second call with same timestamp should return nil (no change)
 	current2, _, err2 := controller.getPacemakerStatus(ctx)
 	require.NoError(t, err2, "Second getPacemakerStatus should not return an error")


### PR DESCRIPTION
Previously, getPacemakerStatus updated c.previous before updateOperatorStatus was called. If the status update failed, subsequent syncs would skip processing because c.previous already reflected the new CR timestamp, leaving PacemakerHealthCheckDegraded stuck a True indefinitely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved Pacemaker health check status tracking for more accurate grace-period timing and state transitions.
* Prevented unknown status values from replacing meaningful health information.
* Improved consistency between reported health status and recorded health events.
* Preserved status timestamps when health conditions remain unchanged.
* Improved persistence of health information between consecutive checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->