### PR TITLE
OCPEDGE-2476: Added TNF taint and annotation removal logic in CEO

### DIFF
--- a/pkg/tnf/operator/starter.go
+++ b/pkg/tnf/operator/starter.go
@@ -96,6 +96,9 @@ func HandleDualReplicaClusters(
 				return
 			}
 
+			// clean up Pacemaker's out-of-service taint if the node recovered while CEO was down
+			go tools.RemoveOutOfServiceTaintIfNeeded(ctx, kubeClient, node)
+
 			// this potentially needs some time when we wait for etcd bootstrap to complete, so run it in a goroutine,
 			// to not block the event handler
 			klog.Infof("node added and ready: %s", node.GetName())
@@ -114,6 +117,8 @@ func HandleDualReplicaClusters(
 			newReady := tools.IsNodeReady(newNode)
 			if !oldReady && newReady {
 				klog.Infof("node %s transitioned to ready state", newNode.GetName())
+				// clean up Pacemaker's out-of-service taint now that the failed node is back
+				go tools.RemoveOutOfServiceTaintIfNeeded(ctx, kubeClient, newNode)
 				// this potentially needs some time when we wait for etcd bootstrap to complete, so run it in a goroutine,
 				// to not block the event handler
 				go handleNodesWithRetry(controllerContext, controlPlaneNodeLister, ctx, operatorClient, kubeClient, kubeInformersForNamespaces, etcdInformer)

--- a/pkg/tnf/operator/starter.go
+++ b/pkg/tnf/operator/starter.go
@@ -97,7 +97,7 @@ func HandleDualReplicaClusters(
 			}
 
 			// clean up Pacemaker's out-of-service taint if the node recovered while CEO was down
-			go tools.RemoveOutOfServiceTaintIfNeeded(ctx, kubeClient, node)
+			go tools.RemoveOutOfServiceTaintIfNeeded(ctx, kubeClient, operatorClient, node)
 
 			// this potentially needs some time when we wait for etcd bootstrap to complete, so run it in a goroutine,
 			// to not block the event handler
@@ -112,13 +112,12 @@ func HandleDualReplicaClusters(
 				return
 			}
 
-			// only handle if node transitioned from not ready to ready
 			oldReady := tools.IsNodeReady(oldNode)
 			newReady := tools.IsNodeReady(newNode)
 			if !oldReady && newReady {
 				klog.Infof("node %s transitioned to ready state", newNode.GetName())
 				// clean up Pacemaker's out-of-service taint now that the failed node is back
-				go tools.RemoveOutOfServiceTaintIfNeeded(ctx, kubeClient, newNode)
+				go tools.RemoveOutOfServiceTaintIfNeeded(ctx, kubeClient, operatorClient, newNode)
 				// this potentially needs some time when we wait for etcd bootstrap to complete, so run it in a goroutine,
 				// to not block the event handler
 				go handleNodesWithRetry(controllerContext, controlPlaneNodeLister, ctx, operatorClient, kubeClient, kubeInformersForNamespaces, etcdInformer)

--- a/pkg/tnf/pkg/tools/taint.go
+++ b/pkg/tnf/pkg/tools/taint.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -45,34 +46,45 @@ func RemoveOutOfServiceTaintIfNeeded(ctx context.Context, kubeClient kubernetes.
 
 	klog.Infof("node %s has out-of-service taint and pacemaker annotation, removing both", node.Name)
 
-	var filteredTaints []corev1.Taint
-	for _, taint := range node.Spec.Taints {
-		if isOutOfServiceTaint(taint) {
-			continue
+	// Use read-modify-update with conflict retry for taints to avoid clobbering concurrent changes
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		freshNode, err := kubeClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get node %s: %w", node.Name, err)
 		}
-		filteredTaints = append(filteredTaints, taint)
+
+		if !hasOutOfServiceTaint(freshNode) {
+			klog.V(4).Infof("node %s no longer has out-of-service taint after re-read, skipping taint removal", node.Name)
+			return nil
+		}
+
+		freshNode.Spec.Taints = slices.DeleteFunc(freshNode.Spec.Taints, isOutOfServiceTaint)
+
+		_, err = kubeClient.CoreV1().Nodes().Update(ctx, freshNode, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		klog.Errorf("failed to remove out-of-service taint from node %s: %v", node.Name, err)
+		return fmt.Errorf("failed to remove out-of-service taint from node %s: %w", node.Name, err)
 	}
 
+	// Remove the annotation via merge patch — annotations are a map so no clobber risk
 	patch := map[string]any{
 		"metadata": map[string]any{
 			"annotations": map[string]any{
 				OutOfServiceAnnotationKey: nil,
 			},
 		},
-		"spec": map[string]any{
-			"taints": filteredTaints,
-		},
 	}
-
 	patchBytes, err := json.Marshal(patch)
 	if err != nil {
-		return fmt.Errorf("failed to marshal patch for node %s: %w", node.Name, err)
+		return fmt.Errorf("failed to marshal annotation patch for node %s: %w", node.Name, err)
 	}
 
 	_, err = kubeClient.CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		klog.Errorf("failed to patch node %s to remove out-of-service taint and annotation: %v", node.Name, err)
-		return fmt.Errorf("failed to patch node %s to remove out-of-service taint and annotation: %w", node.Name, err)
+		klog.Errorf("failed to remove out-of-service annotation from node %s: %v", node.Name, err)
+		return fmt.Errorf("failed to remove out-of-service annotation from node %s: %w", node.Name, err)
 	}
 
 	klog.Infof("successfully removed out-of-service taint and pacemaker annotation from node %s", node.Name)

--- a/pkg/tnf/pkg/tools/taint.go
+++ b/pkg/tnf/pkg/tools/taint.go
@@ -1,0 +1,80 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const (
+	OutOfServiceTaintKey        = "node.kubernetes.io/out-of-service"
+	OutOfServiceTaintValue      = "nodeshutdown"
+	OutOfServiceAnnotationKey   = "node.kubernetes.io/out-of-service-applied-by"
+	OutOfServiceAnnotationValue = "pacemaker"
+)
+
+func isOutOfServiceTaint(taint corev1.Taint) bool {
+	return taint.Key == OutOfServiceTaintKey &&
+		taint.Value == OutOfServiceTaintValue &&
+		taint.Effect == corev1.TaintEffectNoExecute
+}
+
+func hasOutOfServiceTaint(node *corev1.Node) bool {
+	return slices.ContainsFunc(node.Spec.Taints, isOutOfServiceTaint)
+}
+
+func hasOutOfServiceAnnotation(node *corev1.Node) bool {
+	if node.Annotations == nil {
+		return false
+	}
+	return node.Annotations[OutOfServiceAnnotationKey] == OutOfServiceAnnotationValue
+}
+
+func RemoveOutOfServiceTaintIfNeeded(ctx context.Context, kubeClient kubernetes.Interface, node *corev1.Node) error {
+	if !hasOutOfServiceTaint(node) || !hasOutOfServiceAnnotation(node) {
+		klog.V(4).Infof("node %s does not have both out-of-service taint and pacemaker annotation, skipping", node.Name)
+		return nil
+	}
+
+	klog.Infof("node %s has out-of-service taint and pacemaker annotation, removing both", node.Name)
+
+	var filteredTaints []corev1.Taint
+	for _, taint := range node.Spec.Taints {
+		if isOutOfServiceTaint(taint) {
+			continue
+		}
+		filteredTaints = append(filteredTaints, taint)
+	}
+
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				OutOfServiceAnnotationKey: nil,
+			},
+		},
+		"spec": map[string]any{
+			"taints": filteredTaints,
+		},
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch for node %s: %w", node.Name, err)
+	}
+
+	_, err = kubeClient.CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		klog.Errorf("failed to patch node %s to remove out-of-service taint and annotation: %v", node.Name, err)
+		return fmt.Errorf("failed to patch node %s to remove out-of-service taint and annotation: %w", node.Name, err)
+	}
+
+	klog.Infof("successfully removed out-of-service taint and pacemaker annotation from node %s", node.Name)
+	return nil
+}

--- a/pkg/tnf/pkg/tools/taint.go
+++ b/pkg/tnf/pkg/tools/taint.go
@@ -2,13 +2,11 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
@@ -39,52 +37,33 @@ func hasOutOfServiceAnnotation(node *corev1.Node) bool {
 }
 
 func RemoveOutOfServiceTaintIfNeeded(ctx context.Context, kubeClient kubernetes.Interface, node *corev1.Node) error {
-	if !hasOutOfServiceTaint(node) || !hasOutOfServiceAnnotation(node) {
-		klog.V(4).Infof("node %s does not have both out-of-service taint and pacemaker annotation, skipping", node.Name)
+	if !hasOutOfServiceAnnotation(node) {
+		klog.V(4).Infof("node %s does not have %s=%s annotation, skipping (taint not ours to remove)", node.Name, OutOfServiceAnnotationKey, OutOfServiceAnnotationValue)
 		return nil
 	}
 
-	klog.Infof("node %s has out-of-service taint and pacemaker annotation, removing both", node.Name)
+	klog.Infof("node %s has pacemaker annotation, cleaning up out-of-service taint and annotation", node.Name)
 
-	// Use read-modify-update with conflict retry for taints to avoid clobbering concurrent changes
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		freshNode, err := kubeClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to get node %s: %w", node.Name, err)
 		}
 
-		if !hasOutOfServiceTaint(freshNode) {
-			klog.V(4).Infof("node %s no longer has out-of-service taint after re-read, skipping taint removal", node.Name)
+		if !hasOutOfServiceTaint(freshNode) && !hasOutOfServiceAnnotation(freshNode) {
+			klog.V(4).Infof("node %s no longer has out-of-service taint or annotation after re-read, skipping", node.Name)
 			return nil
 		}
 
 		freshNode.Spec.Taints = slices.DeleteFunc(freshNode.Spec.Taints, isOutOfServiceTaint)
+		delete(freshNode.Annotations, OutOfServiceAnnotationKey)
 
 		_, err = kubeClient.CoreV1().Nodes().Update(ctx, freshNode, metav1.UpdateOptions{})
 		return err
 	})
 	if err != nil {
-		klog.Errorf("failed to remove out-of-service taint from node %s: %v", node.Name, err)
-		return fmt.Errorf("failed to remove out-of-service taint from node %s: %w", node.Name, err)
-	}
-
-	// Remove the annotation via merge patch — annotations are a map so no clobber risk
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"annotations": map[string]any{
-				OutOfServiceAnnotationKey: nil,
-			},
-		},
-	}
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return fmt.Errorf("failed to marshal annotation patch for node %s: %w", node.Name, err)
-	}
-
-	_, err = kubeClient.CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-	if err != nil {
-		klog.Errorf("failed to remove out-of-service annotation from node %s: %v", node.Name, err)
-		return fmt.Errorf("failed to remove out-of-service annotation from node %s: %w", node.Name, err)
+		klog.Errorf("failed to remove out-of-service taint and annotation from node %s: %v", node.Name, err)
+		return fmt.Errorf("failed to remove out-of-service taint and annotation from node %s: %w", node.Name, err)
 	}
 
 	klog.Infof("successfully removed out-of-service taint and pacemaker annotation from node %s", node.Name)

--- a/pkg/tnf/pkg/tools/taint.go
+++ b/pkg/tnf/pkg/tools/taint.go
@@ -8,6 +8,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -51,6 +52,10 @@ func RemoveOutOfServiceTaintIfNeeded(ctx context.Context, kubeClient kubernetes.
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		freshNode, err := kubeClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("node %s no longer exists, skipping cleanup", node.Name)
+			return nil
+		}
 		if err != nil {
 			return fmt.Errorf("failed to get node %s: %w", node.Name, err)
 		}
@@ -64,6 +69,10 @@ func RemoveOutOfServiceTaintIfNeeded(ctx context.Context, kubeClient kubernetes.
 		delete(freshNode.Annotations, OutOfServiceAnnotationKey)
 
 		_, err = kubeClient.CoreV1().Nodes().Update(ctx, freshNode, metav1.UpdateOptions{})
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("node %s no longer exists during update, skipping cleanup", node.Name)
+			return nil
+		}
 		return err
 	})
 	if err != nil {

--- a/pkg/tnf/pkg/tools/taint.go
+++ b/pkg/tnf/pkg/tools/taint.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -17,6 +19,9 @@ const (
 	OutOfServiceTaintValue      = "nodeshutdown"
 	OutOfServiceAnnotationKey   = "node.kubernetes.io/out-of-service-applied-by"
 	OutOfServiceAnnotationValue = "pacemaker"
+
+	conditionTypeTNFTaintRemoval = "TNFTaintRemovalControllerDegraded"
+	reasonTaintRemovalFailed     = "TaintRemovalFailed"
 )
 
 func isOutOfServiceTaint(taint corev1.Taint) bool {
@@ -36,10 +41,10 @@ func hasOutOfServiceAnnotation(node *corev1.Node) bool {
 	return node.Annotations[OutOfServiceAnnotationKey] == OutOfServiceAnnotationValue
 }
 
-func RemoveOutOfServiceTaintIfNeeded(ctx context.Context, kubeClient kubernetes.Interface, node *corev1.Node) error {
+func RemoveOutOfServiceTaintIfNeeded(ctx context.Context, kubeClient kubernetes.Interface, operatorClient v1helpers.StaticPodOperatorClient, node *corev1.Node) {
 	if !hasOutOfServiceAnnotation(node) {
 		klog.V(4).Infof("node %s does not have %s=%s annotation, skipping (taint not ours to remove)", node.Name, OutOfServiceAnnotationKey, OutOfServiceAnnotationValue)
-		return nil
+		return
 	}
 
 	klog.Infof("node %s has pacemaker annotation, cleaning up out-of-service taint and annotation", node.Name)
@@ -63,9 +68,34 @@ func RemoveOutOfServiceTaintIfNeeded(ctx context.Context, kubeClient kubernetes.
 	})
 	if err != nil {
 		klog.Errorf("failed to remove out-of-service taint and annotation from node %s: %v", node.Name, err)
-		return fmt.Errorf("failed to remove out-of-service taint and annotation from node %s: %w", node.Name, err)
+		setTaintRemovalDegradedCondition(ctx, operatorClient, node.Name, err)
+		return
 	}
 
 	klog.Infof("successfully removed out-of-service taint and pacemaker annotation from node %s", node.Name)
-	return nil
+	clearTaintRemovalDegradedCondition(ctx, operatorClient)
+}
+
+func setTaintRemovalDegradedCondition(ctx context.Context, operatorClient v1helpers.StaticPodOperatorClient, nodeName string, err error) {
+	condition := operatorv1.OperatorCondition{
+		Type:    conditionTypeTNFTaintRemoval,
+		Status:  operatorv1.ConditionTrue,
+		Reason:  reasonTaintRemovalFailed,
+		Message: fmt.Sprintf("failed to remove out-of-service taint from node %s: %v", nodeName, err),
+	}
+	_, _, updateErr := v1helpers.UpdateStaticPodStatus(ctx, operatorClient, v1helpers.UpdateStaticPodConditionFn(condition))
+	if updateErr != nil {
+		klog.Errorf("failed to set %s condition: %v", conditionTypeTNFTaintRemoval, updateErr)
+	}
+}
+
+func clearTaintRemovalDegradedCondition(ctx context.Context, operatorClient v1helpers.StaticPodOperatorClient) {
+	condition := operatorv1.OperatorCondition{
+		Type:   conditionTypeTNFTaintRemoval,
+		Status: operatorv1.ConditionFalse,
+	}
+	_, _, updateErr := v1helpers.UpdateStaticPodStatus(ctx, operatorClient, v1helpers.UpdateStaticPodConditionFn(condition))
+	if updateErr != nil {
+		klog.Errorf("failed to clear %s condition: %v", conditionTypeTNFTaintRemoval, updateErr)
+	}
 }

--- a/pkg/tnf/pkg/tools/taint_test.go
+++ b/pkg/tnf/pkg/tools/taint_test.go
@@ -1,0 +1,319 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestHasOutOfServiceTaint(t *testing.T) {
+	tests := []struct {
+		name string
+		node *corev1.Node
+		want bool
+	}{
+		{
+			name: "node with matching taint",
+			node: &corev1.Node{
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    OutOfServiceTaintKey,
+							Value:  OutOfServiceTaintValue,
+							Effect: corev1.TaintEffectNoExecute,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "node with matching key but wrong value",
+			node: &corev1.Node{
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    OutOfServiceTaintKey,
+							Value:  "other",
+							Effect: corev1.TaintEffectNoExecute,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "node with matching key and value but wrong effect",
+			node: &corev1.Node{
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    OutOfServiceTaintKey,
+							Value:  OutOfServiceTaintValue,
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "node with no taints",
+			node: &corev1.Node{},
+			want: false,
+		},
+		{
+			name: "node with other taints only",
+			node: &corev1.Node{
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    "node.kubernetes.io/not-ready",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasOutOfServiceTaint(tt.node)
+			require.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestHasOutOfServiceAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		node *corev1.Node
+		want bool
+	}{
+		{
+			name: "node with matching annotation",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						OutOfServiceAnnotationKey: OutOfServiceAnnotationValue,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "node with matching key but wrong value",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						OutOfServiceAnnotationKey: "other-controller",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "node with no annotations",
+			node: &corev1.Node{},
+			want: false,
+		},
+		{
+			name: "node with other annotations only",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"some-other-annotation": "value",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasOutOfServiceAnnotation(tt.node)
+			require.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
+	tests := []struct {
+		name            string
+		node            *corev1.Node
+		expectPatch     bool
+		expectTaintGone bool
+		expectAnnoGone  bool
+	}{
+		{
+			name: "both taint and annotation present - removes both",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "master-0",
+					Annotations: map[string]string{
+						OutOfServiceAnnotationKey: OutOfServiceAnnotationValue,
+						"other-annotation":        "keep-me",
+					},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    "node.kubernetes.io/not-ready",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+						{
+							Key:    OutOfServiceTaintKey,
+							Value:  OutOfServiceTaintValue,
+							Effect: corev1.TaintEffectNoExecute,
+						},
+					},
+				},
+			},
+			expectPatch:     true,
+			expectTaintGone: true,
+			expectAnnoGone:  true,
+		},
+		{
+			name: "taint only, no annotation - no patch",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "master-0",
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    OutOfServiceTaintKey,
+							Value:  OutOfServiceTaintValue,
+							Effect: corev1.TaintEffectNoExecute,
+						},
+					},
+				},
+			},
+			expectPatch: false,
+		},
+		{
+			name: "annotation only, no taint - no patch",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "master-0",
+					Annotations: map[string]string{
+						OutOfServiceAnnotationKey: OutOfServiceAnnotationValue,
+					},
+				},
+			},
+			expectPatch: false,
+		},
+		{
+			name: "neither taint nor annotation - no patch",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "master-0",
+				},
+			},
+			expectPatch: false,
+		},
+		{
+			name: "taint key matches but wrong value - no patch",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "master-0",
+					Annotations: map[string]string{
+						OutOfServiceAnnotationKey: OutOfServiceAnnotationValue,
+					},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    OutOfServiceTaintKey,
+							Value:  "other-value",
+							Effect: corev1.TaintEffectNoExecute,
+						},
+					},
+				},
+			},
+			expectPatch: false,
+		},
+		{
+			name: "annotation key matches but wrong value - no patch",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "master-0",
+					Annotations: map[string]string{
+						OutOfServiceAnnotationKey: "other-controller",
+					},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    OutOfServiceTaintKey,
+							Value:  OutOfServiceTaintValue,
+							Effect: corev1.TaintEffectNoExecute,
+						},
+					},
+				},
+			},
+			expectPatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeClient := fake.NewClientset(tt.node)
+
+			err := RemoveOutOfServiceTaintIfNeeded(context.Background(), kubeClient, tt.node)
+			require.NoError(t, err)
+
+			actions := kubeClient.Actions()
+			patchFound := false
+			for _, action := range actions {
+				if action.GetVerb() == "patch" && action.GetResource().Resource == "nodes" {
+					patchFound = true
+				}
+			}
+
+			if tt.expectPatch {
+				require.True(t, patchFound, "expected a patch action but none was found")
+
+				updatedNode, err := kubeClient.CoreV1().Nodes().Get(context.Background(), tt.node.Name, metav1.GetOptions{})
+				require.NoError(t, err)
+
+				if tt.expectTaintGone {
+					require.False(t, hasOutOfServiceTaint(updatedNode),
+						"expected out-of-service taint to be removed")
+					for _, taint := range tt.node.Spec.Taints {
+						if taint.Key != OutOfServiceTaintKey {
+							found := false
+							for _, remaining := range updatedNode.Spec.Taints {
+								if remaining.Key == taint.Key {
+									found = true
+									break
+								}
+							}
+							require.True(t, found, "expected taint %s to be preserved", taint.Key)
+						}
+					}
+				}
+
+				if tt.expectAnnoGone {
+					_, exists := updatedNode.Annotations[OutOfServiceAnnotationKey]
+					require.False(t, exists, "expected out-of-service annotation to be removed")
+					for key, val := range tt.node.Annotations {
+						if key != OutOfServiceAnnotationKey {
+							require.Equal(t, val, updatedNode.Annotations[key],
+								"expected annotation %s to be preserved", key)
+						}
+					}
+				}
+			} else {
+				require.False(t, patchFound, "expected no patch action but one was found")
+			}
+		})
+	}
+}

--- a/pkg/tnf/pkg/tools/taint_test.go
+++ b/pkg/tnf/pkg/tools/taint_test.go
@@ -146,11 +146,9 @@ func TestHasOutOfServiceAnnotation(t *testing.T) {
 
 func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 	tests := []struct {
-		name            string
-		node            *corev1.Node
-		expectPatch     bool
-		expectTaintGone bool
-		expectAnnoGone  bool
+		name           string
+		node           *corev1.Node
+		expectModified bool
 	}{
 		{
 			name: "both taint and annotation present - removes both",
@@ -176,12 +174,10 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 					},
 				},
 			},
-			expectPatch:     true,
-			expectTaintGone: true,
-			expectAnnoGone:  true,
+			expectModified: true,
 		},
 		{
-			name: "taint only, no annotation - no patch",
+			name: "taint only, no annotation - no-op",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "master-0",
@@ -196,10 +192,10 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 					},
 				},
 			},
-			expectPatch: false,
+			expectModified: false,
 		},
 		{
-			name: "annotation only, no taint - no patch",
+			name: "annotation only, no taint - no-op",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "master-0",
@@ -208,19 +204,19 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 					},
 				},
 			},
-			expectPatch: false,
+			expectModified: false,
 		},
 		{
-			name: "neither taint nor annotation - no patch",
+			name: "neither taint nor annotation - no-op",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "master-0",
 				},
 			},
-			expectPatch: false,
+			expectModified: false,
 		},
 		{
-			name: "taint key matches but wrong value - no patch",
+			name: "taint key matches but wrong value - no-op",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "master-0",
@@ -238,10 +234,10 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 					},
 				},
 			},
-			expectPatch: false,
+			expectModified: false,
 		},
 		{
-			name: "annotation key matches but wrong value - no patch",
+			name: "annotation key matches but wrong value - no-op",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "master-0",
@@ -259,7 +255,7 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 					},
 				},
 			},
-			expectPatch: false,
+			expectModified: false,
 		},
 	}
 
@@ -271,48 +267,52 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 			require.NoError(t, err)
 
 			actions := kubeClient.Actions()
-			patchFound := false
+			hasUpdate := false
+			hasPatch := false
 			for _, action := range actions {
-				if action.GetVerb() == "patch" && action.GetResource().Resource == "nodes" {
-					patchFound = true
+				if action.GetResource().Resource == "nodes" {
+					if action.GetVerb() == "update" {
+						hasUpdate = true
+					}
+					if action.GetVerb() == "patch" {
+						hasPatch = true
+					}
 				}
 			}
 
-			if tt.expectPatch {
-				require.True(t, patchFound, "expected a patch action but none was found")
+			if tt.expectModified {
+				require.True(t, hasUpdate, "expected a node update action for taint removal")
+				require.True(t, hasPatch, "expected a node patch action for annotation removal")
 
 				updatedNode, err := kubeClient.CoreV1().Nodes().Get(context.Background(), tt.node.Name, metav1.GetOptions{})
 				require.NoError(t, err)
 
-				if tt.expectTaintGone {
-					require.False(t, hasOutOfServiceTaint(updatedNode),
-						"expected out-of-service taint to be removed")
-					for _, taint := range tt.node.Spec.Taints {
-						if taint.Key != OutOfServiceTaintKey {
-							found := false
-							for _, remaining := range updatedNode.Spec.Taints {
-								if remaining.Key == taint.Key {
-									found = true
-									break
-								}
+				require.False(t, hasOutOfServiceTaint(updatedNode),
+					"expected out-of-service taint to be removed")
+				for _, taint := range tt.node.Spec.Taints {
+					if taint.Key != OutOfServiceTaintKey {
+						found := false
+						for _, remaining := range updatedNode.Spec.Taints {
+							if remaining.Key == taint.Key {
+								found = true
+								break
 							}
-							require.True(t, found, "expected taint %s to be preserved", taint.Key)
 						}
+						require.True(t, found, "expected taint %s to be preserved", taint.Key)
 					}
 				}
 
-				if tt.expectAnnoGone {
-					_, exists := updatedNode.Annotations[OutOfServiceAnnotationKey]
-					require.False(t, exists, "expected out-of-service annotation to be removed")
-					for key, val := range tt.node.Annotations {
-						if key != OutOfServiceAnnotationKey {
-							require.Equal(t, val, updatedNode.Annotations[key],
-								"expected annotation %s to be preserved", key)
-						}
+				_, exists := updatedNode.Annotations[OutOfServiceAnnotationKey]
+				require.False(t, exists, "expected out-of-service annotation to be removed")
+				for key, val := range tt.node.Annotations {
+					if key != OutOfServiceAnnotationKey {
+						require.Equal(t, val, updatedNode.Annotations[key],
+							"expected annotation %s to be preserved", key)
 					}
 				}
 			} else {
-				require.False(t, patchFound, "expected no patch action but one was found")
+				require.False(t, hasUpdate, "expected no node update action")
+				require.False(t, hasPatch, "expected no node patch action")
 			}
 		})
 	}

--- a/pkg/tnf/pkg/tools/taint_test.go
+++ b/pkg/tnf/pkg/tools/taint_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +74,7 @@ func TestHasOutOfServiceTaint(t *testing.T) {
 				Spec: corev1.NodeSpec{
 					Taints: []corev1.Taint{
 						{
-							Key:    "node.kubernetes.io/not-ready",
+							Key:    corev1.TaintNodeNotReady,
 							Effect: corev1.TaintEffectNoSchedule,
 						},
 					},
@@ -90,7 +92,7 @@ func TestHasOutOfServiceTaint(t *testing.T) {
 	}
 }
 
-func TestHasOutOfServiceAnnotation(t *testing.T) {
+func Test_hasOutOfServiceAnnotation(t *testing.T) {
 	tests := []struct {
 		name string
 		node *corev1.Node
@@ -163,7 +165,7 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 				Spec: corev1.NodeSpec{
 					Taints: []corev1.Taint{
 						{
-							Key:    "node.kubernetes.io/not-ready",
+							Key:    corev1.TaintNodeNotReady,
 							Effect: corev1.TaintEffectNoSchedule,
 						},
 						{
@@ -262,9 +264,18 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			kubeClient := fake.NewClientset(tt.node)
+			operatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				&operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+				},
+				&operatorv1.StaticPodOperatorStatus{},
+				nil,
+				nil,
+			)
 
-			err := RemoveOutOfServiceTaintIfNeeded(context.Background(), kubeClient, tt.node)
-			require.NoError(t, err)
+			RemoveOutOfServiceTaintIfNeeded(context.Background(), kubeClient, operatorClient, tt.node)
 
 			actions := kubeClient.Actions()
 			hasUpdate := false

--- a/pkg/tnf/pkg/tools/taint_test.go
+++ b/pkg/tnf/pkg/tools/taint_test.go
@@ -195,7 +195,7 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 			expectModified: false,
 		},
 		{
-			name: "annotation only, no taint - no-op",
+			name: "annotation only, no taint - removes stale annotation",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "master-0",
@@ -204,7 +204,7 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 					},
 				},
 			},
-			expectModified: false,
+			expectModified: true,
 		},
 		{
 			name: "neither taint nor annotation - no-op",
@@ -216,7 +216,7 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 			expectModified: false,
 		},
 		{
-			name: "taint key matches but wrong value - no-op",
+			name: "taint key matches but wrong value - removes stale annotation, preserves unrelated taint",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "master-0",
@@ -234,7 +234,7 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 					},
 				},
 			},
-			expectModified: false,
+			expectModified: true,
 		},
 		{
 			name: "annotation key matches but wrong value - no-op",
@@ -281,8 +281,8 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 			}
 
 			if tt.expectModified {
-				require.True(t, hasUpdate, "expected a node update action for taint removal")
-				require.True(t, hasPatch, "expected a node patch action for annotation removal")
+				require.True(t, hasUpdate, "expected a node update action for taint and annotation removal")
+				require.False(t, hasPatch, "expected no separate patch — taint and annotation should be removed atomically in a single update")
 
 				updatedNode, err := kubeClient.CoreV1().Nodes().Get(context.Background(), tt.node.Name, metav1.GetOptions{})
 				require.NoError(t, err)
@@ -290,16 +290,17 @@ func TestRemoveOutOfServiceTaintIfNeeded(t *testing.T) {
 				require.False(t, hasOutOfServiceTaint(updatedNode),
 					"expected out-of-service taint to be removed")
 				for _, taint := range tt.node.Spec.Taints {
-					if taint.Key != OutOfServiceTaintKey {
-						found := false
-						for _, remaining := range updatedNode.Spec.Taints {
-							if remaining.Key == taint.Key {
-								found = true
-								break
-							}
-						}
-						require.True(t, found, "expected taint %s to be preserved", taint.Key)
+					if isOutOfServiceTaint(taint) {
+						continue
 					}
+					found := false
+					for _, remaining := range updatedNode.Spec.Taints {
+						if remaining.Key == taint.Key && remaining.Value == taint.Value && remaining.Effect == taint.Effect {
+							found = true
+							break
+						}
+					}
+					require.True(t, found, "expected taint %s=%s:%s to be preserved", taint.Key, taint.Value, taint.Effect)
 				}
 
 				_, exists := updatedNode.Annotations[OutOfServiceAnnotationKey]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator now proactively removes "out-of-service" taints and their associated annotation when nodes transition to Ready, and updates operator status (sets/clears a degraded condition) on taint-removal failures or successes.

* **Tests**
  * Added unit tests covering detection and cleanup behavior, including successful removal and no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->