### PR TITLE
OCPBUGS-83332: fix cluster-restore-tnf.sh for FQDN hostnames

### DIFF
--- a/bindata/etcd/cluster-restore-tnf.sh
+++ b/bindata/etcd/cluster-restore-tnf.sh
@@ -42,14 +42,14 @@ fi
 
 function get_etcd_advertise_ip() {
   # Try to detect IP from etcd.env (NODE_<nodename>_IP variable)
-  NODENAME_UNDERSCORE=$(echo "${NODENAME}" | tr '-' '_')
+  NODENAME_UNDERSCORE=$(echo "${NODENAME}" | tr '.-' '_')
   NODE_IP_VAR="NODE_${NODENAME_UNDERSCORE}_IP"
   IP="${!NODE_IP_VAR}"
   echo "$IP"
 }
 
 function get_peer_node_name() {
-  NODENAME_UNDERSCORE=$(echo "${NODENAME}" | tr '-' '_')
+  NODENAME_UNDERSCORE=$(echo "${NODENAME}" | tr '.-' '_')
 
   # Find all NODE_*_ETCD_NAME environment variables, exclude current node, get the value
   env | grep -E '^NODE_.*_ETCD_NAME' | grep -v "${NODENAME_UNDERSCORE}" | cut -d= -f2


### PR DESCRIPTION
## Summary

`cluster-restore-tnf.sh` fails with `invalid variable name` when run on nodes with FQDN hostnames (hostnames containing dots).

**Root cause:** The `get_etcd_advertise_ip()` and `get_peer_node_name()` functions use `tr '-' '_'` to construct bash variable names from node hostnames. However, the Go [`envVarSafe()`](https://github.com/openshift/cluster-etcd-operator/blob/main/pkg/etcdenvvar/etcd_env.go#L270) function replaces **both** hyphens and dots with underscores when generating `etcd.env` entries. This mismatch causes the shell script to produce invalid variable names like `NODE_node_0.cluster.example.com_IP` instead of `NODE_node_0_cluster_example_com_IP`.

**Fix:** Change `tr '-' '_'` to `tr '.-' '_'` in both functions to match `envVarSafe()` behavior.

**Error before fix:**
```
/usr/local/bin/cluster-restore.sh: line 47: NODE_master_0.test.example.com_IP: invalid variable name
```

## Verification

Reproduced and verified on a Two-Node Fencing cluster (OCP 4.23.0-0.nightly-2026-05-18-212225):

1. Deployed a healthy TNF cluster via dev-scripts IPI
2. Took an etcd backup on master-0
3. Set hostname to FQDN: `hostnamectl set-hostname master-0.test.example.com`
4. Ran `cluster-restore.sh` — **failed** with `invalid variable name` (confirmed bug)
5. Applied the `tr '.-' '_'` fix to the script on the node
6. Re-ran `cluster-restore.sh` — **passed** the variable name construction (no more bash error)

Short hostnames (`master-0`) are unaffected since they contain no dots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved etcd cluster restore process to properly handle node names containing hyphens and dots when constructing environment variables for IP address lookups during cluster recovery operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->