### PR TITLE
OCPEDGE-2711: register pacemaker alert agents for fencing events to taint/untaint nodes

### DIFF
--- a/pkg/tnf/pkg/pcs/alerts.go
+++ b/pkg/tnf/pkg/pcs/alerts.go
@@ -2,7 +2,9 @@ package pcs
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	osexec "os/exec"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -11,13 +13,22 @@ import (
 )
 
 type alertConfig struct {
-	id   string
-	path string
+	id        string
+	path      string
+	selectXML string // CIB <select> element content to filter event types
 }
 
 var alertConfigs = []alertConfig{
-	{id: "tnf-taint-alert", path: "/var/lib/pacemaker/alerts/tnf-taint-alert.sh"},
-	{id: "tnf-untaint-alert", path: "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh"},
+	{
+		id:        "tnf-taint-alert",
+		path:      "/var/lib/pacemaker/alerts/tnf-taint-alert.sh",
+		selectXML: "<select_fencing/>",
+	},
+	{
+		id:        "tnf-untaint-alert",
+		path:      "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh",
+		selectXML: "<select_nodes/><select_attributes/>",
+	},
 }
 
 // ConfigureAlerts registers pacemaker alert agents for fencing taint/untaint.
@@ -65,7 +76,26 @@ func configureAlert(ctx context.Context, ac alertConfig) error {
 		return fmt.Errorf("failed to create alert %q: stdout=%s stderr=%s: %w", ac.id, stdOut, stdErr, err)
 	}
 
+	if ac.selectXML != "" {
+		if err := applyAlertSelectFilter(ctx, ac.id, ac.selectXML); err != nil {
+			return fmt.Errorf("failed to apply select filter for alert %q: %w", ac.id, err)
+		}
+	}
+
 	klog.Infof("Successfully configured pacemaker alert %q", ac.id)
+	return nil
+}
+
+// applyAlertSelectFilter adds a <select> element to an alert via cibadmin.
+// pcs does not expose select filters, so we modify the CIB directly.
+func applyAlertSelectFilter(ctx context.Context, alertID, selectContent string) error {
+	selectXML := fmt.Sprintf(`<select>%s</select>`, selectContent)
+	cmd := fmt.Sprintf("/usr/sbin/cibadmin --modify --xpath //alerts/alert[@id='%s'] --xml-text '%s'", alertID, selectXML)
+	_, stdErr, err := exec.Execute(ctx, cmd)
+	if err != nil {
+		return fmt.Errorf("cibadmin modify for alert %q failed: %s: %w", alertID, stdErr, err)
+	}
+	klog.Infof("Applied select filter to alert %q: %s", alertID, selectContent)
 	return nil
 }
 
@@ -85,7 +115,11 @@ func fileExistsOnHost(ctx context.Context, path string) (bool, error) {
 	cmd := fmt.Sprintf("test -x %s", path)
 	_, _, err := exec.Execute(ctx, cmd)
 	if err != nil {
-		return false, nil
+		var exitErr *osexec.ExitError
+		if errors.As(err, &exitErr) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check file %s on host: %w", path, err)
 	}
 	return true, nil
 }

--- a/pkg/tnf/pkg/pcs/alerts.go
+++ b/pkg/tnf/pkg/pcs/alerts.go
@@ -2,10 +2,10 @@ package pcs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	osexec "os/exec"
-	"strings"
 
 	"k8s.io/klog/v2"
 
@@ -99,16 +99,31 @@ func applyAlertSelectFilter(ctx context.Context, alertID, selectContent string) 
 	return nil
 }
 
+// pcsAlertConfigOutput represents the JSON output of `pcs alert config --output-format json`.
+type pcsAlertConfigOutput struct {
+	Alerts []struct {
+		ID string `json:"id"`
+	} `json:"alerts"`
+}
+
 func alertExists(ctx context.Context, alertID string) (bool, error) {
-	cmd := fmt.Sprintf("/usr/sbin/pcs alert config %s", alertID)
-	_, stdErr, err := exec.Execute(ctx, cmd)
+	cmd := "/usr/sbin/pcs alert config --output-format json"
+	stdOut, stdErr, err := exec.Execute(ctx, cmd)
 	if err != nil {
-		if strings.Contains(stdErr, "does not exist") {
-			return false, nil
-		}
-		return false, fmt.Errorf("pcs alert config %s failed: %w", alertID, err)
+		return false, fmt.Errorf("pcs alert config failed: stderr=%s: %w", stdErr, err)
 	}
-	return true, nil
+
+	var config pcsAlertConfigOutput
+	if err := json.Unmarshal([]byte(stdOut), &config); err != nil {
+		return false, fmt.Errorf("failed to parse pcs alert config JSON: %w", err)
+	}
+
+	for _, alert := range config.Alerts {
+		if alert.ID == alertID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func fileExistsOnHost(ctx context.Context, path string) (bool, error) {

--- a/pkg/tnf/pkg/pcs/alerts.go
+++ b/pkg/tnf/pkg/pcs/alerts.go
@@ -1,0 +1,91 @@
+package pcs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/exec"
+)
+
+type alertConfig struct {
+	id   string
+	path string
+}
+
+var alertConfigs = []alertConfig{
+	{id: "tnf-taint-alert", path: "/var/lib/pacemaker/alerts/tnf-taint-alert.sh"},
+	{id: "tnf-untaint-alert", path: "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh"},
+}
+
+// ConfigureAlerts registers pacemaker alert agents for fencing taint/untaint.
+// It is idempotent: existing alerts are deleted and re-created to handle upgrades.
+// Returns an error if alert scripts are not yet on disk (MCO rollout pending),
+// which causes the calling job to retry.
+func ConfigureAlerts(ctx context.Context) error {
+	klog.Info("Configuring pacemaker alert agents")
+
+	for _, ac := range alertConfigs {
+		if err := configureAlert(ctx, ac); err != nil {
+			return err
+		}
+	}
+
+	klog.Info("Pacemaker alert agent configuration succeeded")
+	return nil
+}
+
+func configureAlert(ctx context.Context, ac alertConfig) error {
+	scriptPresent, err := fileExistsOnHost(ctx, ac.path)
+	if err != nil {
+		return fmt.Errorf("failed to check for alert script %s: %w", ac.path, err)
+	}
+	if !scriptPresent {
+		return fmt.Errorf("alert script %s not yet present (MCO rollout pending), will retry", ac.path)
+	}
+
+	exists, err := alertExists(ctx, ac.id)
+	if err != nil {
+		return fmt.Errorf("failed to check existing alert %q: %w", ac.id, err)
+	}
+
+	if exists {
+		klog.Infof("Alert %q already exists, deleting for re-creation", ac.id)
+		deleteCmd := fmt.Sprintf("/usr/sbin/pcs alert delete %s", ac.id)
+		if _, stdErr, err := exec.Execute(ctx, deleteCmd); err != nil {
+			return fmt.Errorf("failed to delete existing alert %q: %s: %w", ac.id, stdErr, err)
+		}
+	}
+
+	createCmd := fmt.Sprintf("/usr/sbin/pcs alert create id=%s path=%s meta timeout=30s", ac.id, ac.path)
+	stdOut, stdErr, err := exec.Execute(ctx, createCmd)
+	if err != nil {
+		return fmt.Errorf("failed to create alert %q: stdout=%s stderr=%s: %w", ac.id, stdOut, stdErr, err)
+	}
+
+	klog.Infof("Successfully configured pacemaker alert %q", ac.id)
+	return nil
+}
+
+func alertExists(ctx context.Context, alertID string) (bool, error) {
+	cmd := fmt.Sprintf("/usr/sbin/pcs alert config %s", alertID)
+	_, stdErr, err := exec.Execute(ctx, cmd)
+	if err != nil {
+		if strings.Contains(stdErr, "does not exist") {
+			return false, nil
+		}
+		return false, fmt.Errorf("pcs alert config %s failed: %w", alertID, err)
+	}
+	return true, nil
+}
+
+func fileExistsOnHost(ctx context.Context, path string) (bool, error) {
+	cmd := fmt.Sprintf("test -x %s", path)
+	_, _, err := exec.Execute(ctx, cmd)
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/tnf/pkg/pcs/alerts.go
+++ b/pkg/tnf/pkg/pcs/alerts.go
@@ -77,7 +77,7 @@ func configureAlert(ctx context.Context, ac alertConfig) error {
 	}
 
 	if ac.selectXML != "" {
-		if err := applyAlertSelectFilter(ctx, ac.id, ac.selectXML); err != nil {
+		if err := applyAlertSelectFilter(ctx, ac.id, ac.path, ac.selectXML); err != nil {
 			return fmt.Errorf("failed to apply select filter for alert %q: %w", ac.id, err)
 		}
 	}
@@ -88,9 +88,12 @@ func configureAlert(ctx context.Context, ac alertConfig) error {
 
 // applyAlertSelectFilter adds a <select> element to an alert via cibadmin.
 // pcs does not expose select filters, so we modify the CIB directly.
-func applyAlertSelectFilter(ctx context.Context, alertID, selectContent string) error {
-	selectXML := fmt.Sprintf(`<select>%s</select>`, selectContent)
-	cmd := fmt.Sprintf("/usr/sbin/cibadmin --modify --xpath //alerts/alert[@id='%s'] --xml-text '%s'", alertID, selectXML)
+// We use cibadmin --modify with the full <alert> element (matched by id attribute)
+// rather than --xpath, because --xpath with a child xml-text that doesn't match
+// the target element type fails with "No such device or address" on Pacemaker 2.1.x.
+func applyAlertSelectFilter(ctx context.Context, alertID, alertPath, selectContent string) error {
+	alertXML := fmt.Sprintf(`<alert id="%s" path="%s"><select>%s</select></alert>`, alertID, alertPath, selectContent)
+	cmd := fmt.Sprintf("/usr/sbin/cibadmin --modify --xml-text '%s'", alertXML)
 	_, stdErr, err := exec.Execute(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("cibadmin modify for alert %q failed: %s: %w", alertID, stdErr, err)

--- a/pkg/tnf/pkg/pcs/alerts.go
+++ b/pkg/tnf/pkg/pcs/alerts.go
@@ -27,12 +27,13 @@ var alertConfigs = []alertConfig{
 	{
 		id:        "tnf-untaint-alert",
 		path:      "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh",
-		selectXML: "<select_nodes/><select_attributes/>",
+		selectXML: "<select_nodes/>",
 	},
 }
 
 // ConfigureAlerts registers pacemaker alert agents for fencing taint/untaint.
-// It is idempotent: existing alerts are deleted and re-created to handle upgrades.
+// It is idempotent: existing alerts are updated in-place via cibadmin --modify
+// to avoid a race window where the alert is temporarily absent.
 // Returns an error if alert scripts are not yet on disk (MCO rollout pending),
 // which causes the calling job to retry.
 func ConfigureAlerts(ctx context.Context) error {
@@ -63,26 +64,46 @@ func configureAlert(ctx context.Context, ac alertConfig) error {
 	}
 
 	if exists {
-		klog.Infof("Alert %q already exists, deleting for re-creation", ac.id)
-		deleteCmd := fmt.Sprintf("/usr/sbin/pcs alert delete %s", ac.id)
-		if _, stdErr, err := exec.Execute(ctx, deleteCmd); err != nil {
-			return fmt.Errorf("failed to delete existing alert %q: %s: %w", ac.id, stdErr, err)
+		klog.Infof("Alert %q already exists, updating in-place", ac.id)
+		if err := modifyAlert(ctx, ac); err != nil {
+			return fmt.Errorf("failed to update alert %q in-place: %w", ac.id, err)
 		}
-	}
-
-	createCmd := fmt.Sprintf("/usr/sbin/pcs alert create id=%s path=%s meta timeout=30s", ac.id, ac.path)
-	stdOut, stdErr, err := exec.Execute(ctx, createCmd)
-	if err != nil {
-		return fmt.Errorf("failed to create alert %q: stdout=%s stderr=%s: %w", ac.id, stdOut, stdErr, err)
-	}
-
-	if ac.selectXML != "" {
-		if err := applyAlertSelectFilter(ctx, ac.id, ac.path, ac.selectXML); err != nil {
-			return fmt.Errorf("failed to apply select filter for alert %q: %w", ac.id, err)
+	} else {
+		createCmd := fmt.Sprintf("/usr/sbin/pcs alert create id=%s path=%s meta timeout=30s", ac.id, ac.path)
+		stdOut, stdErr, err := exec.Execute(ctx, createCmd)
+		if err != nil {
+			return fmt.Errorf("failed to create alert %q: stdout=%s stderr=%s: %w", ac.id, stdOut, stdErr, err)
+		}
+		if ac.selectXML != "" {
+			if err := applyAlertSelectFilter(ctx, ac.id, ac.path, ac.selectXML); err != nil {
+				return fmt.Errorf("failed to apply select filter for alert %q: %w", ac.id, err)
+			}
 		}
 	}
 
 	klog.Infof("Successfully configured pacemaker alert %q", ac.id)
+	return nil
+}
+
+// modifyAlert atomically updates an existing alert via cibadmin --modify,
+// setting path, meta timeout, and select filter in a single CIB write.
+func modifyAlert(ctx context.Context, ac alertConfig) error {
+	metaXML := fmt.Sprintf(
+		`<meta_attributes id="%s-meta_attributes">`+
+			`<nvpair id="%s-meta_attributes-timeout" name="timeout" value="30s"/>`+
+			`</meta_attributes>`,
+		ac.id, ac.id,
+	)
+	selectXML := ""
+	if ac.selectXML != "" {
+		selectXML = fmt.Sprintf("<select>%s</select>", ac.selectXML)
+	}
+	alertXML := fmt.Sprintf(`<alert id="%s" path="%s">%s%s</alert>`, ac.id, ac.path, metaXML, selectXML)
+	cmd := fmt.Sprintf("/usr/sbin/cibadmin --modify --xml-text '%s'", alertXML)
+	_, stdErr, err := exec.Execute(ctx, cmd)
+	if err != nil {
+		return fmt.Errorf("cibadmin modify for alert %q failed: %s: %w", ac.id, stdErr, err)
+	}
 	return nil
 }
 

--- a/pkg/tnf/pkg/pcs/alerts_test.go
+++ b/pkg/tnf/pkg/pcs/alerts_test.go
@@ -10,8 +10,8 @@ func TestAlertConfigs(t *testing.T) {
 	}
 
 	expectedConfigs := []alertConfig{
-		{id: "tnf-taint-alert", path: "/var/lib/pacemaker/alerts/tnf-taint-alert.sh"},
-		{id: "tnf-untaint-alert", path: "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh"},
+		{id: "tnf-taint-alert", path: "/var/lib/pacemaker/alerts/tnf-taint-alert.sh", selectXML: "<select_fencing/>"},
+		{id: "tnf-untaint-alert", path: "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh", selectXML: "<select_nodes/><select_attributes/>"},
 	}
 
 	for i, expected := range expectedConfigs {
@@ -20,6 +20,9 @@ func TestAlertConfigs(t *testing.T) {
 		}
 		if alertConfigs[i].path != expected.path {
 			t.Errorf("alertConfigs[%d].path = %q, want %q", i, alertConfigs[i].path, expected.path)
+		}
+		if alertConfigs[i].selectXML != expected.selectXML {
+			t.Errorf("alertConfigs[%d].selectXML = %q, want %q", i, alertConfigs[i].selectXML, expected.selectXML)
 		}
 	}
 }

--- a/pkg/tnf/pkg/pcs/alerts_test.go
+++ b/pkg/tnf/pkg/pcs/alerts_test.go
@@ -1,0 +1,25 @@
+package pcs
+
+import (
+	"testing"
+)
+
+func TestAlertConfigs(t *testing.T) {
+	if len(alertConfigs) != 2 {
+		t.Fatalf("expected 2 alert configs, got %d", len(alertConfigs))
+	}
+
+	expectedConfigs := []alertConfig{
+		{id: "tnf-taint-alert", path: "/var/lib/pacemaker/alerts/tnf-taint-alert.sh"},
+		{id: "tnf-untaint-alert", path: "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh"},
+	}
+
+	for i, expected := range expectedConfigs {
+		if alertConfigs[i].id != expected.id {
+			t.Errorf("alertConfigs[%d].id = %q, want %q", i, alertConfigs[i].id, expected.id)
+		}
+		if alertConfigs[i].path != expected.path {
+			t.Errorf("alertConfigs[%d].path = %q, want %q", i, alertConfigs[i].path, expected.path)
+		}
+	}
+}

--- a/pkg/tnf/pkg/pcs/alerts_test.go
+++ b/pkg/tnf/pkg/pcs/alerts_test.go
@@ -11,7 +11,7 @@ func TestAlertConfigs(t *testing.T) {
 
 	expectedConfigs := []alertConfig{
 		{id: "tnf-taint-alert", path: "/var/lib/pacemaker/alerts/tnf-taint-alert.sh", selectXML: "<select_fencing/>"},
-		{id: "tnf-untaint-alert", path: "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh", selectXML: "<select_nodes/><select_attributes/>"},
+		{id: "tnf-untaint-alert", path: "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh", selectXML: "<select_nodes/>"},
 	}
 
 	for i, expected := range expectedConfigs {

--- a/pkg/tnf/setup/runner.go
+++ b/pkg/tnf/setup/runner.go
@@ -105,6 +105,12 @@ func RunTnfSetup() error {
 		return err
 	}
 
+	// register pacemaker alert agents for fencing taint/untaint
+	err = pcs.ConfigureAlerts(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Etcd handover
 
 	// configure etcd resource - it won't start etcd before CEO managed etcd is removed per node

--- a/pkg/tnf/update-setup/runner.go
+++ b/pkg/tnf/update-setup/runner.go
@@ -132,6 +132,12 @@ func RunTnfUpdateSetup() error {
 		return err
 	}
 
+	// register pacemaker alert agents for fencing taint/untaint
+	err = pcs.ConfigureAlerts(ctx)
+	if err != nil {
+		return err
+	}
+
 	commands = []string{
 		// Force new cluster on next etcd restart on this node
 		fmt.Sprintf("crm_attribute --lifetime reboot --node %s --name \"force_new_cluster\" --update %s", currentNodeName, currentNodeName),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two pacemaker fencing alert agents are now automatically configured during cluster setup and update; setup/update will abort if alert registration fails. Existing alert definitions are validated and replaced as needed, including verification that alert scripts are present and executable and optional XML select-filters are applied.

* **Tests**
  * Added unit test coverage verifying the two expected alert configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->