### PR TITLE
OCPBUGS-77345: validate snapshot before destructive operations in cluster-restore-tnf.sh

### DIFF
--- a/bindata/etcd/cluster-restore-tnf.sh
+++ b/bindata/etcd/cluster-restore-tnf.sh
@@ -204,6 +204,8 @@ echo "starting snapshot restore through etcdctl..."
 # We are never going to rev-bump here to ensure we don't cause a revision split between the
 # remainder of the running cluster and this restore member. Imagine your non-restore quorum members run at rev 100,
 # we would attempt to rev bump this with snapshot at rev 120, now this member is 20 revisions ahead and RAFT is confused.
+# --skip-hash-check: learner snapshots from podman-etcd lack the trailing
+# integrity hash that etcdctl snapshot save appends (OCPBUGS-79662).
 if ! ${ETCD_CLIENT} snapshot restore "${SNAPSHOT_FILE}" --skip-hash-check "${ETCDCTL_RESTORE_FLAGS[@]}"; then
     echo "Snapshot restore failed. Aborting!"
     exit 1

--- a/bindata/etcd/cluster-restore-tnf.sh
+++ b/bindata/etcd/cluster-restore-tnf.sh
@@ -163,6 +163,22 @@ if [ -n "${ETCD_ETCDUTL_BIN}" ]; then
   ETCD_CLIENT="${ETCD_ETCDUTL_BIN}"
 fi
 
+# Validate that the snapshot can be restored before performing any destructive
+# operations. A failed dry-run here is safe — etcd is still running, no state
+# has been modified.
+RESTORE_DRYRUN_DIR=$(mktemp -d)
+trap "rm -rf ${RESTORE_DRYRUN_DIR}" EXIT
+echo "validating snapshot restorability..."
+if ! ${ETCD_CLIENT} snapshot restore "${SNAPSHOT_FILE}" \
+    --data-dir="${RESTORE_DRYRUN_DIR}/data" \
+    --skip-hash-check 2>&1; then
+  rm -rf "${RESTORE_DRYRUN_DIR}"
+  echo "Snapshot validation failed: the snapshot cannot be restored."
+  echo "Aborting before any cluster modifications."
+  exit 1
+fi
+rm -rf "${RESTORE_DRYRUN_DIR}"
+
 if [ ! -d "${ETCD_DATA_DIR_BACKUP}" ]; then
   mkdir -p "${ETCD_DATA_DIR_BACKUP}"
 fi
@@ -188,7 +204,7 @@ echo "starting snapshot restore through etcdctl..."
 # We are never going to rev-bump here to ensure we don't cause a revision split between the
 # remainder of the running cluster and this restore member. Imagine your non-restore quorum members run at rev 100,
 # we would attempt to rev bump this with snapshot at rev 120, now this member is 20 revisions ahead and RAFT is confused.
-if ! ${ETCD_CLIENT} snapshot restore "${SNAPSHOT_FILE}" "${ETCDCTL_RESTORE_FLAGS[@]}"; then
+if ! ${ETCD_CLIENT} snapshot restore "${SNAPSHOT_FILE}" --skip-hash-check "${ETCDCTL_RESTORE_FLAGS[@]}"; then
     echo "Snapshot restore failed. Aborting!"
     exit 1
 fi


### PR DESCRIPTION
## Summary

`cluster-restore-tnf.sh` performs destructive operations (disable etcd, clear CRM attributes, delete `/var/lib/etcd`) before attempting `etcdutl snapshot restore`. If the restore fails, the cluster is left in an unrecoverable state with no rollback.

This adds a dry-run restore to a temporary directory before any destructive operations, and passes `--skip-hash-check` on both the dry-run and the real restore so learner snapshots (hash-less raw BoltDB copies from `podman-etcd`) are accepted alongside standard `etcdctl snapshot save` snapshots.

## Bugs

- [OCPBUGS-77345](https://issues.redhat.com/browse/OCPBUGS-77345) — Pre-validate snapshot integrity before destructive operations to prevent unrecoverable cluster state.
- [OCPBUGS-79664](https://issues.redhat.com/browse/OCPBUGS-79664) — No rollback on restore failure leaves TNF cluster broken (duplicate of 77345).
- [OCPBUGS-79662](https://issues.redhat.com/browse/OCPBUGS-79662) — Missing `--skip-hash-check` causes restore to reject valid learner snapshots on etcd v3.6.

## Related

- [OCPEDGE-2299](https://issues.redhat.com/browse/OCPEDGE-2299) — Parent story: Backup and Restore testing (where all three bugs were discovered).
- RHEL-145622, RHEL-145626, RHEL-145627, [RHEL-145628](https://redhat.atlassian.net/browse/RHEL-145628) — Upstream resource-agents fixes to produce hash-compatible learner snapshots.

## Testing

Verified on OCP 4.22.0-0.nightly-2026-05-28-111510, TNF topology (2 masters, dev-scripts IPI):

| Test | Snapshot Type | Expected | Result |
|------|--------------|----------|--------|
| Corrupt snapshot | `dd if=/dev/urandom` | Abort before destructive ops | PASS — caught at `check_snapshot_status`, etcd stayed running |
| Learner snapshot (hash-less) | `podman-etcd` raw copy from rejoin | Dry-run passes, restore succeeds | PASS — both dry-run and real restore succeeded |
| Primary snapshot (hash-bearing) | `etcdctl snapshot save` | Dry-run passes, restore succeeds | PASS — `--skip-hash-check` is a no-op when hash is present |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added pre-restore snapshot validation: snapshots are first restored in a temporary environment to verify integrity before any destructive cluster actions. Validation failures abort immediately with clear error messaging to prevent data loss.
  * Actual restore still fails fast on restore errors to preserve cluster safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->