### PR TITLE
ETCD-704: cluster-restore.sh: move extra /var/lib/etcd files to backup

### DIFF
--- a/bindata/etcd/cluster-restore-tnf.sh
+++ b/bindata/etcd/cluster-restore-tnf.sh
@@ -196,6 +196,9 @@ if [ -d "${ETCD_DATA_DIR}/member" ]; then
   mv "${ETCD_DATA_DIR}"/member "${ETCD_DATA_DIR_BACKUP}"/
 fi
 
+# Move any remaining files out of the data dir before wiping it.
+backup_remaining_etcd_data_dir_contents
+
 echo "removing etcd data dir..."
 rm -rf "${ETCD_DATA_DIR}"
 mkdir -p "${ETCD_DATA_DIR}"

--- a/bindata/etcd/cluster-restore.sh
+++ b/bindata/etcd/cluster-restore.sh
@@ -61,24 +61,6 @@ function restore_static_pods() {
   done
 }
 
-function backup_remaining_etcd_data_dir_contents() {
-  local entry base extras_dir="${ETCD_DATA_DIR_BACKUP}/extra-data-dir-contents"
-
-  mkdir -p "${extras_dir}"
-
-  shopt -s nullglob dotglob
-  for entry in "${ETCD_DATA_DIR}"/*; do
-    base=$(basename "${entry}")
-    if [ -e "${extras_dir}/${base}" ]; then
-      echo "removing previous backup ${extras_dir}/${base}"
-      rm -rf "${extras_dir:?}/${base}"
-    fi
-    echo "Moving ${entry} to ${extras_dir}/"
-    mv "${entry}" "${extras_dir}/"
-  done
-  shopt -u nullglob dotglob
-}
-
 BACKUP_DIR="$1"
 # shellcheck disable=SC2012
 BACKUP_FILE=$(ls -vd "${BACKUP_DIR}"/static_kuberesources*.tar.gz | tail -1) || true

--- a/bindata/etcd/cluster-restore.sh
+++ b/bindata/etcd/cluster-restore.sh
@@ -61,6 +61,22 @@ function restore_static_pods() {
   done
 }
 
+function backup_remaining_etcd_data_dir_contents() {
+  local entry base
+
+  shopt -s nullglob dotglob
+  for entry in "${ETCD_DATA_DIR}"/*; do
+    base=$(basename "${entry}")
+    if [ -e "${ETCD_DATA_DIR_BACKUP}/${base}" ]; then
+      echo "removing previous backup ${ETCD_DATA_DIR_BACKUP}/${base}"
+      rm -rf "${ETCD_DATA_DIR_BACKUP:?}/${base}"
+    fi
+    echo "Moving ${entry} to ${ETCD_DATA_DIR_BACKUP}/"
+    mv "${entry}" "${ETCD_DATA_DIR_BACKUP}/"
+  done
+  shopt -u nullglob dotglob
+}
+
 BACKUP_DIR="$1"
 # shellcheck disable=SC2012
 BACKUP_FILE=$(ls -vd "${BACKUP_DIR}"/static_kuberesources*.tar.gz | tail -1) || true
@@ -110,14 +126,9 @@ if [ -z "${ETCD_ETCDCTL_RESTORE}" ]; then
   cp -p "${SNAPSHOT_FILE}" "${ETCD_DATA_DIR_BACKUP}"/snapshot.db
   # Move the revision.json when it exists
   [ ! -f "${ETCD_REV_JSON}" ] ||  mv -f "${ETCD_REV_JSON}" "${ETCD_DATA_DIR_BACKUP}"/revision.json
-  # removing any fio perf files left behind that could be deleted without problems
-  rm -f "${ETCD_DATA_DIR}"/etcd_perf*
-
-  # ensure the folder is really empty, otherwise the restore pod will crash loop
-  if [ -n "$(ls -A "${ETCD_DATA_DIR}")" ]; then
-      echo "folder ${ETCD_DATA_DIR} is not empty, please review and remove all files in it"
-      exit 1
-  fi
+  # Move any remaining files (fio perf artifacts, stray snapshots, etc.) out of the data dir.
+  # The restore pod requires /var/lib/etcd to be empty before it runs.
+  backup_remaining_etcd_data_dir_contents
 
   echo "starting restore-etcd static pod"
   cp -p "${RESTORE_ETCD_POD_YAML}" "${MANIFEST_DIR}/etcd-pod.yaml"

--- a/bindata/etcd/cluster-restore.sh
+++ b/bindata/etcd/cluster-restore.sh
@@ -62,17 +62,19 @@ function restore_static_pods() {
 }
 
 function backup_remaining_etcd_data_dir_contents() {
-  local entry base
+  local entry base extras_dir="${ETCD_DATA_DIR_BACKUP}/extra-data-dir-contents"
+
+  mkdir -p "${extras_dir}"
 
   shopt -s nullglob dotglob
   for entry in "${ETCD_DATA_DIR}"/*; do
     base=$(basename "${entry}")
-    if [ -e "${ETCD_DATA_DIR_BACKUP}/${base}" ]; then
-      echo "removing previous backup ${ETCD_DATA_DIR_BACKUP}/${base}"
-      rm -rf "${ETCD_DATA_DIR_BACKUP:?}/${base}"
+    if [ -e "${extras_dir}/${base}" ]; then
+      echo "removing previous backup ${extras_dir}/${base}"
+      rm -rf "${extras_dir:?}/${base}"
     fi
-    echo "Moving ${entry} to ${ETCD_DATA_DIR_BACKUP}/"
-    mv "${entry}" "${ETCD_DATA_DIR_BACKUP}/"
+    echo "Moving ${entry} to ${extras_dir}/"
+    mv "${entry}" "${extras_dir}/"
   done
   shopt -u nullglob dotglob
 }

--- a/bindata/etcd/etcd-common-tools
+++ b/bindata/etcd/etcd-common-tools
@@ -78,6 +78,24 @@ function wait_for_containers_to_stop() {
   done
 }
 
+function backup_remaining_etcd_data_dir_contents() {
+  local entry base extras_dir="${ETCD_DATA_DIR_BACKUP}/extra-data-dir-contents"
+
+  mkdir -p "${extras_dir}"
+
+  shopt -s nullglob dotglob
+  for entry in "${ETCD_DATA_DIR}"/*; do
+    base=$(basename "${entry}")
+    if [ -e "${extras_dir}/${base}" ]; then
+      echo "removing previous backup ${extras_dir}/${base}"
+      rm -rf "${extras_dir:?}/${base}"
+    fi
+    echo "Moving ${entry} to ${extras_dir}/"
+    mv "${entry}" "${extras_dir}/"
+  done
+  shopt -u nullglob dotglob
+}
+
 function mv_static_pods() {
   local containers=("$@")
 


### PR DESCRIPTION
## Summary
- Legacy `cluster-restore.sh` fails with `folder /var/lib/etcd is not empty` when extra files exist under `/var/lib/etcd` after `member/` is moved.
- Add `backup_remaining_etcd_data_dir_contents()` to move remaining top-level files to `/var/lib/etcd-backup` instead of exiting.
## Jira
Fixes: [ETCD-704](https://redhat.atlassian.net/browse/ETCD-704)
## Verification
OCP 4.22.0-rc.4, AWS IPI 3-node HA:
- Legacy script fails when seed files present in `/var/lib/etcd`
- Patched script moves demo files to `/var/lib/etcd-backup` and completes `SNAPSHOT RESTORE COMPLETED`
- Full HA restore; cluster healthy; `testing-seed-project` restored from backup
## Test plan
- [x] Reproduce legacy failure with extra files in `/var/lib/etcd`
- [x] Patched restore moves extras to `/var/lib/etcd-backup`
- [x] Full 3-node HA restore succeeds
- [x] etcd data restored from snapshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restore process now preserves and moves leftover etcd data into a backup location before clearing the data directory, preventing hard failures when the data directory is not empty and improving recoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->