### PR TITLE
OCPBUGS-88490: fix etcd operator deadlock when etcd-endpoints configmap is stale

### DIFF
--- a/pkg/etcdcli/helpers.go
+++ b/pkg/etcdcli/helpers.go
@@ -74,6 +74,9 @@ func (f *fakeEtcdClient) MemberPromote(ctx context.Context, member *etcdserverpb
 }
 
 func (f *fakeEtcdClient) MemberList(ctx context.Context) ([]*etcdserverpb.Member, error) {
+	if f.opts.memberListError != nil {
+		return nil, f.opts.memberListError
+	}
 	return f.members, nil
 }
 
@@ -210,6 +213,7 @@ type FakeClientOptions struct {
 	dbSize          int64
 	dbSizeInUse     int64
 	defragErrors    []error
+	memberListError error
 }
 
 func newFakeClientOpts(opts ...FakeClientOption) *FakeClientOptions {
@@ -255,5 +259,12 @@ func WithFakeStatus(status []*clientv3.StatusResponse) FakeClientOption {
 func WithFakeDefragErrors(errors []error) FakeClientOption {
 	return func(fo *FakeClientOptions) {
 		fo.defragErrors = errors
+	}
+}
+
+// WithMemberListError configures MemberList to return the given error.
+func WithMemberListError(err error) FakeClientOption {
+	return func(fo *FakeClientOptions) {
+		fo.memberListError = err
 	}
 }

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/health"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -15,9 +17,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/dnshelpers"
@@ -33,6 +37,8 @@ type EtcdEndpointsController struct {
 	etcdClient      etcdcli.EtcdClient
 	configmapLister corev1listers.ConfigMapLister
 	configmapClient corev1client.ConfigMapsGetter
+	nodeLister      corev1listers.NodeLister
+	networkLister   configv1listers.NetworkLister
 }
 
 func NewEtcdEndpointsController(
@@ -41,13 +47,19 @@ func NewEtcdEndpointsController(
 	etcdClient etcdcli.EtcdClient,
 	eventRecorder events.Recorder,
 	kubeClient kubernetes.Interface,
-	kubeInformers operatorv1helpers.KubeInformersForNamespaces) factory.Controller {
+	kubeInformers operatorv1helpers.KubeInformersForNamespaces,
+	controlPlaneNodeInformer cache.SharedIndexInformer,
+	nodeLister corev1listers.NodeLister,
+	networkInformer configv1informers.NetworkInformer,
+) factory.Controller {
 
 	c := &EtcdEndpointsController{
 		operatorClient:  operatorClient,
 		etcdClient:      etcdClient,
 		configmapLister: kubeInformers.ConfigMapLister(),
 		configmapClient: kubeClient.CoreV1(),
+		nodeLister:      nodeLister,
+		networkLister:   networkInformer.Lister(),
 	}
 
 	syncer := health.NewDefaultCheckingSyncWrapper(c.sync)
@@ -57,6 +69,8 @@ func NewEtcdEndpointsController(
 		operatorClient.Informer(),
 		kubeInformers.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer(),
 		kubeInformers.InformersFor("kube-system").Core().V1().ConfigMaps().Informer(),
+		controlPlaneNodeInformer,
+		networkInformer.Informer(),
 	).WithSync(syncer.Sync).ToController("EtcdEndpointsController", eventRecorder.WithComponentSuffix("etcd-endpoints-controller"))
 }
 
@@ -116,7 +130,17 @@ func (c *EtcdEndpointsController) syncConfigMap(ctx context.Context, recorder ev
 
 	members, err := c.etcdClient.MemberList(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get member list: %w", err)
+		klog.Warningf("EtcdEndpointsController: MemberList failed (%v), falling back to control-plane node IPs", err)
+		fallbackAddresses, fbErr := c.endpointsFromNodeLister()
+		if fbErr != nil {
+			return fmt.Errorf("failed to get member list: %v; node fallback also failed: %w", err, fbErr)
+		}
+		required.Data = fallbackAddresses
+		if _, _, applyErr := resourceapply.ApplyConfigMap(ctx, c.configmapClient, recorder, required); applyErr != nil {
+			return fmt.Errorf("applying fallback configmap update failed: %w", applyErr)
+		}
+		klog.Infof("EtcdEndpointsController: populated etcd-endpoints configmap from node IPs (%d endpoints)", len(fallbackAddresses))
+		return nil
 	}
 
 	endpointAddresses := make(map[string]string, len(members))
@@ -152,6 +176,44 @@ func (c *EtcdEndpointsController) syncConfigMap(ctx context.Context, recorder ev
 	}
 
 	return nil
+}
+
+// endpointsFromNodeLister populates endpoint addresses from control-plane node internal IPs.
+// Used as a fallback when MemberList is unreachable due to stale configmap endpoints.
+// Keys are derived from node names since member IDs are unavailable without etcd.
+// On the next successful sync, MemberList will overwrite with authoritative member data.
+func (c *EtcdEndpointsController) endpointsFromNodeLister() (map[string]string, error) {
+	network, err := c.networkLister.Get("cluster")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster network: %w", err)
+	}
+
+	// The nodeLister is already scoped to control-plane nodes (master + arbiter in arbiter topology)
+	// via the controlPlaneNodeLister constructed in starter.go, so List(Everything) is correct here.
+	nodes, err := c.nodeLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list control-plane nodes: %w", err)
+	}
+
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no control-plane nodes found")
+	}
+
+	endpointAddresses := make(map[string]string, len(nodes))
+	for _, node := range nodes {
+		internalIP, _, err := dnshelpers.GetPreferredInternalIPAddressForNodeName(network, node)
+		if err != nil {
+			klog.Warningf("EtcdEndpointsController: could not get internal IP for node %s: %v", node.Name, err)
+			continue
+		}
+		endpointAddresses[node.Name] = internalIP
+	}
+
+	if len(endpointAddresses) == 0 {
+		return nil, fmt.Errorf("no control-plane node IPs found")
+	}
+
+	return endpointAddresses, nil
 }
 
 func configMapAsset() *corev1.ConfigMap {

--- a/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
+++ b/pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go
@@ -2,10 +2,12 @@ package etcdendpointscontroller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -354,6 +356,160 @@ func TestBootstrapAnnotationRemoval(t *testing.T) {
 			}
 			if scenario.validateFunc != nil {
 				scenario.validateFunc(t, endpoints, fakeKubeClient.Actions())
+			}
+		})
+	}
+}
+
+func TestMemberListFallbackToNodeIPs(t *testing.T) {
+	network := &configv1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status: configv1.NetworkStatus{
+			ServiceNetwork: []string{"10.0.0.0/16"},
+		},
+	}
+
+	masterNodes := []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "master-0",
+				Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "master-1",
+				Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "master-2",
+				Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.3"},
+				},
+			},
+		},
+	}
+
+	scenarios := []struct {
+		name           string
+		memberListErr  error
+		nodes          []*corev1.Node
+		expectErr      bool
+		expectedData   map[string]string
+		expectFallback bool
+	}{
+		{
+			name:          "MemberListFails_FallbackToNodeIPs",
+			memberListErr: fmt.Errorf("context deadline exceeded"),
+			nodes:         masterNodes,
+			expectedData: map[string]string{
+				"master-0": "10.0.0.1",
+				"master-1": "10.0.0.2",
+				"master-2": "10.0.0.3",
+			},
+			expectFallback: true,
+		},
+		{
+			name:          "MemberListFails_NoNodes_BothFail",
+			memberListErr: fmt.Errorf("connection refused"),
+			nodes:         []*corev1.Node{},
+			expectErr:     true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				&operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+				},
+				u.StaticPodOperatorStatus(
+					u.WithLatestRevision(3),
+					u.WithNodeStatusAtCurrentRevision(3),
+					u.WithNodeStatusAtCurrentRevision(3),
+					u.WithNodeStatusAtCurrentRevision(3),
+				),
+				nil,
+				nil,
+			)
+
+			objects := []runtime.Object{
+				u.BootstrapConfigMap(u.WithBootstrapStatus("complete")),
+			}
+			fakeKubeClient := fake.NewSimpleClientset(objects...)
+
+			var opts []etcdcli.FakeClientOption
+			if scenario.memberListErr != nil {
+				opts = append(opts, etcdcli.WithMemberListError(scenario.memberListErr))
+			}
+			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(nil, opts...)
+			require.NoError(t, err)
+
+			coreIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			require.NoError(t, coreIndexer.Add(&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: operatorclient.TargetNamespace},
+			}))
+			for _, obj := range objects {
+				require.NoError(t, coreIndexer.Add(obj))
+			}
+
+			nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, node := range scenario.nodes {
+				require.NoError(t, nodeIndexer.Add(node))
+			}
+
+			networkIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			require.NoError(t, networkIndexer.Add(network))
+
+			eventRecorder := events.NewRecorder(
+				fakeKubeClient.CoreV1().Events(operatorclient.TargetNamespace),
+				"test-etcdendpointscontroller", &corev1.ObjectReference{}, clock.RealClock{},
+			)
+
+			controller := &EtcdEndpointsController{
+				operatorClient:  fakeOperatorClient,
+				etcdClient:      fakeEtcdClient,
+				configmapLister: corev1listers.NewConfigMapLister(coreIndexer),
+				configmapClient: fakeKubeClient.CoreV1(),
+				nodeLister:      corev1listers.NewNodeLister(nodeIndexer),
+				networkLister:   configv1listers.NewNetworkLister(networkIndexer),
+			}
+
+			syncErr := controller.sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
+			if scenario.expectErr {
+				require.Error(t, syncErr)
+				return
+			}
+			require.NoError(t, syncErr)
+
+			if scenario.expectFallback {
+				for _, action := range fakeKubeClient.Actions() {
+					if action.Matches("create", "configmaps") {
+						createAction := action.(clientgotesting.CreateAction)
+						actual := createAction.GetObject().(*corev1.ConfigMap)
+						assert.Equal(t, scenario.expectedData, actual.Data,
+							"configmap data should contain node IPs as fallback")
+						return
+					}
+				}
+				t.Error("expected configmap create action not found")
 			}
 		})
 	}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -447,6 +447,9 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 		coreClient,
 		kubeInformersForNamespaces,
+		controlPlaneNodeInformer,
+		controlPlaneNodeLister,
+		networkInformer,
 	)
 
 	etcdMembersController := etcdmemberscontroller.NewEtcdMembersController(


### PR DESCRIPTION
## Summary

Fixes [OCPBUGS-88490](https://redhat.atlassian.net/browse/OCPBUGS-88490)

When the etcd-endpoints configmap contains stale IPs (e.g. after VM migration by vSphere DRS), the etcd client pool cannot reach any member, causing MemberList() to fail with context deadline exceeded. This creates a circular dependency: the operator cannot update the configmap without MemberList, but MemberList fails because the configmap has stale addresses.

### Root Cause

After VMs migrate to new ESXi hosts, node IPs may change, but the etcd-endpoints configmap retains the old IPs. EtcdEndpointsController.syncConfigMap() calls MemberList() to discover current members, but the etcd client is initialized from the stale configmap and cannot connect. The controller returns an error and retries indefinitely with the same stale endpoints.

### Fix

In EtcdEndpointsController.syncConfigMap(), when MemberList() fails, fall back to discovering control-plane node internal IPs via the node lister and network config (already available in the operator). This populates the configmap with reachable node IPs, allowing the etcd client to reconnect on the next cycle. Once connectivity is restored, MemberList() succeeds and overwrites the configmap with authoritative member data (member ID keys instead of node name keys).

### Changes

- **pkg/operator/etcdendpointscontroller/etcdendpointscontroller.go**: Added nodeLister and networkLister fields; added endpointsFromNodeLister() method; modified syncConfigMap() to fall back to node IPs when MemberList fails.
- **pkg/operator/starter.go**: Passed controlPlaneNodeLister and networkInformer.Lister() to NewEtcdEndpointsController.
- **pkg/etcdcli/helpers.go**: Added WithMemberListError option to FakeEtcdClient for testing.
- **pkg/operator/etcdendpointscontroller/etcdendpointscontroller_test.go**: Added TestMemberListFallbackToNodeIPs with cases for successful fallback and dual failure.

## Test Plan

- [x] go build ./... compiles cleanly
- [x] go vet ./... passes
- [x] All existing TestBootstrapAnnotationRemoval tests pass
- [x] New TestMemberListFallbackToNodeIPs tests pass
- [x] Reproduced on real OCP cluster: stale configmap leads to operator deadlock (before), self-healing via node IP fallback (after)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Etcd endpoint configuration now includes a fallback mechanism: when member discovery fails, the system uses control-plane node IP addresses to populate the endpoint configuration instead of failing completely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->