### PR TITLE
OCPBUGS-88318: fix cluster-restore-tnf.sh IP auto-detection when hostname diverges from node name

### DIFF
--- a/bindata/etcd/cluster-restore-tnf.sh
+++ b/bindata/etcd/cluster-restore-tnf.sh
@@ -44,7 +44,7 @@ function resolve_k8s_node_name() {
   while IFS='=' read -r var_name var_value; do
     if [[ "$var_name" =~ ^NODE_(.+)_IP$ ]]; then
       node_prefix="${BASH_REMATCH[1]}"
-      if echo "$local_ips" | grep -qxF "$var_value"; then
+      if echo "$local_ips" | grep -qxF "${var_value//[\[\]]/}"; then
         local name_var="NODE_${node_prefix}_ETCD_NAME"
         if [ -n "${!name_var}" ]; then
           echo "${!name_var}"

--- a/bindata/etcd/cluster-restore-tnf.sh
+++ b/bindata/etcd/cluster-restore-tnf.sh
@@ -29,6 +29,32 @@ function source_required_dependency {
 source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
 source_required_dependency /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
 
+function resolve_k8s_node_name() {
+  # Resolve the Kubernetes node name by matching local IPs against NODE_*_IP
+  # entries sourced from etcd.env. This avoids relying on hostname which may
+  # diverge from the Kubernetes node name (e.g. when hostname is set to FQDN).
+  local local_ips
+  local_ips=$(ip -o addr show scope global | awk '{print $4}' | cut -d/ -f1)
+
+  if [ -z "$local_ips" ]; then
+    return
+  fi
+
+  local var_name var_value node_prefix
+  while IFS='=' read -r var_name var_value; do
+    if [[ "$var_name" =~ ^NODE_(.+)_IP$ ]]; then
+      node_prefix="${BASH_REMATCH[1]}"
+      if echo "$local_ips" | grep -qxF "$var_value"; then
+        local name_var="NODE_${node_prefix}_ETCD_NAME"
+        if [ -n "${!name_var}" ]; then
+          echo "${!name_var}"
+          return
+        fi
+      fi
+    fi
+  done < <(env | grep -E '^NODE_.*_IP=')
+}
+
 function usage() {
   echo 'Path to the directory containing backup files is required: ./cluster-restore.sh <path-to-backup>'
   echo 'The backup directory is expected to contain the etcd snapshot'
@@ -49,10 +75,11 @@ function get_etcd_advertise_ip() {
 }
 
 function get_peer_node_name() {
-  NODENAME_UNDERSCORE=$(echo "${NODENAME}" | tr '.-' '_')
+  local safe_name
+  safe_name=$(echo "${NODENAME}" | tr '.-' '_')
 
   # Find all NODE_*_ETCD_NAME environment variables, exclude current node, get the value
-  env | grep -E '^NODE_.*_ETCD_NAME' | grep -v "${NODENAME_UNDERSCORE}" | cut -d= -f2
+  env | grep -E '^NODE_.*_ETCD_NAME=' | grep -v "NODE_${safe_name}_ETCD_NAME=" | cut -d= -f2
 }
 
 function wait_for_podman_etcd_start() {
@@ -94,9 +121,15 @@ function cleanup_podman_etcd_attributes() {
 function setup_pacemaker_restore() {
   PODMAN_ETCD_CONFIGURATION_FILES=(certs.hash config-previous.tar.gz config.yaml pod.yaml)
 
-  NODENAME=${NODENAME:-$(hostname)}
-  if [ -z "${NODENAME}" ] ; then
-    echo "could not determine the node hostname. Please set NODENAME env variable and try again"
+  if [ -z "${NODENAME}" ]; then
+    NODENAME=$(resolve_k8s_node_name)
+    if [ -z "${NODENAME}" ]; then
+      echo "Warning: could not auto-detect Kubernetes node name from etcd.env IPs. Falling back to hostname." >&2
+      NODENAME=$(hostname)
+    fi
+  fi
+  if [ -z "${NODENAME}" ]; then
+    echo "could not determine the node name. Please set NODENAME env variable and try again"
     exit 1
   fi
 


### PR DESCRIPTION
## Summary

`cluster-restore-tnf.sh` fails to auto-detect the etcd advertise IP when the system `hostname` does not match the Kubernetes node name used to generate `etcd.env`. This commonly occurs on bare metal clusters where the hostname is set to an FQDN after deployment.

**Root cause:** `get_etcd_advertise_ip()` constructs an env var name from `hostname` output (e.g. `NODE_master_0_test_example_com_IP`), but `etcd.env` contains entries keyed by the Kubernetes node name (e.g. `NODE_master_0_IP`). When these diverge, the indirect variable expansion returns empty and the restore aborts.

The same mismatch also causes:
- `get_peer_node_name()` to return both nodes instead of just the peer
- `crm_attribute --node` calls to target the wrong Pacemaker identity

**Fix:** Add `resolve_k8s_node_name()` which matches local IPs (from `ip addr`) against `NODE_*_IP` entries sourced from `etcd.env`, then reads the k8s node name from the corresponding `NODE_*_ETCD_NAME` variable. This makes node identity resolution robust regardless of hostname configuration, with a hostname fallback for backward compatibility.

Also improve `get_peer_node_name()` exclusion to match the full variable name pattern (`NODE_<safe>_ETCD_NAME=`) rather than a raw substring, preventing false matches when one node name is a prefix of another.

## Test plan

Tested on a live TNF cluster (OCP 4.22, two masters) without redeploying:

- [x] `resolve_k8s_node_name()` returns correct k8s node name (`master-0`, `master-1`) on both nodes
- [x] With simulated FQDN hostname divergence (`master-0.test.example.com`):
  - Old code: IP lookup returns empty (would abort)
  - New code: correctly resolves to `master-0` via IP matching
- [x] `get_peer_node_name()` correctly excludes only the current node (old code returned both nodes with diverged hostname)
- [x] Pacemaker node names confirmed matching k8s node names via `crm_node -l`
- [x] shellcheck clean (only pre-existing SC2064 warning on unrelated line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic node name detection during cluster restoration by matching local network IPs to configured node IP/name entries.

* **Improvements**
  * Improved peer node selection by using a clearer, safer exclusion approach based on the resolved node name.
  * Refined `NODENAME` handling to auto-resolve only when unset, warn and fall back to `hostname` if detection fails, and error if still empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->