### PR TITLE
OCPEDGE-2705: Add TNF Pacemaker metrics controller

### DIFF
--- a/pkg/tnf/internal/testutil/fakeinformer.go
+++ b/pkg/tnf/internal/testutil/fakeinformer.go
@@ -1,0 +1,55 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	pacmkrv1 "github.com/openshift/api/etcd/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func CreateFakeInformer(obj *pacmkrv1.PacemakerCluster) cache.SharedIndexInformer {
+	store := cache.NewStore(func(obj any) (string, error) {
+		if pc, ok := obj.(*pacmkrv1.PacemakerCluster); ok {
+			return pc.Name, nil
+		}
+		return "", fmt.Errorf("object is not a PacemakerCluster")
+	})
+	if obj != nil {
+		_ = store.Add(obj)
+	}
+	return &fakeInformer{store: store}
+}
+
+type fakeInformer struct {
+	store cache.Store
+}
+
+func (f *fakeInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+func (f *fakeInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+func (f *fakeInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+func (f *fakeInformer) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
+	return nil
+}
+func (f *fakeInformer) GetStore() cache.Store           { return f.store }
+func (f *fakeInformer) GetController() cache.Controller { return nil }
+func (f *fakeInformer) Run(stopCh <-chan struct{})      {}
+func (f *fakeInformer) RunWithContext(ctx context.Context) {
+}
+func (f *fakeInformer) HasSynced() bool                                            { return true }
+func (f *fakeInformer) LastSyncResourceVersion() string                            { return "" }
+func (f *fakeInformer) SetWatchErrorHandler(handler cache.WatchErrorHandler) error { return nil }
+func (f *fakeInformer) SetWatchErrorHandlerWithContext(handler cache.WatchErrorHandlerWithContext) error {
+	return nil
+}
+func (f *fakeInformer) SetTransform(handler cache.TransformFunc) error { return nil }
+func (f *fakeInformer) IsStopped() bool                                { return false }
+func (f *fakeInformer) AddIndexers(indexers cache.Indexers) error      { return nil }
+func (f *fakeInformer) GetIndexer() cache.Indexer                      { return nil }

--- a/pkg/tnf/operator/starter.go
+++ b/pkg/tnf/operator/starter.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/cluster-etcd-operator/bindata"
@@ -32,6 +34,7 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/externaletcdsupportcontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/jobs"
+	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/metriccontroller"
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/pacemaker"
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/tools"
 )
@@ -313,6 +316,16 @@ func runPacemakerControllers(ctx context.Context, controllerContext *controllerc
 		// Start the healthcheck controller
 		klog.Infof("starting Pacemaker healthcheck controller")
 		go healthCheckController.Run(ctx, 1)
+
+		// Create and start the metrics controller, sharing the same informer
+		klog.Infof("creating Pacemaker metrics controller")
+		metricsController := metriccontroller.NewPacemakerMetricsController(
+			pacemakerInformer,
+			controllerContext.EventRecorder,
+			legacyregistry.DefaultGatherer.(metrics.KubeRegistry),
+		)
+		klog.Infof("starting Pacemaker metrics controller")
+		go metricsController.Run(ctx, 1)
 
 		// Start the status collector CronJob
 		klog.Infof("starting Pacemaker status collector CronJob")

--- a/pkg/tnf/pkg/metriccontroller/controller.go
+++ b/pkg/tnf/pkg/metriccontroller/controller.go
@@ -1,0 +1,121 @@
+package metriccontroller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/component-base/metrics"
+	"k8s.io/klog/v2"
+
+	pacmkrv1 "github.com/openshift/api/etcd/v1"
+	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/pacemaker"
+)
+
+const resyncInterval = 30 * time.Second
+
+type pacemakerMetricsController struct {
+	pacemakerInformer cache.SharedIndexInformer
+}
+
+func NewPacemakerMetricsController(
+	pacemakerInformer cache.SharedIndexInformer,
+	recorder events.Recorder,
+	metricsRegistry metrics.KubeRegistry,
+) factory.Controller {
+	c := &pacemakerMetricsController{
+		pacemakerInformer: pacemakerInformer,
+	}
+
+	for _, g := range clusterGauges {
+		metricsRegistry.MustRegister(g)
+	}
+	for _, gv := range nodeGaugeVecs {
+		metricsRegistry.MustRegister(gv)
+	}
+	for _, gv := range resourceGaugeVecs {
+		metricsRegistry.MustRegister(gv)
+	}
+
+	return factory.New().
+		ResyncEvery(resyncInterval).
+		WithSync(c.sync).
+		WithInformers(pacemakerInformer).
+		ToController("PacemakerMetricsController", recorder)
+}
+
+func (c *pacemakerMetricsController) sync(ctx context.Context, _ factory.SyncContext) error {
+	klog.V(4).Infof("syncing Pacemaker metrics")
+
+	item, exists, err := c.pacemakerInformer.GetStore().GetByKey(pacemaker.PacemakerClusterResourceName)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		klog.V(4).Infof("PacemakerCluster CR not found, resetting metrics")
+		resetAllMetrics()
+		return nil
+	}
+
+	cr, ok := item.(*pacmkrv1.PacemakerCluster)
+	if !ok {
+		return fmt.Errorf("unexpected object type in informer store: %T", item)
+	}
+
+	for _, gv := range nodeGaugeVecs {
+		gv.Reset()
+	}
+	for _, gv := range resourceGaugeVecs {
+		gv.Reset()
+	}
+
+	for _, m := range clusterConditionMetrics {
+		cond := pacemaker.FindCondition(cr.Status.Conditions, m.conditionType)
+		m.gauge.Set(conditionToFloat64(cond))
+	}
+
+	if cr.Status.Nodes == nil {
+		klog.V(4).Infof("synced Pacemaker metrics: 0 nodes")
+		return nil
+	}
+
+	nodes := *cr.Status.Nodes
+	for i := range nodes {
+		node := &nodes[i]
+		nodeName := node.NodeName
+
+		for _, m := range nodeConditionMetrics {
+			cond := pacemaker.FindCondition(node.Conditions, m.conditionType)
+			m.gaugeVec.WithLabelValues(nodeName).Set(conditionToFloat64(cond))
+		}
+
+		for j := range node.Resources {
+			resource := &node.Resources[j]
+			resourceName := string(resource.Name)
+
+			for _, m := range resourceConditionMetrics {
+				cond := pacemaker.FindCondition(resource.Conditions, m.conditionType)
+				m.gaugeVec.WithLabelValues(nodeName, resourceName).Set(conditionToFloat64(cond))
+			}
+		}
+	}
+
+	klog.V(4).Infof("synced Pacemaker metrics: %d nodes", len(nodes))
+	return nil
+}
+
+func resetAllMetrics() {
+	for _, g := range clusterGauges {
+		g.Set(0)
+	}
+	for _, gv := range nodeGaugeVecs {
+		gv.Reset()
+	}
+	for _, gv := range resourceGaugeVecs {
+		gv.Reset()
+	}
+}

--- a/pkg/tnf/pkg/metriccontroller/controller_test.go
+++ b/pkg/tnf/pkg/metriccontroller/controller_test.go
@@ -2,70 +2,20 @@ package metriccontroller
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	pacmkrv1 "github.com/openshift/api/etcd/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/utils/clock"
+
+	tnftestutil "github.com/openshift/cluster-etcd-operator/pkg/tnf/internal/testutil"
 )
-
-// ---------------------------------------------------------------------------
-// fakeInformer — copied from pacemaker/healthcheck_test.go (package-private)
-// ---------------------------------------------------------------------------
-
-func createFakeInformer(obj *pacmkrv1.PacemakerCluster) cache.SharedIndexInformer {
-	store := cache.NewStore(func(obj any) (string, error) {
-		if pc, ok := obj.(*pacmkrv1.PacemakerCluster); ok {
-			return pc.Name, nil
-		}
-		return "", fmt.Errorf("object is not a PacemakerCluster")
-	})
-	if obj != nil {
-		_ = store.Add(obj)
-	}
-	return &fakeInformer{store: store}
-}
-
-type fakeInformer struct {
-	store cache.Store
-}
-
-func (f *fakeInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, nil
-}
-func (f *fakeInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, nil
-}
-func (f *fakeInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, nil
-}
-func (f *fakeInformer) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
-	return nil
-}
-func (f *fakeInformer) GetStore() cache.Store           { return f.store }
-func (f *fakeInformer) GetController() cache.Controller { return nil }
-func (f *fakeInformer) Run(stopCh <-chan struct{})      {}
-func (f *fakeInformer) RunWithContext(ctx context.Context) {
-}
-func (f *fakeInformer) HasSynced() bool                                            { return true }
-func (f *fakeInformer) LastSyncResourceVersion() string                            { return "" }
-func (f *fakeInformer) SetWatchErrorHandler(handler cache.WatchErrorHandler) error { return nil }
-func (f *fakeInformer) SetWatchErrorHandlerWithContext(handler cache.WatchErrorHandlerWithContext) error {
-	return nil
-}
-func (f *fakeInformer) SetTransform(handler cache.TransformFunc) error { return nil }
-func (f *fakeInformer) IsStopped() bool                                { return false }
-func (f *fakeInformer) AddIndexers(indexers cache.Indexers) error      { return nil }
-func (f *fakeInformer) GetIndexer() cache.Indexer                      { return nil }
 
 // ---------------------------------------------------------------------------
 // CR builder
@@ -221,7 +171,7 @@ func setCondition(conditions *[]metav1.Condition, condType string, status metav1
 func setupAndSync(t *testing.T, cr *pacmkrv1.PacemakerCluster) metrics.KubeRegistry {
 	t.Helper()
 	registry := metrics.NewKubeRegistry()
-	informer := createFakeInformer(cr)
+	informer := tnftestutil.CreateFakeInformer(cr)
 	recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
 	controller := NewPacemakerMetricsController(informer, recorder, registry)
 	err := controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder))
@@ -360,7 +310,7 @@ tnf_node_clean{node="master-1"} 1
 
 func TestNodeRemovalBetweenSyncs(t *testing.T) {
 	registry := metrics.NewKubeRegistry()
-	informer := createFakeInformer(buildCluster())
+	informer := tnftestutil.CreateFakeInformer(buildCluster())
 	recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
 	controller := NewPacemakerMetricsController(informer, recorder, registry)
 	syncCtx := factory.NewSyncContext("test", recorder)
@@ -426,7 +376,7 @@ tnf_resource_healthy{node="node-beta",resource="Kubelet"} 1
 
 func TestSyncIdempotency(t *testing.T) {
 	registry := metrics.NewKubeRegistry()
-	informer := createFakeInformer(buildCluster())
+	informer := tnftestutil.CreateFakeInformer(buildCluster())
 	recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
 	controller := NewPacemakerMetricsController(informer, recorder, registry)
 	syncCtx := factory.NewSyncContext("test", recorder)

--- a/pkg/tnf/pkg/metriccontroller/controller_test.go
+++ b/pkg/tnf/pkg/metriccontroller/controller_test.go
@@ -1,0 +1,459 @@
+package metriccontroller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	pacmkrv1 "github.com/openshift/api/etcd/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/utils/clock"
+)
+
+// ---------------------------------------------------------------------------
+// fakeInformer — copied from pacemaker/healthcheck_test.go (package-private)
+// ---------------------------------------------------------------------------
+
+func createFakeInformer(obj *pacmkrv1.PacemakerCluster) cache.SharedIndexInformer {
+	store := cache.NewStore(func(obj any) (string, error) {
+		if pc, ok := obj.(*pacmkrv1.PacemakerCluster); ok {
+			return pc.Name, nil
+		}
+		return "", fmt.Errorf("object is not a PacemakerCluster")
+	})
+	if obj != nil {
+		_ = store.Add(obj)
+	}
+	return &fakeInformer{store: store}
+}
+
+type fakeInformer struct {
+	store cache.Store
+}
+
+func (f *fakeInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+func (f *fakeInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+func (f *fakeInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+func (f *fakeInformer) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
+	return nil
+}
+func (f *fakeInformer) GetStore() cache.Store           { return f.store }
+func (f *fakeInformer) GetController() cache.Controller { return nil }
+func (f *fakeInformer) Run(stopCh <-chan struct{})      {}
+func (f *fakeInformer) RunWithContext(ctx context.Context) {
+}
+func (f *fakeInformer) HasSynced() bool                                            { return true }
+func (f *fakeInformer) LastSyncResourceVersion() string                            { return "" }
+func (f *fakeInformer) SetWatchErrorHandler(handler cache.WatchErrorHandler) error { return nil }
+func (f *fakeInformer) SetWatchErrorHandlerWithContext(handler cache.WatchErrorHandlerWithContext) error {
+	return nil
+}
+func (f *fakeInformer) SetTransform(handler cache.TransformFunc) error { return nil }
+func (f *fakeInformer) IsStopped() bool                                { return false }
+func (f *fakeInformer) AddIndexers(indexers cache.Indexers) error      { return nil }
+func (f *fakeInformer) GetIndexer() cache.Indexer                      { return nil }
+
+// ---------------------------------------------------------------------------
+// CR builder
+// ---------------------------------------------------------------------------
+
+type crOption func(*pacmkrv1.PacemakerCluster)
+
+func buildCluster(opts ...crOption) *pacmkrv1.PacemakerCluster {
+	cr := &pacmkrv1.PacemakerCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status: pacmkrv1.PacemakerClusterStatus{
+			Conditions: healthyClusterConditions(),
+			Nodes:      healthyNodes("master-0", "master-1"),
+		},
+	}
+	for _, opt := range opts {
+		opt(cr)
+	}
+	return cr
+}
+
+func healthyClusterConditions() []metav1.Condition {
+	return []metav1.Condition{
+		{Type: pacmkrv1.ClusterHealthyConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.ClusterInServiceConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.ClusterNodeCountAsExpectedConditionType, Status: metav1.ConditionTrue},
+	}
+}
+
+func healthyNodeConditions() []metav1.Condition {
+	return []metav1.Condition{
+		{Type: pacmkrv1.NodeHealthyConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.NodeOnlineConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.NodeInServiceConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.NodeActiveConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.NodeReadyConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.NodeCleanConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.NodeMemberConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.NodeFencingAvailableConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.NodeFencingHealthyConditionType, Status: metav1.ConditionTrue},
+	}
+}
+
+func healthyResourceConditions() []metav1.Condition {
+	return []metav1.Condition{
+		{Type: pacmkrv1.ResourceHealthyConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.ResourceInServiceConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.ResourceManagedConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.ResourceEnabledConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.ResourceOperationalConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.ResourceActiveConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.ResourceStartedConditionType, Status: metav1.ConditionTrue},
+		{Type: pacmkrv1.ResourceSchedulableConditionType, Status: metav1.ConditionTrue},
+	}
+}
+
+func healthyNodes(names ...string) *[]pacmkrv1.PacemakerClusterNodeStatus {
+	nodes := make([]pacmkrv1.PacemakerClusterNodeStatus, len(names))
+	for i, name := range names {
+		nodes[i] = pacmkrv1.PacemakerClusterNodeStatus{
+			NodeName:   name,
+			Conditions: healthyNodeConditions(),
+			Resources: []pacmkrv1.PacemakerClusterResourceStatus{
+				{Name: pacmkrv1.PacemakerClusterResourceNameKubelet, Conditions: healthyResourceConditions()},
+				{Name: pacmkrv1.PacemakerClusterResourceNameEtcd, Conditions: healthyResourceConditions()},
+			},
+		}
+	}
+	return &nodes
+}
+
+func withNodeCondition(nodeName, condType string, status metav1.ConditionStatus) crOption {
+	return func(cr *pacmkrv1.PacemakerCluster) {
+		if cr.Status.Nodes == nil {
+			return
+		}
+		for i := range *cr.Status.Nodes {
+			if (*cr.Status.Nodes)[i].NodeName == nodeName {
+				setCondition(&(*cr.Status.Nodes)[i].Conditions, condType, status)
+				return
+			}
+		}
+	}
+}
+
+func withResourceCondition(nodeName string, resourceName pacmkrv1.PacemakerClusterResourceName, condType string, status metav1.ConditionStatus) crOption {
+	return func(cr *pacmkrv1.PacemakerCluster) {
+		if cr.Status.Nodes == nil {
+			return
+		}
+		for i := range *cr.Status.Nodes {
+			node := &(*cr.Status.Nodes)[i]
+			if node.NodeName != nodeName {
+				continue
+			}
+			for j := range node.Resources {
+				if node.Resources[j].Name == resourceName {
+					setCondition(&node.Resources[j].Conditions, condType, status)
+					return
+				}
+			}
+		}
+	}
+}
+
+func withNilNodes() crOption {
+	return func(cr *pacmkrv1.PacemakerCluster) {
+		cr.Status.Nodes = nil
+	}
+}
+
+func withNodes(names ...string) crOption {
+	return func(cr *pacmkrv1.PacemakerCluster) {
+		cr.Status.Nodes = healthyNodes(names...)
+	}
+}
+
+func withoutNodeCondition(nodeName, condType string) crOption {
+	return func(cr *pacmkrv1.PacemakerCluster) {
+		if cr.Status.Nodes == nil {
+			return
+		}
+		for i := range *cr.Status.Nodes {
+			node := &(*cr.Status.Nodes)[i]
+			if node.NodeName != nodeName {
+				continue
+			}
+			filtered := make([]metav1.Condition, 0, len(node.Conditions))
+			for _, c := range node.Conditions {
+				if c.Type != condType {
+					filtered = append(filtered, c)
+				}
+			}
+			node.Conditions = filtered
+			return
+		}
+	}
+}
+
+func setCondition(conditions *[]metav1.Condition, condType string, status metav1.ConditionStatus) {
+	for i := range *conditions {
+		if (*conditions)[i].Type == condType {
+			(*conditions)[i].Status = status
+			return
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func setupAndSync(t *testing.T, cr *pacmkrv1.PacemakerCluster) metrics.KubeRegistry {
+	t.Helper()
+	registry := metrics.NewKubeRegistry()
+	informer := createFakeInformer(cr)
+	recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+	controller := NewPacemakerMetricsController(informer, recorder, registry)
+	err := controller.Sync(context.TODO(), factory.NewSyncContext("test", recorder))
+	require.NoError(t, err)
+	return registry
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestHealthyCluster(t *testing.T) {
+	registry := setupAndSync(t, buildCluster())
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	familyNames := make(map[string]bool)
+	totalSeries := 0
+	for _, mf := range families {
+		familyNames[mf.GetName()] = true
+		for _, m := range mf.GetMetric() {
+			require.InDelta(t, 1.0, m.GetGauge().GetValue(), 0.001,
+				"metric %s should be 1.0 on healthy cluster", mf.GetName())
+			totalSeries++
+		}
+	}
+
+	require.Len(t, familyNames, 20, "expected 20 metric families")
+	require.Equal(t, 53, totalSeries, "expected 53 series on 2-node cluster")
+
+	require.True(t, familyNames["tnf_cluster_healthy"])
+	require.True(t, familyNames["tnf_cluster_in_service"])
+	require.True(t, familyNames["tnf_cluster_node_count_as_expected"])
+	require.True(t, familyNames["tnf_node_online"])
+	require.True(t, familyNames["tnf_resource_started"])
+}
+
+func TestNodeOffline(t *testing.T) {
+	registry := setupAndSync(t, buildCluster(
+		withNodeCondition("master-1", pacmkrv1.NodeOnlineConditionType, metav1.ConditionFalse),
+		withNodeCondition("master-1", pacmkrv1.NodeHealthyConditionType, metav1.ConditionFalse),
+	))
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+# HELP tnf_node_online [ALPHA] Whether a TNF node is online (1=online, 0=offline)
+# TYPE tnf_node_online gauge
+tnf_node_online{node="master-0"} 1
+tnf_node_online{node="master-1"} 0
+`), "tnf_node_online"))
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+# HELP tnf_node_healthy [ALPHA] Whether a TNF node is healthy (1=healthy, 0=unhealthy)
+# TYPE tnf_node_healthy gauge
+tnf_node_healthy{node="master-0"} 1
+tnf_node_healthy{node="master-1"} 0
+`), "tnf_node_healthy"))
+}
+
+func TestResourceStopped(t *testing.T) {
+	registry := setupAndSync(t, buildCluster(
+		withResourceCondition("master-0", pacmkrv1.PacemakerClusterResourceNameEtcd,
+			pacmkrv1.ResourceStartedConditionType, metav1.ConditionFalse),
+	))
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+# HELP tnf_resource_started [ALPHA] Whether a TNF resource is started (1=started, 0=stopped)
+# TYPE tnf_resource_started gauge
+tnf_resource_started{node="master-0",resource="Etcd"} 0
+tnf_resource_started{node="master-0",resource="Kubelet"} 1
+tnf_resource_started{node="master-1",resource="Etcd"} 1
+tnf_resource_started{node="master-1",resource="Kubelet"} 1
+`), "tnf_resource_started"))
+}
+
+func TestMissingCR(t *testing.T) {
+	registry := setupAndSync(t, nil)
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+# HELP tnf_cluster_healthy [ALPHA] Whether the TNF cluster is healthy (1=healthy, 0=unhealthy)
+# TYPE tnf_cluster_healthy gauge
+tnf_cluster_healthy 0
+# HELP tnf_cluster_in_service [ALPHA] Whether the TNF cluster is in service (1=in-service, 0=maintenance)
+# TYPE tnf_cluster_in_service gauge
+tnf_cluster_in_service 0
+# HELP tnf_cluster_node_count_as_expected [ALPHA] Whether the TNF cluster has the expected node count (1=expected, 0=mismatch)
+# TYPE tnf_cluster_node_count_as_expected gauge
+tnf_cluster_node_count_as_expected 0
+`), "tnf_cluster_healthy", "tnf_cluster_in_service", "tnf_cluster_node_count_as_expected"))
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if strings.HasPrefix(mf.GetName(), "tnf_node_") || strings.HasPrefix(mf.GetName(), "tnf_resource_") {
+			require.Empty(t, mf.GetMetric(), "expected no samples for %s after missing CR", mf.GetName())
+		}
+	}
+}
+
+func TestNilNodesPointer(t *testing.T) {
+	registry := setupAndSync(t, buildCluster(withNilNodes()))
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+# HELP tnf_cluster_healthy [ALPHA] Whether the TNF cluster is healthy (1=healthy, 0=unhealthy)
+# TYPE tnf_cluster_healthy gauge
+tnf_cluster_healthy 1
+# HELP tnf_cluster_in_service [ALPHA] Whether the TNF cluster is in service (1=in-service, 0=maintenance)
+# TYPE tnf_cluster_in_service gauge
+tnf_cluster_in_service 1
+# HELP tnf_cluster_node_count_as_expected [ALPHA] Whether the TNF cluster has the expected node count (1=expected, 0=mismatch)
+# TYPE tnf_cluster_node_count_as_expected gauge
+tnf_cluster_node_count_as_expected 1
+`), "tnf_cluster_healthy", "tnf_cluster_in_service", "tnf_cluster_node_count_as_expected"))
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if strings.HasPrefix(mf.GetName(), "tnf_node_") || strings.HasPrefix(mf.GetName(), "tnf_resource_") {
+			require.Empty(t, mf.GetMetric(), "expected no samples for %s with nil Nodes", mf.GetName())
+		}
+	}
+}
+
+func TestMissingCondition(t *testing.T) {
+	registry := setupAndSync(t, buildCluster(
+		withoutNodeCondition("master-0", pacmkrv1.NodeCleanConditionType),
+	))
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+# HELP tnf_node_clean [ALPHA] Whether a TNF node is in a clean state (1=clean, 0=unclean)
+# TYPE tnf_node_clean gauge
+tnf_node_clean{node="master-0"} 0
+tnf_node_clean{node="master-1"} 1
+`), "tnf_node_clean"))
+}
+
+func TestNodeRemovalBetweenSyncs(t *testing.T) {
+	registry := metrics.NewKubeRegistry()
+	informer := createFakeInformer(buildCluster())
+	recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+	controller := NewPacemakerMetricsController(informer, recorder, registry)
+	syncCtx := factory.NewSyncContext("test", recorder)
+
+	require.NoError(t, controller.Sync(context.TODO(), syncCtx))
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() == "tnf_node_online" {
+			require.Len(t, mf.GetMetric(), 2, "expected 2 node series before removal")
+		}
+	}
+
+	oneNodeCR := buildCluster(withNodes("master-0"))
+	require.NoError(t, informer.GetStore().Update(oneNodeCR))
+	require.NoError(t, controller.Sync(context.TODO(), syncCtx))
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+# HELP tnf_node_online [ALPHA] Whether a TNF node is online (1=online, 0=offline)
+# TYPE tnf_node_online gauge
+tnf_node_online{node="master-0"} 1
+`), "tnf_node_online"))
+}
+
+func TestMultipleResourcesPerNode(t *testing.T) {
+	registry := setupAndSync(t, buildCluster(
+		withResourceCondition("master-0", pacmkrv1.PacemakerClusterResourceNameEtcd,
+			pacmkrv1.ResourceStartedConditionType, metav1.ConditionFalse),
+		withResourceCondition("master-1", pacmkrv1.PacemakerClusterResourceNameKubelet,
+			pacmkrv1.ResourceStartedConditionType, metav1.ConditionFalse),
+	))
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+# HELP tnf_resource_started [ALPHA] Whether a TNF resource is started (1=started, 0=stopped)
+# TYPE tnf_resource_started gauge
+tnf_resource_started{node="master-0",resource="Etcd"} 0
+tnf_resource_started{node="master-0",resource="Kubelet"} 1
+tnf_resource_started{node="master-1",resource="Etcd"} 1
+tnf_resource_started{node="master-1",resource="Kubelet"} 0
+`), "tnf_resource_started"))
+}
+
+func TestLabelCorrectness(t *testing.T) {
+	registry := setupAndSync(t, buildCluster(withNodes("node-alpha", "node-beta")))
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+# HELP tnf_node_online [ALPHA] Whether a TNF node is online (1=online, 0=offline)
+# TYPE tnf_node_online gauge
+tnf_node_online{node="node-alpha"} 1
+tnf_node_online{node="node-beta"} 1
+`), "tnf_node_online"))
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
+# HELP tnf_resource_healthy [ALPHA] Whether a TNF resource is healthy (1=healthy, 0=unhealthy)
+# TYPE tnf_resource_healthy gauge
+tnf_resource_healthy{node="node-alpha",resource="Etcd"} 1
+tnf_resource_healthy{node="node-alpha",resource="Kubelet"} 1
+tnf_resource_healthy{node="node-beta",resource="Etcd"} 1
+tnf_resource_healthy{node="node-beta",resource="Kubelet"} 1
+`), "tnf_resource_healthy"))
+}
+
+func TestSyncIdempotency(t *testing.T) {
+	registry := metrics.NewKubeRegistry()
+	informer := createFakeInformer(buildCluster())
+	recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+	controller := NewPacemakerMetricsController(informer, recorder, registry)
+	syncCtx := factory.NewSyncContext("test", recorder)
+
+	require.NoError(t, controller.Sync(context.TODO(), syncCtx))
+	first, err := registry.Gather()
+	require.NoError(t, err)
+
+	require.NoError(t, controller.Sync(context.TODO(), syncCtx))
+	second, err := registry.Gather()
+	require.NoError(t, err)
+
+	require.Equal(t, len(first), len(second), "family count should be stable across syncs")
+	for i := range first {
+		require.Equal(t, first[i].GetName(), second[i].GetName())
+		require.Equal(t, len(first[i].GetMetric()), len(second[i].GetMetric()),
+			"series count for %s should be stable", first[i].GetName())
+		for j := range first[i].GetMetric() {
+			require.InDelta(t, first[i].GetMetric()[j].GetGauge().GetValue(),
+				second[i].GetMetric()[j].GetGauge().GetValue(), 0.001,
+				"value for %s should be stable", first[i].GetName())
+		}
+	}
+}
+
+func TestConditionToFloat64(t *testing.T) {
+	require.InDelta(t, 1.0, conditionToFloat64(&metav1.Condition{Status: metav1.ConditionTrue}), 0.001)
+	require.InDelta(t, 0.0, conditionToFloat64(&metav1.Condition{Status: metav1.ConditionFalse}), 0.001)
+	require.InDelta(t, 0.0, conditionToFloat64(nil), 0.001)
+}

--- a/pkg/tnf/pkg/metriccontroller/metrics.go
+++ b/pkg/tnf/pkg/metriccontroller/metrics.go
@@ -9,104 +9,144 @@ import (
 
 var (
 	clusterHealthyGauge = metrics.NewGauge(&metrics.GaugeOpts{
-		Name:           "tnf_cluster_healthy",
+		Namespace:      "tnf",
+		Subsystem:      "cluster",
+		Name:           "healthy",
 		Help:           "Whether the TNF cluster is healthy (1=healthy, 0=unhealthy)",
 		StabilityLevel: metrics.ALPHA,
 	})
 	clusterInServiceGauge = metrics.NewGauge(&metrics.GaugeOpts{
-		Name:           "tnf_cluster_in_service",
+		Namespace:      "tnf",
+		Subsystem:      "cluster",
+		Name:           "in_service",
 		Help:           "Whether the TNF cluster is in service (1=in-service, 0=maintenance)",
 		StabilityLevel: metrics.ALPHA,
 	})
 	clusterNodeCountAsExpectedGauge = metrics.NewGauge(&metrics.GaugeOpts{
-		Name:           "tnf_cluster_node_count_as_expected",
+		Namespace:      "tnf",
+		Subsystem:      "cluster",
+		Name:           "node_count_as_expected",
 		Help:           "Whether the TNF cluster has the expected node count (1=expected, 0=mismatch)",
 		StabilityLevel: metrics.ALPHA,
 	})
 
 	nodeHealthyGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_node_healthy",
+		Namespace:      "tnf",
+		Subsystem:      "node",
+		Name:           "healthy",
 		Help:           "Whether a TNF node is healthy (1=healthy, 0=unhealthy)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node"})
 	nodeOnlineGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_node_online",
+		Namespace:      "tnf",
+		Subsystem:      "node",
+		Name:           "online",
 		Help:           "Whether a TNF node is online (1=online, 0=offline)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node"})
 	nodeInServiceGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_node_in_service",
+		Namespace:      "tnf",
+		Subsystem:      "node",
+		Name:           "in_service",
 		Help:           "Whether a TNF node is in service (1=in-service, 0=maintenance)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node"})
 	nodeActiveGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_node_active",
+		Namespace:      "tnf",
+		Subsystem:      "node",
+		Name:           "active",
 		Help:           "Whether a TNF node is active (1=active, 0=standby)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node"})
 	nodeReadyGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_node_ready",
+		Namespace:      "tnf",
+		Subsystem:      "node",
+		Name:           "ready",
 		Help:           "Whether a TNF node is ready (1=ready, 0=pending)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node"})
 	nodeCleanGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_node_clean",
+		Namespace:      "tnf",
+		Subsystem:      "node",
+		Name:           "clean",
 		Help:           "Whether a TNF node is in a clean state (1=clean, 0=unclean)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node"})
 	nodeMemberGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_node_member",
+		Namespace:      "tnf",
+		Subsystem:      "node",
+		Name:           "member",
 		Help:           "Whether a TNF node is a cluster member (1=member, 0=not-member)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node"})
 	nodeFencingAvailableGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_node_fencing_available",
+		Namespace:      "tnf",
+		Subsystem:      "node",
+		Name:           "fencing_available",
 		Help:           "Whether a TNF node has at least one healthy fence device (1=available, 0=unavailable)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node"})
 	nodeFencingHealthyGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_node_fencing_healthy",
+		Namespace:      "tnf",
+		Subsystem:      "node",
+		Name:           "fencing_healthy",
 		Help:           "Whether all fence devices for a TNF node are healthy (1=all-healthy, 0=degraded)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node"})
 
 	resourceHealthyGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_resource_healthy",
+		Namespace:      "tnf",
+		Subsystem:      "resource",
+		Name:           "healthy",
 		Help:           "Whether a TNF resource is healthy (1=healthy, 0=unhealthy)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node", "resource"})
 	resourceInServiceGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_resource_in_service",
+		Namespace:      "tnf",
+		Subsystem:      "resource",
+		Name:           "in_service",
 		Help:           "Whether a TNF resource is in service (1=in-service, 0=maintenance)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node", "resource"})
 	resourceManagedGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_resource_managed",
+		Namespace:      "tnf",
+		Subsystem:      "resource",
+		Name:           "managed",
 		Help:           "Whether a TNF resource is managed by Pacemaker (1=managed, 0=unmanaged)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node", "resource"})
 	resourceEnabledGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_resource_enabled",
+		Namespace:      "tnf",
+		Subsystem:      "resource",
+		Name:           "enabled",
 		Help:           "Whether a TNF resource is enabled (1=enabled, 0=disabled)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node", "resource"})
 	resourceOperationalGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_resource_operational",
+		Namespace:      "tnf",
+		Subsystem:      "resource",
+		Name:           "operational",
 		Help:           "Whether a TNF resource is operational (1=operational, 0=failed)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node", "resource"})
 	resourceActiveGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_resource_active",
+		Namespace:      "tnf",
+		Subsystem:      "resource",
+		Name:           "active",
 		Help:           "Whether a TNF resource is active (1=active, 0=inactive)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node", "resource"})
 	resourceStartedGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_resource_started",
+		Namespace:      "tnf",
+		Subsystem:      "resource",
+		Name:           "started",
 		Help:           "Whether a TNF resource is started (1=started, 0=stopped)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node", "resource"})
 	resourceSchedulableGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
-		Name:           "tnf_resource_schedulable",
+		Namespace:      "tnf",
+		Subsystem:      "resource",
+		Name:           "schedulable",
 		Help:           "Whether a TNF resource is schedulable (1=schedulable, 0=unschedulable)",
 		StabilityLevel: metrics.ALPHA,
 	}, []string{"node", "resource"})

--- a/pkg/tnf/pkg/metriccontroller/metrics.go
+++ b/pkg/tnf/pkg/metriccontroller/metrics.go
@@ -1,0 +1,193 @@
+package metriccontroller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/metrics"
+
+	pacmkrv1 "github.com/openshift/api/etcd/v1"
+)
+
+var (
+	clusterHealthyGauge = metrics.NewGauge(&metrics.GaugeOpts{
+		Name:           "tnf_cluster_healthy",
+		Help:           "Whether the TNF cluster is healthy (1=healthy, 0=unhealthy)",
+		StabilityLevel: metrics.ALPHA,
+	})
+	clusterInServiceGauge = metrics.NewGauge(&metrics.GaugeOpts{
+		Name:           "tnf_cluster_in_service",
+		Help:           "Whether the TNF cluster is in service (1=in-service, 0=maintenance)",
+		StabilityLevel: metrics.ALPHA,
+	})
+	clusterNodeCountAsExpectedGauge = metrics.NewGauge(&metrics.GaugeOpts{
+		Name:           "tnf_cluster_node_count_as_expected",
+		Help:           "Whether the TNF cluster has the expected node count (1=expected, 0=mismatch)",
+		StabilityLevel: metrics.ALPHA,
+	})
+
+	nodeHealthyGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_node_healthy",
+		Help:           "Whether a TNF node is healthy (1=healthy, 0=unhealthy)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node"})
+	nodeOnlineGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_node_online",
+		Help:           "Whether a TNF node is online (1=online, 0=offline)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node"})
+	nodeInServiceGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_node_in_service",
+		Help:           "Whether a TNF node is in service (1=in-service, 0=maintenance)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node"})
+	nodeActiveGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_node_active",
+		Help:           "Whether a TNF node is active (1=active, 0=standby)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node"})
+	nodeReadyGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_node_ready",
+		Help:           "Whether a TNF node is ready (1=ready, 0=pending)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node"})
+	nodeCleanGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_node_clean",
+		Help:           "Whether a TNF node is in a clean state (1=clean, 0=unclean)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node"})
+	nodeMemberGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_node_member",
+		Help:           "Whether a TNF node is a cluster member (1=member, 0=not-member)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node"})
+	nodeFencingAvailableGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_node_fencing_available",
+		Help:           "Whether a TNF node has at least one healthy fence device (1=available, 0=unavailable)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node"})
+	nodeFencingHealthyGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_node_fencing_healthy",
+		Help:           "Whether all fence devices for a TNF node are healthy (1=all-healthy, 0=degraded)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node"})
+
+	resourceHealthyGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_resource_healthy",
+		Help:           "Whether a TNF resource is healthy (1=healthy, 0=unhealthy)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node", "resource"})
+	resourceInServiceGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_resource_in_service",
+		Help:           "Whether a TNF resource is in service (1=in-service, 0=maintenance)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node", "resource"})
+	resourceManagedGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_resource_managed",
+		Help:           "Whether a TNF resource is managed by Pacemaker (1=managed, 0=unmanaged)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node", "resource"})
+	resourceEnabledGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_resource_enabled",
+		Help:           "Whether a TNF resource is enabled (1=enabled, 0=disabled)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node", "resource"})
+	resourceOperationalGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_resource_operational",
+		Help:           "Whether a TNF resource is operational (1=operational, 0=failed)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node", "resource"})
+	resourceActiveGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_resource_active",
+		Help:           "Whether a TNF resource is active (1=active, 0=inactive)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node", "resource"})
+	resourceStartedGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_resource_started",
+		Help:           "Whether a TNF resource is started (1=started, 0=stopped)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node", "resource"})
+	resourceSchedulableGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Name:           "tnf_resource_schedulable",
+		Help:           "Whether a TNF resource is schedulable (1=schedulable, 0=unschedulable)",
+		StabilityLevel: metrics.ALPHA,
+	}, []string{"node", "resource"})
+)
+
+var clusterGauges = []*metrics.Gauge{
+	clusterHealthyGauge,
+	clusterInServiceGauge,
+	clusterNodeCountAsExpectedGauge,
+}
+
+var nodeGaugeVecs = []*metrics.GaugeVec{
+	nodeHealthyGauge,
+	nodeOnlineGauge,
+	nodeInServiceGauge,
+	nodeActiveGauge,
+	nodeReadyGauge,
+	nodeCleanGauge,
+	nodeMemberGauge,
+	nodeFencingAvailableGauge,
+	nodeFencingHealthyGauge,
+}
+
+var resourceGaugeVecs = []*metrics.GaugeVec{
+	resourceHealthyGauge,
+	resourceInServiceGauge,
+	resourceManagedGauge,
+	resourceEnabledGauge,
+	resourceOperationalGauge,
+	resourceActiveGauge,
+	resourceStartedGauge,
+	resourceSchedulableGauge,
+}
+
+type clusterConditionMapping struct {
+	conditionType string
+	gauge         *metrics.Gauge
+}
+
+type nodeConditionMapping struct {
+	conditionType string
+	gaugeVec      *metrics.GaugeVec
+}
+
+type resourceConditionMapping struct {
+	conditionType string
+	gaugeVec      *metrics.GaugeVec
+}
+
+var clusterConditionMetrics = []clusterConditionMapping{
+	{pacmkrv1.ClusterHealthyConditionType, clusterHealthyGauge},
+	{pacmkrv1.ClusterInServiceConditionType, clusterInServiceGauge},
+	{pacmkrv1.ClusterNodeCountAsExpectedConditionType, clusterNodeCountAsExpectedGauge},
+}
+
+var nodeConditionMetrics = []nodeConditionMapping{
+	{pacmkrv1.NodeHealthyConditionType, nodeHealthyGauge},
+	{pacmkrv1.NodeOnlineConditionType, nodeOnlineGauge},
+	{pacmkrv1.NodeInServiceConditionType, nodeInServiceGauge},
+	{pacmkrv1.NodeActiveConditionType, nodeActiveGauge},
+	{pacmkrv1.NodeReadyConditionType, nodeReadyGauge},
+	{pacmkrv1.NodeCleanConditionType, nodeCleanGauge},
+	{pacmkrv1.NodeMemberConditionType, nodeMemberGauge},
+	{pacmkrv1.NodeFencingAvailableConditionType, nodeFencingAvailableGauge},
+	{pacmkrv1.NodeFencingHealthyConditionType, nodeFencingHealthyGauge},
+}
+
+var resourceConditionMetrics = []resourceConditionMapping{
+	{pacmkrv1.ResourceHealthyConditionType, resourceHealthyGauge},
+	{pacmkrv1.ResourceInServiceConditionType, resourceInServiceGauge},
+	{pacmkrv1.ResourceManagedConditionType, resourceManagedGauge},
+	{pacmkrv1.ResourceEnabledConditionType, resourceEnabledGauge},
+	{pacmkrv1.ResourceOperationalConditionType, resourceOperationalGauge},
+	{pacmkrv1.ResourceActiveConditionType, resourceActiveGauge},
+	{pacmkrv1.ResourceStartedConditionType, resourceStartedGauge},
+	{pacmkrv1.ResourceSchedulableConditionType, resourceSchedulableGauge},
+}
+
+func conditionToFloat64(cond *metav1.Condition) float64 {
+	if cond != nil && cond.Status == metav1.ConditionTrue {
+		return 1.0
+	}
+	return 0.0
+}

--- a/pkg/tnf/pkg/pacemaker/healthcheck_test.go
+++ b/pkg/tnf/pkg/pacemaker/healthcheck_test.go
@@ -2,7 +2,6 @@ package pacemaker
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -14,10 +13,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/clock"
 
 	pacmkrv1 "github.com/openshift/api/etcd/v1"
+	"github.com/openshift/cluster-etcd-operator/pkg/tnf/internal/testutil"
 )
 
 // Test helper functions
@@ -45,58 +44,10 @@ func createTestHealthCheck() *HealthCheck {
 		operatorClient:    createFakeOperatorClient(),
 		kubeClient:        fake.NewSimpleClientset(),
 		eventRecorder:     events.NewInMemoryRecorder("test", clock.RealClock{}),
-		pacemakerInformer: createFakeInformer(nil),
+		pacemakerInformer: testutil.CreateFakeInformer(nil),
 		recordedEvents:    make(map[string]time.Time),
 	}
 }
-
-// createFakeInformer creates a fake SharedIndexInformer with a store containing the given object.
-// If obj is nil, the store will be empty.
-func createFakeInformer(obj *pacmkrv1.PacemakerCluster) cache.SharedIndexInformer {
-	store := cache.NewStore(func(obj any) (string, error) {
-		if pc, ok := obj.(*pacmkrv1.PacemakerCluster); ok {
-			return pc.Name, nil
-		}
-		return "", fmt.Errorf("object is not a PacemakerCluster")
-	})
-	if obj != nil {
-		_ = store.Add(obj)
-	}
-	return &fakeInformer{store: store}
-}
-
-// fakeInformer implements cache.SharedIndexInformer for testing
-type fakeInformer struct {
-	store cache.Store
-}
-
-func (f *fakeInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, nil
-}
-func (f *fakeInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, nil
-}
-func (f *fakeInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, nil
-}
-func (f *fakeInformer) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
-	return nil
-}
-func (f *fakeInformer) GetStore() cache.Store           { return f.store }
-func (f *fakeInformer) GetController() cache.Controller { return nil }
-func (f *fakeInformer) Run(stopCh <-chan struct{})      {}
-func (f *fakeInformer) RunWithContext(ctx context.Context) {
-}
-func (f *fakeInformer) HasSynced() bool                                            { return true }
-func (f *fakeInformer) LastSyncResourceVersion() string                            { return "" }
-func (f *fakeInformer) SetWatchErrorHandler(handler cache.WatchErrorHandler) error { return nil }
-func (f *fakeInformer) SetWatchErrorHandlerWithContext(handler cache.WatchErrorHandlerWithContext) error {
-	return nil
-}
-func (f *fakeInformer) SetTransform(handler cache.TransformFunc) error { return nil }
-func (f *fakeInformer) IsStopped() bool                                { return false }
-func (f *fakeInformer) AddIndexers(indexers cache.Indexers) error      { return nil }
-func (f *fakeInformer) GetIndexer() cache.Indexer                      { return nil }
 
 // createTestHealthCheckWithMockStatus creates a HealthCheck with a mocked Pacemaker CR in the informer cache
 func createTestHealthCheckWithMockStatus(t *testing.T, mockStatus *pacmkrv1.PacemakerCluster) *HealthCheck {
@@ -104,7 +55,7 @@ func createTestHealthCheckWithMockStatus(t *testing.T, mockStatus *pacmkrv1.Pace
 		operatorClient:    createFakeOperatorClient(),
 		kubeClient:        fake.NewSimpleClientset(),
 		eventRecorder:     events.NewInMemoryRecorder("test", clock.RealClock{}),
-		pacemakerInformer: createFakeInformer(mockStatus),
+		pacemakerInformer: testutil.CreateFakeInformer(mockStatus),
 		recordedEvents:    make(map[string]time.Time),
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a metrics controller that projects PacemakerCluster CR conditions into Prometheus gauges (20 metric families, ~53 series on a 2-node cluster)
- Shares the existing `pacemakerInformer` with HealthCheck — zero additional API server load
- Uses table-driven sync logic with `GaugeVec.Reset()` to prevent stale data from removed nodes

## Details

New package `pkg/tnf/pkg/metriccontroller/` with three files:

| File | Purpose |
|------|---------|
| `metrics.go` | 20 metric definitions (3 cluster, 9 node, 8 resource), mapping tables, `conditionToFloat64` helper |
| `controller.go` | Controller struct, constructor with `metrics.KubeRegistry` injection, sync logic |
| `controller_test.go` | 11 test cases covering healthy cluster, node offline, resource stopped, missing CR, nil nodes, missing condition, node removal, multi-resource, label correctness, idempotency, and edge cases |

Wiring in `pkg/tnf/operator/starter.go` — controller created after HealthCheck, sharing `pacemakerInformer`.

### Key design decisions

- **Registry injection** for test isolation (matches `EtcdCertSignerController` pattern)
- **Missing CR → gauges reset to 0** — makes "unhealthy" the safe default for alerting rules (`== 0` vs `absent()`)
- **No operator condition** — failure modes overlap with HealthCheck; self-health metric deferred to [OCPEDGE-2707](https://redhat.atlassian.net/browse/OCPEDGE-2707)
- **`StabilityLevel: metrics.ALPHA`** — explicit on all metrics

### Metrics exposed

| Level | Count | Type | Labels |
|-------|-------|------|--------|
| Cluster | 3 | `Gauge` | none |
| Node | 9 | `GaugeVec` | `node` |
| Resource | 8 | `GaugeVec` | `node`, `resource` |

## Test plan

- [x] `go build ./...` — all binaries compile
- [x] `go test ./pkg/tnf/pkg/metriccontroller/ -v -count=5` — 55/55 pass, no registration pollution
- [x] `go test ./pkg/tnf/... -count=1` — 454 existing TNF tests pass (no regressions)
- [x] `make build` — clean
- [x] `make test-unit` — all tests pass with `-race`
- [x] E2E: Deployed on fencing-IPI cluster, 53 series confirmed on `:8443/metrics` and in Prometheus

### E2E validation (11 scenarios on live cluster)

17/20 metrics dynamically validated via reversible `pcs` operations (maintenance mode, unmanage, disable, standby, fence disable, cluster stop, force-stop, double-ban, virsh destroy, kubelet kill). 3 remaining are not dynamically testable: `node_ready` (too-transient, 1-3s vs 60s poll), `node_clean` (API blind spot — quorum loss blocks CR writes), `cluster_node_count_as_expected` (structurally unreachable — configured membership fixed at 2). All code paths covered by unit tests.

## Related

- **Jira**: [OCPEDGE-2705](https://issues.redhat.com/browse/OCPEDGE-2705)
- **Epic**: [OCPEDGE-2091](https://issues.redhat.com/browse/OCPEDGE-2091) (TNF monitoring)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for `PacemakerCluster`, including cluster condition gauges, per-node online status, and per-resource state.
  * Metrics are maintained by a dedicated controller and reset appropriately when cluster or node details are unavailable.

* **Tests**
  * Added unit tests validating metric outputs across healthy, unhealthy/offline, stopped/started, missing data, label correctness, node removal, and Sync idempotency.
  * Updated health check tests to use shared fake informer utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->