### PR TITLE
OCPEDGE-2770: fix: handle default-port BMC URLs in Phase 3 address matching

### DIFF
--- a/bindata/etcd/update-fencing-credentials.sh
+++ b/bindata/etcd/update-fencing-credentials.sh
@@ -85,7 +85,8 @@ function detect_fencing_secret {
         local name addr
         for name in $(oc get secrets -n "${namespace}" -o name 2>/dev/null | grep fencing-credentials-); do
             addr=$(oc get "${name}" -n "${namespace}" -o jsonpath='{.data.address}' 2>/dev/null | base64 -d) || continue
-            if [[ "${addr}" == *"://${stonith_ip}:"* ]] || [[ "${addr}" == *"://[${stonith_ip}]:"* ]]; then
+            if [[ "${addr}" == *"://${stonith_ip}:"* ]] || [[ "${addr}" == *"://${stonith_ip}/"* ]] || \
+               [[ "${addr}" == *"://\[${stonith_ip}\]:"* ]] || [[ "${addr}" == *"://\[${stonith_ip}\]/"* ]]; then
                 if [[ "${addr}" == *"${stonith_uri}" ]]; then
                     echo "${name#secret/}"
                     return 0


### PR DESCRIPTION
The IP matching pattern required a colon after the hostname (`://host:`), which fails when the BMC uses the default HTTPS port and the URL omits it (`://host/)`. Match on both colon and slash delimiters for IPv4 and IPv6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fencing credential detection to properly support IPv6 address formats in addition to IPv4 addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->