### PR TITLE
NO-JIRA: quote bootstrap IP in bootkube etcd endpoints manifest

### DIFF
--- a/bindata/bootkube/manifests/00_etcd-endpoints-cm.yaml
+++ b/bindata/bootkube/manifests/00_etcd-endpoints-cm.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-etcd
 {{- if ne .BootstrapScalingStrategy "BootstrapInPlaceStrategy" }}
   annotations:
-    alpha.installer.openshift.io/etcd-bootstrap: {{ .BootstrapIP }}
+    alpha.installer.openshift.io/etcd-bootstrap: "{{ .BootstrapIP }}"
 {{- else }}
 data:
   {{ .EtcdEndpointConfigmapData }}

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -45,6 +45,7 @@ type renderOpts struct {
 	infraConfigFile      string
 
 	delayedHABootstrapScalingStrategyMarker string
+	bootstrapIPLocator                      BootstrapIPLocator
 }
 
 // NewRenderCommand creates a render command.
@@ -235,7 +236,11 @@ func newTemplateData(opts *renderOpts) (*TemplateData, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := templateData.setBootstrapIP(templateData.MachineCIDR, templateData.PreferIPv6, excludedIPs); err != nil {
+	bootstrapIPLocator := opts.bootstrapIPLocator
+	if bootstrapIPLocator == nil {
+		bootstrapIPLocator = defaultBootstrapIPLocator
+	}
+	if err := templateData.setBootstrapIP(bootstrapIPLocator, templateData.MachineCIDR, templateData.PreferIPv6, excludedIPs); err != nil {
 		return nil, err
 	}
 
@@ -417,8 +422,8 @@ func writeKeyFile(dir, name string, keyData []byte) error {
 	return nil
 }
 
-func (t *TemplateData) setBootstrapIP(machineCIDR string, ipv6 bool, excludedIPs []string) error {
-	ip, err := defaultBootstrapIPLocator.getBootstrapIP(ipv6, machineCIDR, excludedIPs)
+func (t *TemplateData) setBootstrapIP(locator BootstrapIPLocator, machineCIDR string, ipv6 bool, excludedIPs []string) error {
+	ip, err := locator.getBootstrapIP(ipv6, machineCIDR, excludedIPs)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -15,6 +15,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceohelpers"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -320,10 +321,30 @@ func TestRenderIpv6(t *testing.T) {
 		infraConfig:          infraConfig,
 		clusterConfigMap:     clusterConfigMap,
 	}
-	testRender(t, config)
+	dir := renderManifests(t, config)
+
+	etcdEndpointsPath := filepath.Join(dir, "manifests", "00_etcd-endpoints-cm.yaml")
+	etcdEndpointsBytes, err := os.ReadFile(etcdEndpointsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	etcdEndpoints := &corev1.ConfigMap{}
+	if err := yaml.Unmarshal(etcdEndpointsBytes, etcdEndpoints); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedBootstrapIP := "2001:db8::1"
+	if got := etcdEndpoints.Annotations["alpha.installer.openshift.io/etcd-bootstrap"]; got != expectedBootstrapIP {
+		t.Errorf("etcd bootstrap annotation want: %q got: %q", expectedBootstrapIP, got)
+	}
 }
 
 func testRender(t *testing.T, tc *testConfig) {
+	renderManifests(t, tc)
+}
+
+func renderManifests(t *testing.T, tc *testConfig) string {
 	var errOut io.Writer
 	dir := t.TempDir()
 
@@ -354,6 +375,8 @@ func testRender(t *testing.T, tc *testConfig) {
 	if err := render.Run(); err != nil {
 		t.Errorf("failed render.Run(): %v", err)
 	}
+
+	return dir
 }
 
 func TestTemplateDataIpv4(t *testing.T) {

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -310,6 +310,19 @@ func TestRenderIpv4(t *testing.T) {
 	testRender(t, config)
 }
 
+func TestRenderIpv6(t *testing.T) {
+	orig := defaultBootstrapIPLocator
+	defaultBootstrapIPLocator = &fakeBootstrapIPLocator{ip: net.ParseIP("2001:db8::1")}
+	defer func() { defaultBootstrapIPLocator = orig }()
+
+	config := &testConfig{
+		clusterNetworkConfig: networkConfigIPv6SingleStack,
+		infraConfig:          infraConfig,
+		clusterConfigMap:     clusterConfigMap,
+	}
+	testRender(t, config)
+}
+
 func testRender(t *testing.T, tc *testConfig) {
 	var errOut io.Writer
 	dir := t.TempDir()

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -293,12 +293,7 @@ type testConfig struct {
 	infraConfig                             string
 	clusterConfigMap                        string
 	delayedHABootstrapScalingStrategyMarker string
-}
-
-func TestMain(m *testing.M) {
-	// TODO: implement tests for bootstrap IP determination
-	defaultBootstrapIPLocator = &fakeBootstrapIPLocator{ip: net.ParseIP("10.0.0.1")}
-	os.Exit(m.Run())
+	bootstrapIP                             net.IP
 }
 
 func TestRenderIpv4(t *testing.T) {
@@ -312,16 +307,13 @@ func TestRenderIpv4(t *testing.T) {
 }
 
 func TestRenderIpv6(t *testing.T) {
-	orig := defaultBootstrapIPLocator
-	defaultBootstrapIPLocator = &fakeBootstrapIPLocator{ip: net.ParseIP("2001:db8::1")}
-	defer func() { defaultBootstrapIPLocator = orig }()
-
 	config := &testConfig{
 		clusterNetworkConfig: networkConfigIPv6SingleStack,
 		infraConfig:          infraConfig,
 		clusterConfigMap:     clusterConfigMap,
+		bootstrapIP:          net.ParseIP("2001:db8::1"),
 	}
-	dir := renderManifests(t, config)
+	dir := testRender(t, config)
 
 	etcdEndpointsPath := filepath.Join(dir, "manifests", "00_etcd-endpoints-cm.yaml")
 	etcdEndpointsBytes, err := os.ReadFile(etcdEndpointsPath)
@@ -340,11 +332,12 @@ func TestRenderIpv6(t *testing.T) {
 	}
 }
 
-func testRender(t *testing.T, tc *testConfig) {
-	renderManifests(t, tc)
-}
+func testRender(t *testing.T, tc *testConfig) string {
+	bootstrapIP := tc.bootstrapIP
+	if bootstrapIP == nil {
+		bootstrapIP = net.ParseIP("10.0.0.1")
+	}
 
-func renderManifests(t *testing.T, tc *testConfig) string {
 	var errOut io.Writer
 	dir := t.TempDir()
 
@@ -370,6 +363,7 @@ func renderManifests(t *testing.T, tc *testConfig) string {
 		networkConfigFile:    clusterConfigPath,
 		infraConfigFile:      infraConfigPath,
 		clusterConfigMapFile: clusterConfigMapPath,
+		bootstrapIPLocator:   &fakeBootstrapIPLocator{ip: bootstrapIP},
 	}
 
 	if err := render.Run(); err != nil {
@@ -572,6 +566,11 @@ func hasNamespaceAnnotations(expected map[string]string) func(*testing.T, *Templ
 }
 
 func testTemplateData(t *testing.T, tc *testConfig, validators ...func(*testing.T, *TemplateData)) {
+	bootstrapIP := tc.bootstrapIP
+	if bootstrapIP == nil {
+		bootstrapIP = net.ParseIP("10.0.0.1")
+	}
+
 	var errOut io.Writer
 	dir := t.TempDir()
 
@@ -598,6 +597,7 @@ func testTemplateData(t *testing.T, tc *testConfig, validators ...func(*testing.
 		infraConfigFile:                         infraConfigPath,
 		clusterConfigMapFile:                    clusterConfigMapPath,
 		delayedHABootstrapScalingStrategyMarker: tc.delayedHABootstrapScalingStrategyMarker,
+		bootstrapIPLocator:                      &fakeBootstrapIPLocator{ip: bootstrapIP},
 	}
 
 	got, err := newTemplateData(render)


### PR DESCRIPTION
During bootstrap, the rendered etcd-endpoints ConfigMap writes the bootstrap
IP into an annotation.

IPv4 bootstrap IPs render safely either way, but IPv6 addresses can contain
colon sequences such as `::`. When emitted as an unquoted YAML plain scalar,
a value like this can fail YAML parsing:

    alpha.installer.openshift.io/etcd-bootstrap: fd3b:8433:2a9:138::

Quote the rendered annotation value so the bootstrap IP is always treated as
a string. This preserves the rendered value for IPv4 and fixes IPv6 bootstrap
addresses.

Changed:

    alpha.installer.openshift.io/etcd-bootstrap: {{ .BootstrapIP }}

to:

    alpha.installer.openshift.io/etcd-bootstrap: "{{ .BootstrapIP }}"

Tested:

    go test ./pkg/cmd/render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed YAML quoting for the etcd bootstrap configuration so the bootstrap endpoint renders as the intended interpolated value.
* **Tests**
  * Added an IPv6-specific rendering test to validate manifests when an IPv6 bootstrap IP is used.
  * Enhanced the render test setup to use a configurable bootstrap IP and verify the generated ConfigMap contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->