### PR TITLE
NO-JIRA: update build-machinery-go to pull in updated verify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.38.2
 	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250804142706-7b3ab438a292
 	github.com/openshift/api v0.0.0-20260514151338-8ecf6a78d1b0
-	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
+	github.com/openshift/build-machinery-go v0.0.0-20260625204636-d138cd032dd0
 	github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7
 	github.com/openshift/library-go v0.0.0-20260304110309-c56f4c30de58
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/openshift-eng/openshift-tests-extension v0.0.0-20250804142706-7b3ab43
 github.com/openshift-eng/openshift-tests-extension v0.0.0-20250804142706-7b3ab438a292/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
 github.com/openshift/api v0.0.0-20260514151338-8ecf6a78d1b0 h1:m1iFB5kHFUihF14rFCaAV6T8UGsQRia/2upXxb7UhwQ=
 github.com/openshift/api v0.0.0-20260514151338-8ecf6a78d1b0/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
-github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+Sp5GGnjHDhT/a/nQ1xdp43UscBMr7G5wxsYotyhzJ4=
-github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
+github.com/openshift/build-machinery-go v0.0.0-20260625204636-d138cd032dd0 h1:q8HMWZmLIlxScephlS0bd/q0gMNn0h32+Dd7GbpClKU=
+github.com/openshift/build-machinery-go v0.0.0-20260625204636-d138cd032dd0/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7 h1:5GSoQlywIwYsRCw3qN+ZDmN6HrXTMZfI33bdRNm2jRQ=
 github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7/go.mod h1:HhXTUIMhgzxR3Ln/zEkr4QjTL0NN7A+t9Py/we9j2ug=
 github.com/openshift/library-go v0.0.0-20260304110309-c56f4c30de58 h1:3RQXdeYCfbQazMJ/iRr3DL81IGPh/OTN6nGLNsFeRfA=

--- a/vendor/github.com/openshift/build-machinery-go/.gitignore
+++ b/vendor/github.com/openshift/build-machinery-go/.gitignore
@@ -1,1 +1,2 @@
 *.log.raw
+make/examples/golang-versions-check/_output/

--- a/vendor/github.com/openshift/build-machinery-go/OWNERS
+++ b/vendor/github.com/openshift/build-machinery-go/OWNERS
@@ -1,9 +1,9 @@
 reviewers:
+  - control-plane-approvers
   - 2uasimojo
-  - benluddy
   - jsafrane
   - sanchezl
 approvers:
-  - benluddy
+  - control-plane-approvers
   - jsafrane
   - sanchezl

--- a/vendor/github.com/openshift/build-machinery-go/OWNERS_ALIASES
+++ b/vendor/github.com/openshift/build-machinery-go/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+aliases:
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - rh-roman
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan

--- a/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
@@ -60,10 +60,17 @@ ifndef OS_GIT_VERSION
 	OS_GIT_VERSION = $(SOURCE_GIT_TAG)
 endif
 
+# OS_MAJOR_VERSION is populated by ART
+# If building out of the ART pipeline, fallback to '0' and let implementations decide how they handle it
+ifndef OS_MAJOR_VERSION
+	OS_MAJOR_VERSION = "0"
+endif
+
 define version-ldflags
 -X $(1).versionFromGit="$(OS_GIT_VERSION)" \
 -X $(1).commitFromGit="$(SOURCE_GIT_COMMIT)" \
 -X $(1).gitTreeState="$(SOURCE_GIT_TREE_STATE)" \
--X $(1).buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')"
+-X $(1).buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+-X $(1).majorFromGit="$(OS_MAJOR_VERSION)"
 endef
 GO_LD_FLAGS ?=-ldflags "$(call version-ldflags,$(GO_PACKAGE)/pkg/version) $(GO_LD_EXTRAFLAGS)"

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
@@ -9,11 +9,28 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 verify-golang-versions:
 	@if [ -f "$(PERMANENT_TMP)/golang-versions" ]; then \
-		LINES=$$(cat "$(PERMANENT_TMP)/golang-versions" | sort | uniq | wc -l); \
-			if [ $${LINES} -gt 1 ]; then \
+		GOMOD_VER=""; \
+		CI_VER=""; \
+		if [ -f "$(PERMANENT_TMP)/named-golang-versions" ]; then \
+			GOMOD_VER=$$(grep '^go\.mod:' "$(PERMANENT_TMP)/named-golang-versions" | sed 's/go\.mod: *//'); \
+			CI_VER=$$(grep -v '^go\.mod:' "$(PERMANENT_TMP)/named-golang-versions" | sed 's/^[^:]*: *//' | sort | uniq); \
+		fi; \
+		CI_COUNT=$$(echo "$${CI_VER}" | grep -c . 2>/dev/null || :); \
+		if [ "$${CI_COUNT}" -gt 1 ]; then \
 			echo "Golang version mismatch:"; \
 			cat "$(PERMANENT_TMP)/named-golang-versions" | sort | sed 's/^/- /'; \
 			false; \
+		elif [ -n "$${GOMOD_VER}" ] && [ -n "$${CI_VER}" ]; then \
+			GOMOD_MAJOR=$$(echo "$${GOMOD_VER}" | cut -d. -f1); \
+			GOMOD_MINOR=$$(echo "$${GOMOD_VER}" | cut -d. -f2); \
+			CI_MAJOR=$$(echo "$${CI_VER}" | cut -d. -f1); \
+			CI_MINOR=$$(echo "$${CI_VER}" | cut -d. -f2); \
+			if [ "$${GOMOD_MAJOR}" -gt "$${CI_MAJOR}" ] 2>/dev/null || \
+			   { [ "$${GOMOD_MAJOR}" -eq "$${CI_MAJOR}" ] 2>/dev/null && [ "$${GOMOD_MINOR}" -gt "$${CI_MINOR}" ] 2>/dev/null; }; then \
+				echo "Golang version mismatch:"; \
+				cat "$(PERMANENT_TMP)/named-golang-versions" | sort | sed 's/^/- /'; \
+				false; \
+			fi; \
 		fi; \
 	fi
 .PHONY: verify-golang-versions
@@ -24,6 +41,10 @@ define verify-golang-version-reference-internal
 verify-golang-versions-$(1): .empty-golang-versions-files
 verify-golang-versions-$(1):
 	@mkdir -p "$(PERMANENT_TMP)"
+	@if ! echo "$(2)" | grep -qxE '[0-9]+\.[0-9]+'; then \
+		echo "Error: could not extract a valid golang version from $(1) (got '$(2)')"; \
+		false; \
+	fi
 	@echo "$(1): $(2)" >> "$(PERMANENT_TMP)/named-golang-versions"
 	@echo "$(2)" >> "$(PERMANENT_TMP)/golang-versions"
 .PHONY: verify-golang-versions-$(1)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
@@ -8,8 +8,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 YQ_VERSION ?=2.4.0
 YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq-$(YQ_VERSION)
-yq_dir :=$(dir $(YQ))
-
+yq_dir =$(dir $(YQ))
 
 ensure-yq:
 ifeq "" "$(wildcard $(YQ))"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -346,7 +346,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
+# github.com/openshift/build-machinery-go v0.0.0-20260625204636-d138cd032dd0
 ## explicit; go 1.22.0
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
This should allow the verify job from https://github.com/openshift/cluster-etcd-operator/pull/1629 to succeed.

Pulls in https://github.com/openshift/build-machinery-go/pull/119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled dependency to a newer version, which may include internal improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->