### PR TITLE
CNTRLPLANE-2847: render: Resolve featureSet into individual feature gates during bootstrap

### DIFF
--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -803,20 +803,32 @@ func getFeatureGatesStatus(installConfig map[string]any) (sets.Set[configv1.Feat
 	necessaryFeatureGates := []configv1.FeatureGateName{"ShortCertRotation"}
 	disabled.Insert(necessaryFeatureGates...)
 
-	featureGates, found := installConfig["featureGates"]
-	if !found {
-		return enabled, disabled
+	if featureSetRaw, found := installConfig["featureSet"]; found {
+		featureSet := configv1.FeatureSet(featureSetRaw.(string))
+		if resolved := features.FeatureSets(0, features.SelfManaged, featureSet); resolved != nil {
+			for _, fg := range resolved.Enabled {
+				enabled.Insert(fg.FeatureGateAttributes.Name)
+				disabled.Delete(fg.FeatureGateAttributes.Name)
+			}
+			for _, fg := range resolved.Disabled {
+				if !enabled.Has(fg.FeatureGateAttributes.Name) {
+					disabled.Insert(fg.FeatureGateAttributes.Name)
+				}
+			}
+		}
 	}
 
-	for _, featureGate := range featureGates.([]any) {
-		key := strings.Split(featureGate.(string), "=")[0]
-		value := strings.Split(featureGate.(string), "=")[1]
-		if value == "true" {
-			enabled = enabled.Insert(configv1.FeatureGateName(key))
-			disabled = disabled.Delete(configv1.FeatureGateName(key))
-		} else if value == "false" {
-			enabled = enabled.Delete(configv1.FeatureGateName(key))
-			disabled = disabled.Insert(configv1.FeatureGateName(key))
+	if featureGates, found := installConfig["featureGates"]; found {
+		for _, featureGate := range featureGates.([]any) {
+			key := strings.Split(featureGate.(string), "=")[0]
+			value := strings.Split(featureGate.(string), "=")[1]
+			if value == "true" {
+				enabled = enabled.Insert(configv1.FeatureGateName(key))
+				disabled = disabled.Delete(configv1.FeatureGateName(key))
+			} else if value == "false" {
+				enabled = enabled.Delete(configv1.FeatureGateName(key))
+				disabled = disabled.Insert(configv1.FeatureGateName(key))
+			}
 		}
 	}
 

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -349,6 +349,64 @@ data:
           ecdsa:
             curve: P521
 `
+
+	clusterConfigMapWithCustomPKIAndFeatureSet = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-config-v1
+  namespace: kube-system
+data:
+  install-config: |
+    apiVersion: v1
+    baseDomain: gcp.devcluster.openshift.com
+    compute:
+    - architecture: amd64
+      hyperthreading: Enabled
+      name: worker
+      platform: {}
+      replicas: 3
+    controlPlane:
+      architecture: amd64
+      hyperthreading: Enabled
+      name: master
+      platform:
+        gcp:
+          osDisk:
+            DiskSizeGB: 128
+            DiskType: pd-ssd
+          type: n1-standard-4
+          zones:
+          - us-east1-b
+          - us-east1-c
+          - us-east1-d
+      replicas: 3
+    metadata:
+      creationTimestamp: null
+      name: my-cluster
+    networking:
+      clusterNetwork:
+      - cidr: 10.128.0.0/14
+        hostPrefix: 23
+      machineCIDR: 10.0.0.0/16
+      machineNetwork:
+      - cidr: 10.0.0.0/16
+      networkType: OpenShiftSDN
+      serviceNetwork:
+      - 172.30.0.0/16
+    platform:
+      gcp:
+        projectID: openshift
+        region: us-east1
+    publish: External
+    featureSet: TechPreviewNoUpgrade
+    pki:
+      signerCertificates:
+        key:
+          algorithm: ECDSA
+          ecdsa:
+            curve: P521
+`
 )
 
 type testConfig struct {
@@ -602,6 +660,53 @@ func TestTemplateDataWithCustomPKI(t *testing.T) {
 		clusterNetworkConfig: networkConfigIpv4,
 		infraConfig:          infraConfig,
 		clusterConfigMap:     clusterConfigMapWithCustomPKI,
+	}
+
+	testTemplateData(t, config, validateECDSAP521Signer)
+}
+
+func TestTemplateDataWithCustomPKIFeatureSet(t *testing.T) {
+	validateECDSAP521Signer := func(t *testing.T, td *TemplateData) {
+		if len(td.certificates) == 0 {
+			t.Fatal("no certificates generated")
+		}
+
+		var signerCert []byte
+		for _, cert := range td.certificates {
+			if cert.Name == "etcd-signer" {
+				signerCert = cert.Data["tls.crt"]
+				break
+			}
+		}
+
+		if signerCert == nil {
+			t.Fatal("etcd-signer certificate not found in generated certificates")
+		}
+
+		block, _ := pem.Decode(signerCert)
+		if block == nil {
+			t.Fatal("failed to decode PEM block from etcd-signer certificate")
+		}
+
+		x509Cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			t.Fatalf("failed to parse x509 certificate: %v", err)
+		}
+
+		ecdsaKey, ok := x509Cert.PublicKey.(*ecdsa.PublicKey)
+		if !ok {
+			t.Fatalf("expected ECDSA public key, got %T", x509Cert.PublicKey)
+		}
+
+		if ecdsaKey.Curve != elliptic.P521() {
+			t.Errorf("expected P521 curve, got %v", ecdsaKey.Curve.Params().Name)
+		}
+	}
+
+	config := &testConfig{
+		clusterNetworkConfig: networkConfigIpv4,
+		infraConfig:          infraConfig,
+		clusterConfigMap:     clusterConfigMapWithCustomPKIAndFeatureSet,
 	}
 
 	testTemplateData(t, config, validateECDSAP521Signer)
@@ -1020,6 +1125,27 @@ featureGates: [ShortCertRotation=true, UpgradeStatus=foobar]
 			expectedEnabled:  sets.New(features.FeatureShortCertRotation),
 			expectedDisabled: sets.New[configv1.FeatureGateName](),
 		},
+		"featureSet TechPreviewNoUpgrade": {
+			installConfig: `
+apiVersion: v1
+metadata:
+  name: my-cluster
+featureSet: TechPreviewNoUpgrade
+`,
+			expectedEnabled:  techPreviewEnabledGates(),
+			expectedDisabled: techPreviewDisabledGates(),
+		},
+		"featureSet with featureGates override": {
+			installConfig: `
+apiVersion: v1
+metadata:
+  name: my-cluster
+featureSet: TechPreviewNoUpgrade
+featureGates: [ConfigurablePKI=false]
+`,
+			expectedEnabled:  techPreviewEnabledGatesWithout(features.FeatureGateConfigurablePKI),
+			expectedDisabled: techPreviewDisabledGatesWith(features.FeatureGateConfigurablePKI),
+		},
 	}
 
 	for name, test := range tests {
@@ -1196,4 +1322,34 @@ pki:
 			}
 		})
 	}
+}
+
+func techPreviewEnabledGates() sets.Set[configv1.FeatureGateName] {
+	resolved := features.FeatureSets(0, features.SelfManaged, configv1.TechPreviewNoUpgrade)
+	s := sets.New[configv1.FeatureGateName]()
+	for _, fg := range resolved.Enabled {
+		s.Insert(fg.FeatureGateAttributes.Name)
+	}
+	return s
+}
+
+func techPreviewDisabledGates() sets.Set[configv1.FeatureGateName] {
+	resolved := features.FeatureSets(0, features.SelfManaged, configv1.TechPreviewNoUpgrade)
+	s := sets.New[configv1.FeatureGateName]()
+	for _, fg := range resolved.Disabled {
+		s.Insert(fg.FeatureGateAttributes.Name)
+	}
+	return s
+}
+
+func techPreviewEnabledGatesWithout(gates ...configv1.FeatureGateName) sets.Set[configv1.FeatureGateName] {
+	s := techPreviewEnabledGates()
+	s.Delete(gates...)
+	return s
+}
+
+func techPreviewDisabledGatesWith(gates ...configv1.FeatureGateName) sets.Set[configv1.FeatureGateName] {
+	s := techPreviewDisabledGates()
+	s.Insert(gates...)
+	return s
 }


### PR DESCRIPTION
## Summary

  - Fix `getFeatureGatesStatus` to resolve `featureSet` (e.g., `TechPreviewNoUpgrade`) into individual feature gates during bootstrap rendering, so that `ConfigurablePKI` is correctly detected and bootstrap
  etcd-signer certs use the configured key algorithm
  - Add tests for `featureSet` resolution, `featureGates` override on top of `featureSet`, and an end-to-end test that mirrors the real CI install-config structure

  ## Background

  PR #1593 added ConfigurablePKI support to the etcd-operator, threading a `PKIProfileProvider` through both the bootstrap render path and the runtime controller. The installer counterpart
  (openshift/installer#10595) creates a PKI CR at install time with the desired key configuration (e.g., RSA-4096).

  CI job `e2e-aws-ovn-pki-rsa-techpreview` on the installer PR showed the etcd-signer cert was still RSA-2048 instead of the configured RSA-4096. All 7 other signers (managed by kube-apiserver-operator,
  machine-config-operator, etc.) correctly used RSA-4096, confirming the PKI CR was created correctly and the feature gate was active.

  ## Root cause

  The install-config in CI has:

  ```yaml
  featureSet: TechPreviewNoUpgrade
  pki:
    signerCertificates:
      key:
        algorithm: RSA
        rsa:
          keySize: 4096
  ```

  There are no explicit `featureGates` entries — the gates are implied by `featureSet: TechPreviewNoUpgrade`.

  `getFeatureGatesStatus()` in `pkg/cmd/render/render.go` only parsed explicit `featureGates: [Key=Value]` strings. It did not resolve `featureSet` into individual gates. So the enabled set was empty, the
  `ConfigurablePKI` guard was never entered, `pkiProfileProvider` stayed nil, and the bootstrap certs were created with the legacy fallback (`MakeSelfSignedCAConfigForDuration` → RSA-2048).

  At runtime, the operator correctly detected `ConfigurablePKI` from the cluster's FeatureGate CR status, but `needNewSigningCertKeyPair` only checks time-based conditions (expiry, refresh) — it doesn't detect
  key algorithm mismatches. So the already-valid RSA-2048 cert was never regenerated.

  ## Fix

  Use `features.FeatureSets()` from `openshift/api` to resolve the `featureSet` field into its constituent enabled/disabled gates, then layer explicit `featureGates` overrides on top (for `CustomNoUpgrade`
  support). This ensures `ConfigurablePKI` is detected during bootstrap rendering when installed with `featureSet: TechPreviewNoUpgrade`.

  ## Test plan

  - [x] New `Test_getFeatureGates` cases for `featureSet: TechPreviewNoUpgrade` and `featureSet` + `featureGates` override
  - [x] New `TestTemplateDataWithCustomPKIFeatureSet` end-to-end test using `featureSet: TechPreviewNoUpgrade` with PKI config (mirrors real CI install-config)
  - [x] Existing `TestTemplateDataWithCustomPKI` (explicit `featureGates`) still passes
  - [x] `make verify` passes
  - [ ] Re-run `e2e-aws-ovn-pki-rsa-techpreview` on installer PR with this change in the payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature-gate detection now respects the cluster’s feature set, improving how enabled and disabled capabilities are determined.
  * Rendered output now better reflects custom PKI settings when a feature set is configured.

* **Bug Fixes**
  * Fixed an issue where explicit feature-gate settings could be skipped when a feature set was present.
  * Preserved previously determined feature gates instead of dropping them when feature-gate overrides are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->