### PR TITLE
render: Remove install-config feature gate fallback

### DIFF
--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -115,6 +115,12 @@ func (r *renderOpts) Validate() error {
 	if len(r.clusterConfigMapFile) == 0 {
 		return errors.New("missing required flag: --cluster-configmap-file")
 	}
+	if len(r.renderedManifestFiles) == 0 {
+		return errors.New("missing required flag: --rendered-manifest-files")
+	}
+	if len(r.payloadVersion) == 0 {
+		return errors.New("missing required flag: --payload-version")
+	}
 	return nil
 }
 
@@ -285,7 +291,7 @@ func newTemplateData(opts *renderOpts) (*TemplateData, error) {
 			base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(templateData.BootstrapIP)), templateData.BootstrapIP)
 	}
 
-	enabledFeatureGates, disabledFeatureGates, err := opts.getFeatureGates(installConfig)
+	enabledFeatureGates, disabledFeatureGates, err := opts.getFeatureGatesFromManifests()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get feature gates: %w", err)
 	}
@@ -803,26 +809,6 @@ func getBootstrapScalingStrategy(installConfig map[string]any, delayedHAMarkerFi
 	return strategy, nil
 }
 
-// getFeatureGates returns the enabled and disabled feature gate sets.
-//
-// Primary path: when --rendered-manifest-files and --payload-version are
-// provided, reads the pre-resolved FeatureGate CR from rendered manifests.
-// This is the standard operator render pattern used by CKASO and CKCMO.
-//
-// Fallback path: when rendered manifests are not available, resolves
-// feature gates from the install-config's featureSet and featureGates
-// fields directly. This fallback exists for transition until the
-// installer passes the new flags to the etcd-render invocation, and
-// should be removed once openshift/installer carries the change.
-func (r *renderOpts) getFeatureGates(installConfig map[string]any) (sets.Set[configv1.FeatureGateName], sets.Set[configv1.FeatureGateName], error) {
-	if len(r.renderedManifestFiles) > 0 && len(r.payloadVersion) > 0 {
-		return r.getFeatureGatesFromManifests()
-	}
-	klog.Warningf("--rendered-manifest-files or --payload-version not provided, falling back to install-config feature gate parsing")
-	enabled, disabled := getFeatureGatesFromInstallConfig(installConfig)
-	return enabled, disabled, nil
-}
-
 // getFeatureGatesFromManifests reads the FeatureGate CR from pre-rendered
 // manifests and returns enabled/disabled sets.
 func (r *renderOpts) getFeatureGatesFromManifests() (sets.Set[configv1.FeatureGateName], sets.Set[configv1.FeatureGateName], error) {
@@ -893,50 +879,6 @@ func (r *renderOpts) readFeatureGate() (*configv1.FeatureGate, error) {
 		}
 	}
 	return nil, fmt.Errorf("no FeatureGate manifest found in %v", r.renderedManifestFiles)
-}
-
-// getFeatureGatesFromInstallConfig resolves feature gates from the
-// install-config featureSet and featureGates fields. This is the fallback
-// for when rendered manifests are not available.
-// TODO: Remove this fallback once the installer passes --rendered-manifest-files
-// and --payload-version to the etcd-render invocation.
-func getFeatureGatesFromInstallConfig(installConfig map[string]any) (sets.Set[configv1.FeatureGateName], sets.Set[configv1.FeatureGateName]) {
-	enabled := sets.New[configv1.FeatureGateName]()
-	disabled := sets.New[configv1.FeatureGateName]()
-
-	featureSet := configv1.Default
-	if featureSetRaw, found := installConfig["featureSet"]; found {
-		if featureSetStr, ok := featureSetRaw.(string); ok {
-			featureSet = configv1.FeatureSet(featureSetStr)
-		}
-	}
-	if resolved := features.FeatureSets(0, features.SelfManaged, featureSet); resolved != nil {
-		for _, fg := range resolved.Enabled {
-			enabled.Insert(fg.FeatureGateAttributes.Name)
-		}
-		for _, fg := range resolved.Disabled {
-			disabled.Insert(fg.FeatureGateAttributes.Name)
-		}
-	}
-
-	if featureGatesRaw, found := installConfig["featureGates"]; found {
-		for _, entry := range featureGatesRaw.([]any) {
-			key, value, found := strings.Cut(entry.(string), "=")
-			if !found {
-				continue
-			}
-			name := configv1.FeatureGateName(key)
-			if value == "true" {
-				enabled.Insert(name)
-				disabled.Delete(name)
-			} else if value == "false" {
-				enabled.Delete(name)
-				disabled.Insert(name)
-			}
-		}
-	}
-
-	return enabled, disabled
 }
 
 // getPKIProfileProvider extracts PKI configuration from install-config and returns a PKI profile provider.

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -1032,57 +1032,6 @@ func Test_preferIPv6(t *testing.T) {
 	}
 }
 
-func Test_getFeatureGatesFromInstallConfig(t *testing.T) {
-	testCases := map[string]struct {
-		installConfig         string
-		expectConfigurablePKI bool
-	}{
-		"featureSet TechPreviewNoUpgrade enables ConfigurablePKI": {
-			installConfig: `
-apiVersion: v1
-metadata:
-  name: my-cluster
-featureSet: TechPreviewNoUpgrade
-`,
-			expectConfigurablePKI: true,
-		},
-		"default featureSet does not enable ConfigurablePKI": {
-			installConfig: `
-apiVersion: v1
-metadata:
-  name: my-cluster
-`,
-			expectConfigurablePKI: false,
-		},
-		"featureGates override disables ConfigurablePKI even with TechPreview": {
-			installConfig: `
-apiVersion: v1
-metadata:
-  name: my-cluster
-featureSet: TechPreviewNoUpgrade
-featureGates: [ConfigurablePKI=false]
-`,
-			expectConfigurablePKI: false,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var installConfig map[string]any
-			if err := yaml.Unmarshal([]byte(tc.installConfig), &installConfig); err != nil {
-				t.Fatal(err)
-			}
-			enabled, disabled := getFeatureGatesFromInstallConfig(installConfig)
-			if got := enabled.Has(features.FeatureGateConfigurablePKI); got != tc.expectConfigurablePKI {
-				t.Errorf("ConfigurablePKI enabled: want %v, got %v", tc.expectConfigurablePKI, got)
-			}
-			if enabled.Len()+disabled.Len() == 0 {
-				t.Errorf("expected non-empty feature gate sets for any install-config, got empty enabled and disabled sets")
-			}
-		})
-	}
-}
-
 func Test_getPKIProfileProvider(t *testing.T) {
 	tests := map[string]struct {
 		installConfig      string


### PR DESCRIPTION
## Summary

Remove the install-config feature gate parsing fallback now that [openshift/installer#10679](https://github.com/openshift/installer/pull/10679) passes `--rendered-manifest-files` and `--payload-version` to the etcd-render invocation.

This makes both flags required and removes `getFeatureGatesFromInstallConfig()` and the `getFeatureGates()` dispatcher, leaving only the standard FeatureGate CR path via `getFeatureGatesFromManifests()`.

## Depends on

- ~[#1648](https://github.com/openshift/cluster-etcd-operator/pull/1648) — render: Read FeatureGate CR from rendered manifests~ (merged)
- [openshift/installer#10679](https://github.com/openshift/installer/pull/10679) — bootstrap: Pass rendered manifests and payload version to etcd render

This PR should merge after the installer dependency has landed.

## Test plan

- [x] `go test ./pkg/cmd/render/` — all tests pass
- [x] `go vet ./pkg/cmd/render/` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line options to supply rendered manifest locations and the payload version.
  * Feature gate enablement is now derived from `FeatureGate` manifests included in rendered outputs.
* **Bug Fixes**
  * Rendering now reads `FeatureGate` resources directly (from either files or directories) and validates that feature-gate data can be determined.
  * Rendering fails early when required feature-gate information is missing or cannot be derived.
* **Tests**
  * Updated renderer/template tests to generate and consume payload-versioned `FeatureGate` manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->