### PR TITLE
OCPEDGE-2790: Fix TNF upgrade deadlock

### DIFF
--- a/pkg/tnf/operator/nodehandler.go
+++ b/pkg/tnf/operator/nodehandler.go
@@ -269,7 +269,7 @@ func updateSetup(
 	}
 	// wait for completion
 	for _, node := range nodeList {
-		err := jobs.WaitForCompletion(ctx, kubeClient, tools.JobTypeUpdateSetup.GetJobName(&node.Name), operatorclient.TargetNamespace, tools.SetupJobCompletedTimeout)
+		err := jobs.WaitForCompletion(ctx, kubeClient, tools.JobTypeUpdateSetup.GetJobName(&node.Name), operatorclient.TargetNamespace, tools.UpdateSetupJobCompletedTimeout)
 		if err != nil {
 			return fmt.Errorf("failed to wait for update setup job on node %s to complete: %w", node.GetName(), err)
 		}

--- a/pkg/tnf/pkg/pcs/alerts.go
+++ b/pkg/tnf/pkg/pcs/alerts.go
@@ -7,10 +7,17 @@ import (
 	"fmt"
 	osexec "os/exec"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/exec"
+	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/tools"
 )
+
+// ErrAlertScriptNotPresent indicates the alert script has not yet been delivered
+// to the host by MCO. Callers can check for this with errors.Is to distinguish
+// it from other, unexpected failures.
+var ErrAlertScriptNotPresent = errors.New("alert script not yet present")
 
 type alertConfig struct {
 	id        string
@@ -49,13 +56,55 @@ func ConfigureAlerts(ctx context.Context) error {
 	return nil
 }
 
+// AllAlertsConfigured returns true if every known pacemaker alert agent is
+// already registered in the CIB.
+func AllAlertsConfigured(ctx context.Context) (bool, error) {
+	for _, ac := range alertConfigs {
+		exists, err := alertExists(ctx, ac.id)
+		if err != nil {
+			return false, fmt.Errorf("failed to check existing alert %q: %w", ac.id, err)
+		}
+		if !exists {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// ConfigureAlertsWithRetry ensures the pacemaker alert agents are registered,
+// tolerating the alert scripts not yet being present on-node (they are delivered
+// asynchronously by MCO, which can lag behind an
+// etcd-operator upgrade). It skips entirely if the alerts are already configured,
+// and otherwise polls until they can be configured or the timeout is reached.
+func ConfigureAlertsWithRetry(ctx context.Context) error {
+	alreadyConfigured, err := AllAlertsConfigured(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check existing alert configuration: %w", err)
+	}
+	if alreadyConfigured {
+		klog.Info("Pacemaker alert agents are already configured, skipping registration")
+		return nil
+	}
+
+	return wait.PollUntilContextTimeout(ctx, tools.JobPollInterval, tools.AlertConfigurationTimeout, true, func(ctx context.Context) (bool, error) {
+		if err := ConfigureAlerts(ctx); err != nil {
+			if errors.Is(err, ErrAlertScriptNotPresent) {
+				klog.Warningf("Pacemaker alert agent configuration not yet possible, will retry: %v", err)
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
 func configureAlert(ctx context.Context, ac alertConfig) error {
 	scriptPresent, err := fileExistsOnHost(ctx, ac.path)
 	if err != nil {
 		return fmt.Errorf("failed to check for alert script %s: %w", ac.path, err)
 	}
 	if !scriptPresent {
-		return fmt.Errorf("alert script %s not yet present (MCO rollout pending), will retry", ac.path)
+		return fmt.Errorf("%w: %s (MCO rollout pending)", ErrAlertScriptNotPresent, ac.path)
 	}
 
 	exists, err := alertExists(ctx, ac.id)

--- a/pkg/tnf/pkg/tools/jobs.go
+++ b/pkg/tnf/pkg/tools/jobs.go
@@ -14,12 +14,12 @@ import (
 // setup job: waits for auth jobs to complete
 // after setup jobs: waits for setup job to complete
 const (
-	JobPollInterval               = 15 * time.Second
-	AuthJobCompletedTimeout       = 10 * time.Minute
-	SetupJobCompletedTimeout      = 20 * time.Minute
-	AfterSetupJobCompletedTimeout = 5 * time.Minute
-	AllCompletedTimeout           = 30 * time.Minute
-	FencingJobCompletedTimeout    = 25 * time.Minute
+	JobPollInterval                = 15 * time.Second
+	AuthJobCompletedTimeout        = 10 * time.Minute
+	SetupJobCompletedTimeout       = 20 * time.Minute
+	AfterSetupJobCompletedTimeout  = 5 * time.Minute
+	AllCompletedTimeout            = 30 * time.Minute
+	FencingJobCompletedTimeout     = 25 * time.Minute
 	AlertConfigurationTimeout      = 60 * time.Minute
 	UpdateSetupJobCompletedTimeout = 65 * time.Minute
 )

--- a/pkg/tnf/pkg/tools/jobs.go
+++ b/pkg/tnf/pkg/tools/jobs.go
@@ -20,6 +20,8 @@ const (
 	AfterSetupJobCompletedTimeout = 5 * time.Minute
 	AllCompletedTimeout           = 30 * time.Minute
 	FencingJobCompletedTimeout    = 25 * time.Minute
+	AlertConfigurationTimeout      = 60 * time.Minute
+	UpdateSetupJobCompletedTimeout = 65 * time.Minute
 )
 
 // JobType represent the different jobs we run, with some methods needed

--- a/pkg/tnf/setup/runner.go
+++ b/pkg/tnf/setup/runner.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -105,10 +106,15 @@ func RunTnfSetup() error {
 		return err
 	}
 
-	// register pacemaker alert agents for fencing taint/untaint
-	err = pcs.ConfigureAlerts(ctx)
-	if err != nil {
-		return err
+	// Register pacemaker alert agents for fencing taint/untaint.
+	// Tolerate the scripts not being present yet, they are delivered by
+	// MCO which may not have rolled out at this point
+	if err := pcs.ConfigureAlerts(ctx); err != nil {
+		if errors.Is(err, pcs.ErrAlertScriptNotPresent) {
+			klog.Warningf("Deferring pacemaker alert agent configuration: %v", err)
+		} else {
+			return err
+		}
 	}
 
 	// Etcd handover

--- a/pkg/tnf/update-setup/runner.go
+++ b/pkg/tnf/update-setup/runner.go
@@ -68,6 +68,15 @@ func RunTnfUpdateSetup() error {
 		return nil
 	}
 
+	// Register pacemaker alert agents for fencing taint/untaint. This runs on
+	// every invocation (i.e. on every CEO reconcile once TNF is set up,
+	// including upgrades), independent of whether a node is being replaced,
+	// because the alert scripts may only become available well after this job
+	// first starts running.
+	if err := pcs.ConfigureAlertsWithRetry(ctx); err != nil {
+		return err
+	}
+
 	// Get current cluster config from Kubernetes
 	cfg, err := config.GetClusterConfig(ctx, kubeClient)
 	if err != nil {
@@ -129,12 +138,6 @@ func RunTnfUpdateSetup() error {
 	err = pcs.ConfigureFencing(ctx, kubeClient, []string{otherNodeName, currentNodeName})
 	if err != nil {
 		klog.Error(err, "Failed to configure fencing, skipping update of etcd! Restart update-setup job when fencing config is fixed!")
-		return err
-	}
-
-	// register pacemaker alert agents for fencing taint/untaint
-	err = pcs.ConfigureAlerts(ctx)
-	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when Pacemaker alert scripts are not yet present by treating this as a recoverable condition during setup and update setup.
  - Added polling-based alert configuration during update setup, retrying until complete or timing out.
  - Detects already-configured alerts and skips reconfiguration to reduce unnecessary work.
  - Re-running update setup now uses an extended per-node completion timeout for already-initialized environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->