### PR TITLE
OCPBUGS-94106: Add APIServer informer to EnvVarController cache sync

### DIFF
--- a/pkg/etcdenvvar/envvarcontroller.go
+++ b/pkg/etcdenvvar/envvarcontroller.go
@@ -76,6 +76,7 @@ func NewEnvVarController(
 	masterNodeLabelSelector labels.Selector,
 	infrastructureInformer configv1informers.InfrastructureInformer,
 	networkInformer configv1informers.NetworkInformer,
+	apiServerInformer configv1informers.APIServerInformer,
 	eventRecorder events.Recorder,
 	etcdsInformer operatorv1informers.EtcdInformer,
 	featureGateAccessor featuregates.FeatureGateAccess,
@@ -97,6 +98,12 @@ func NewEnvVarController(
 			operatorClient.Informer().HasSynced,
 			infrastructureInformer.Informer().HasSynced,
 			networkInformer.Informer().HasSynced,
+			// The EnvVarController reads cipher suites from observedConfig, which is
+			// populated by the ConfigObserver watching the APIServer CR. Waiting for
+			// the APIServer informer cache to sync ensures the ConfigObserver can run
+			// before the EnvVarController reads observedConfig, preventing bootstrap
+			// timing races where observedConfig is still empty.
+			apiServerInformer.Informer().HasSynced,
 			kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Informer().HasSynced,
 			kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Informer().HasSynced,
 			kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer().HasSynced,
@@ -114,6 +121,7 @@ func NewEnvVarController(
 	kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	etcdsInformer.Informer().AddEventHandler(c.eventHandler())
 	masterNodeInformer.AddEventHandler(c.eventHandler())
+	apiServerInformer.Informer().AddEventHandler(c.eventHandler())
 
 	return c
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -271,6 +271,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controlPlaneNodeLabelSelector,
 		configInformers.Config().V1().Infrastructures(),
 		networkInformer,
+		configInformers.Config().V1().APIServers(),
 		controllerContext.EventRecorder,
 		etcdsInformer,
 		featureGateAccessor,


### PR DESCRIPTION
The EnvVarController reads cipher suites from observedConfig, which is populated by the ConfigObserver watching the APIServer CR. Without waiting for the APIServer informer cache to sync, the EnvVarController can race ahead and read empty observedConfig before the ConfigObserver has run.

Adding the APIServer informer to the EnvVarController's cachesToSync ensures the controller waits for the APIServer informer to complete its initial LIST before running sync(). This narrows the bootstrap timing race that causes intermittent "no supported cipherSuites found" errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable reconciliation during startup by ensuring API server configuration is fully synchronized before processing.
  * Environment variable updates now respond to relevant API server configuration changes.
  * Prevented potential timing-related issues that could result in incomplete or empty observed configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->