### PR TITLE
OCPBUGS-100294: fix TNFNodeInMaintenance PromQL label mismatch

### DIFF
--- a/jsonnet/tnf-alerts.libsonnet
+++ b/jsonnet/tnf-alerts.libsonnet
@@ -86,7 +86,7 @@
           },
           {
             alert: 'TNFNodeInMaintenance',
-            expr: 'tnf_node_in_service == 0 and tnf_cluster_in_service == 1',
+            expr: 'tnf_node_in_service == 0 and on() tnf_cluster_in_service == 1',
             'for': '2m',
             labels: {
               severity: 'warning',

--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -274,7 +274,7 @@ spec:
         description: TNF node {{ $labels.node }} has been placed into maintenance mode. Resources on this node will not be managed by Pacemaker until maintenance mode is cleared.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/TNFNodeInMaintenance.md
         summary: TNF node {{ $labels.node }} is in maintenance mode.
-      expr: tnf_node_in_service == 0 and tnf_cluster_in_service == 1
+      expr: tnf_node_in_service == 0 and on() tnf_cluster_in_service == 1
       for: 2m
       labels:
         severity: warning

--- a/pkg/tnf/pkg/pacemaker/prometheusrule_test.go
+++ b/pkg/tnf/pkg/pacemaker/prometheusrule_test.go
@@ -67,7 +67,7 @@ var expectedAlerts = []expectedAlert{
 	{"TNFNodeFencingUnavailable", "tnf_node_fencing_available == 0", "5m", "critical"},
 	{"TNFNodeFencingDegraded", "tnf_node_fencing_healthy == 0 and tnf_node_fencing_available == 1 and on(node) tnf_node_in_service == 1", "10m", "warning"},
 	{"TNFNodeUnclean", "tnf_node_clean == 0", "5m", "critical"},
-	{"TNFNodeInMaintenance", "tnf_node_in_service == 0 and tnf_cluster_in_service == 1", "2m", "warning"},
+	{"TNFNodeInMaintenance", "tnf_node_in_service == 0 and on() tnf_cluster_in_service == 1", "2m", "warning"},
 	{"TNFNodeStandby", "tnf_node_active == 0", "5m", "warning"},
 	{"TNFResourceStopped", "tnf_resource_started == 0 and on(node) tnf_node_active == 1", "5m", "critical"},
 	{"TNFResourceFailed", "tnf_resource_operational == 0 and on(node) tnf_node_active == 1", "2m", "critical"},


### PR DESCRIPTION
## Summary

The `TNFNodeInMaintenance` alert never fires because of a PromQL label mismatch in the `and` operator.

`tnf_node_in_service` has a `node` label, `tnf_cluster_in_service` does not. PromQL's `and` requires matching label sets, so the expression silently returns empty.

**Fix:** Add `on()` to ignore labels when joining: `and` → `and on()`.

This is the only affected alert — all other cross-metric `and` expressions correctly use `on(node)`.

## Verification

Tested side-by-side on a live TNF cluster (OCP 5.0 nightly):
- Buggy expression (`and`): returns empty — alert never fires
- Fixed expression (`and on()`): correctly returns `{node="master-1"}`
- Deployed a separate PrometheusRule with the fixed expression — alert fired within 2 minutes

## JIRA

[OCPEDGE-2848](https://redhat.atlassian.net/browse/OCPEDGE-2848)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of the node maintenance alert by matching cluster service state with the correct label alignment.
  * Updated the related monitoring rule logic for `TNFNodeInMaintenance` while keeping the same alert intent and thresholds.
* **Tests**
  * Refreshed the expected alert data to reflect the updated rule formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->