### PR TITLE
CNTRLPLANE-3403: reduce default snapshot-count to 5000

### DIFF
--- a/bindata/etcd/pod.gotpl.yaml
+++ b/bindata/etcd/pod.gotpl.yaml
@@ -171,6 +171,7 @@ spec:
           --logger=zap \
           --log-level={{.LogLevel}} \
           --feature-gates=InitialCorruptCheck=true \
+          --snapshot-count={{.SnapshotCount}} \
           --initial-advertise-peer-urls=https://${NODE_NODE_ENVVAR_NAME_IP}:2380 \
           --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.crt \
           --key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-certs/etcd-serving-NODE_NAME.key \

--- a/pkg/operator/ceohelpers/podsubstitution.go
+++ b/pkg/operator/ceohelpers/podsubstitution.go
@@ -31,6 +31,7 @@ type PodSubstitutionTemplate struct {
 	ListenAddress       string
 	LocalhostAddress    string
 	LogLevel            string
+	SnapshotCount       uint64
 	EnvVars             []NameValue
 	BackupArgs          []string
 	CipherSuites        string
@@ -115,6 +116,7 @@ func GetPodSubstitution(
 		ListenAddress:       "0.0.0.0",   // TODO: this needs updating to detect ipv6-ness
 		LocalhostAddress:    "127.0.0.1", // TODO: this needs updating to detect ipv6-ness
 		LogLevel:            LoglevelToZap(operatorSpec.LogLevel),
+		SnapshotCount:       5000,
 		EnvVars:             nameValues,
 		CipherSuites:        envVarMap["ETCD_CIPHER_SUITES"],
 		EnableEtcdContainer: !shouldRemoveEtcdContainer,


### PR DESCRIPTION
With this PR we reduce the default `--snapshot-count` from 10000 to 5000.

The value was selected after evaluating all five snapshot-count values across the full supported quota range (8–16 GiB) — full dataset and analysis in [CNTRLPLANE-3403](https://redhat.atlassian.net/browse/CNTRLPLANE-3403).
snapshot-count=5000 represents a good balance between WAL latency and memory peaks across all tested configurations, with particular benefit for clusters configured with quota sizes above the default 8 GiB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added configurable etcd snapshot scheduling to improve data durability and recovery behavior.
  * Configured etcd to create snapshots after a defined number of operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->