### PR TITLE
NO-JIRA: add ceo disruptive suite to sippy's disruptive

### DIFF
--- a/cmd/cluster-etcd-operator-tests-ext/main.go
+++ b/cmd/cluster-etcd-operator-tests-ext/main.go
@@ -68,6 +68,7 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 	// Tests tagged with [Serial] [Disruptive] are included in this suite.
 	extension.AddSuite(oteextension.Suite{
 		Name:        "openshift/cluster-etcd-operator/operator/disruptive",
+		Parents:     []string{"openshift/disruptive-longrunning"},
 		Parallelism: 1,
 		Qualifiers: []string{
 			`name.contains("[Disruptive]") && name.contains("[Serial]")`,


### PR DESCRIPTION
Add the CEO's disruptive suite to the disruptive-longrunning so sippy will pick it up and give us signal for https://github.com/openshift/api/pull/2946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the disruptive Cluster Etcd Operator test suite classification to run under the disruptive long-running test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->