### PR TITLE
OCPBUGS-105357: Fix TNF fencing skip for IPv6 bracketed stonith IPs.

### DIFF
--- a/pkg/tnf/pkg/pcs/fencing.go
+++ b/pkg/tnf/pkg/pcs/fencing.go
@@ -263,7 +263,10 @@ func canFencingConfigBeSkipped(fc fencingConfig, stonithConfig StonithConfig) bo
 			for option, value := range fc.FencingDeviceOptions {
 				switch option {
 				case Ip:
-					if nvPairNeedsUpdate(nvPairs, "ip", value) {
+					// Compare against GetParsedIP(): stonith create/update stores IPv6
+					// addresses bracketed (e.g. "[fd2e::1]"), while FencingDeviceOptions[Ip]
+					// keeps the unbracketed form from the fencing secret.
+					if nvPairNeedsUpdate(nvPairs, "ip", fc.GetParsedIP()) {
 						klog.V(1).Info("ip needs update")
 						return false
 					}

--- a/pkg/tnf/pkg/pcs/fencing_test.go
+++ b/pkg/tnf/pkg/pcs/fencing_test.go
@@ -753,6 +753,126 @@ func TestCanFencingConfigBeSkipped(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			// Regression: pcs stores IPv6 as "[addr]" via GetParsedIP(), but the
+			// fencing secret keeps the unbracketed form. Skip must treat them as equal
+			// or every tnf-setup retry re-runs stonith update --wait and times out.
+			name: "can be skipped with ipv6 bracketed cib ip",
+			fc: fencingConfig{
+				NodeName:          "node1",
+				FencingID:         "node1_redfish",
+				FencingDeviceType: "fence_redfish",
+				FencingDeviceOptions: map[fencingOption]string{
+					Username:    "admin",
+					Password:    "pass123",
+					Ip:          "fd2e:6f44:5dd8:c956::1",
+					IpPort:      "8000",
+					SystemsUri:  "redfish/v1/Systems/abc",
+					SslInsecure: "",
+				},
+			},
+			sc: StonithConfig{
+				Primitives: []Primitive{
+					{
+						Id: "node1_redfish",
+						AgentName: AgentName{
+							Type: "fence_redfish",
+						},
+						InstanceAttributes: []InstanceAttributes{
+							{
+								NvPairs: []NvPair{
+									{
+										Name:  "username",
+										Value: "admin",
+									},
+									{
+										Name:  "password",
+										Value: "pass123",
+									},
+									{
+										Name:  "ip",
+										Value: "[fd2e:6f44:5dd8:c956::1]",
+									},
+									{
+										Name:  "ipport",
+										Value: "8000",
+									},
+									{
+										Name:  "systems_uri",
+										Value: "redfish/v1/Systems/abc",
+									},
+									{
+										Name:  "pcmk_host_list",
+										Value: "node1",
+									},
+									{
+										Name:  "ssl_insecure",
+										Value: "1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "needs update for different ipv6 address",
+			fc: fencingConfig{
+				NodeName:          "node1",
+				FencingID:         "node1_redfish",
+				FencingDeviceType: "fence_redfish",
+				FencingDeviceOptions: map[fencingOption]string{
+					Username:   "admin",
+					Password:   "pass123",
+					Ip:         "fd2e:6f44:5dd8:c956::2",
+					IpPort:     "8000",
+					SystemsUri: "redfish/v1/Systems/abc",
+				},
+			},
+			sc: StonithConfig{
+				Primitives: []Primitive{
+					{
+						Id: "node1_redfish",
+						AgentName: AgentName{
+							Type: "fence_redfish",
+						},
+						InstanceAttributes: []InstanceAttributes{
+							{
+								NvPairs: []NvPair{
+									{
+										Name:  "username",
+										Value: "admin",
+									},
+									{
+										Name:  "password",
+										Value: "pass123",
+									},
+									{
+										Name:  "ip",
+										Value: "[fd2e:6f44:5dd8:c956::1]",
+									},
+									{
+										Name:  "ipport",
+										Value: "8000",
+									},
+									{
+										Name:  "systems_uri",
+										Value: "redfish/v1/Systems/abc",
+									},
+									{
+										Name:  "pcmk_host_list",
+										Value: "node1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
canFencingConfigBeSkipped compared the unbracketed secret IP to the bracketed value pcs stores after GetParsedIP(), so every tnf-setup retry re-ran stonith update --wait and timed out on IPv6 clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv6 fencing configuration handling by recognizing equivalent bracketed and unbracketed address formats.
  * Prevented unnecessary fencing configuration updates when the stored IPv6 address already matches.

* **Tests**
  * Added regression coverage for matching and differing IPv6 fencing addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->