### PR TITLE
OCPBUGS-105357: Adapt TNF pcs setup for pcs 0.12 stderr and CLI changes.

### DIFF
--- a/bindata/etcd/update-fencing-credentials.sh
+++ b/bindata/etcd/update-fencing-credentials.sh
@@ -225,20 +225,31 @@ echo "Pre-flight validation passed: new credentials are valid"
 
 echo "Updating stonith device ${DEVICE_ID}"
 # matches getStonithCommand() format from fencing.go
-STDERR=$(/usr/sbin/pcs stonith update "${DEVICE_ID}" \
+# pcs 0.12 deprecated --wait; create/update then verify with status query.
+if ! STDERR=$(/usr/sbin/pcs stonith update "${DEVICE_ID}" \
     username="${USERNAME}" \
     password="${PASSWORD}" \
     ip="${REDFISH_IP}" \
     ipport="${REDFISH_PORT}" \
     systems_uri="${REDFISH_PATH}" \
-    ssl_insecure="${SSL_INSECURE_VAL}" \
-    --wait=120 2>&1 > /dev/null) || true
-
-# stderr must contain "is running"
-if [[ "${STDERR}" != *"is running"* ]]; then
+    ssl_insecure="${SSL_INSECURE_VAL}" 2>&1); then
     echo "Failed to update stonith device ${DEVICE_ID}: $(echo "${STDERR}" | redact_credentials)"
     exit 1
 fi
+
+# Poll the specific stonith resource so unrelated pending actions do not block us.
+deadline=$((SECONDS + 120))
+while true; do
+    if QUERY_OUT=$(/usr/sbin/pcs status query resource "${DEVICE_ID}" is-state started 2>/dev/null) \
+        && [[ "${QUERY_OUT}" == *[Tt]rue* ]]; then
+        break
+    fi
+    if (( SECONDS >= deadline )); then
+        echo "Timed out waiting for stonith device ${DEVICE_ID} to reach started state"
+        exit 1
+    fi
+    sleep 2
+done
 echo "Stonith device ${DEVICE_ID} updated successfully"
 
 echo "Updating secret ${SECRET_NAME} in namespace ${NAMESPACE}"

--- a/pkg/tnf/pkg/pcs/cluster.go
+++ b/pkg/tnf/pkg/pcs/cluster.go
@@ -36,7 +36,8 @@ func ConfigureCluster(ctx context.Context, cfg config.ClusterConfig) (bool, erro
 		// Note: `migration-threshold=60` caps Pacemaker start failures before the resource is treated as blocked (60 retries).
 		// Note: `op start start-delay=15s` waits 15s before each start attempt so dependencies (e.g. resolv prepender) can settle; fast-fail ExecConditions still return quickly.
 		// Note: `op start timeout=180s` bounds how long a single start may run; it does not add delay between retries (that is start-delay).
-		"/usr/sbin/pcs resource create kubelet systemd:kubelet op start timeout=180s start-delay=15s clone meta interleave=true migration-threshold=60",
+		// Use `clone meta ... --future` so clone meta lands on the clone under pcs 0.11.6+/0.12 (rhbz#2168155).
+		"/usr/sbin/pcs resource create kubelet systemd:kubelet op start timeout=180s start-delay=15s clone meta interleave=true migration-threshold=60 --future",
 		"/usr/sbin/pcs cluster enable --all",
 		"/usr/sbin/pcs cluster sync",
 		"/usr/sbin/pcs cluster reload corosync",

--- a/pkg/tnf/pkg/pcs/etcd.go
+++ b/pkg/tnf/pkg/pcs/etcd.go
@@ -29,7 +29,10 @@ func ConfigureEtcd(ctx context.Context, cfg config.ClusterConfig) error {
 		// We raise this from the previous low value so that, together with a planned podman-etcd change to pace retries on
 		// missing-precondition / fast-fail starts (e.g. ~15s between failed attempts), the cluster has on the order of
 		// 60 × 15s ≈ 15 minutes of start attempts before etcd is considered blocked—not a few seconds of burst failures.
-		cmd := fmt.Sprintf("/usr/sbin/pcs resource create etcd ocf:heartbeat:podman-etcd node_ip_map=\"%s:%s;%s:%s\" drop_in_dependency=true clone interleave=true notify=true meta migration-threshold=60",
+		//
+		// Use `clone meta ... --future` so clone meta attributes (interleave/notify/migration-threshold) apply to the
+		// clone under pcs 0.11.6+/0.12 parsing (rhbz#2168155), not the base resource.
+		cmd := fmt.Sprintf("/usr/sbin/pcs resource create etcd ocf:heartbeat:podman-etcd node_ip_map=\"%s:%s;%s:%s\" drop_in_dependency=true clone meta interleave=true notify=true migration-threshold=60 --future",
 			cfg.NodeName1, cfg.NodeIP1, cfg.NodeName2, cfg.NodeIP2)
 		stdOut, stdErr, err = exec.Execute(ctx, cmd)
 		if err != nil {

--- a/pkg/tnf/pkg/pcs/fencing.go
+++ b/pkg/tnf/pkg/pcs/fencing.go
@@ -122,13 +122,16 @@ func ConfigureFencing(ctx context.Context, kubeClient kubernetes.Interface, node
 		}
 		klog.Info(fmt.Sprintf("Fencing credentials for node %s are valid, status command returned %q", fc.NodeName, stdOut))
 
-		// configure stonith devices
+		// configure stonith devices (no --wait; pcs 0.12 deprecated it in favor of status wait/query)
 		klog.Infof("Configuring pacemaker fencing for node %s", fc.NodeName)
 		cmd := getStonithCommand(stonithConfig, fc)
-		_, stdErr, err = exec.Execute(ctx, cmd)
-		// we use --wait in the stonith create / update command, which makes stdErr to contain "is running" in case the device successfully started
-		if err != nil || !strings.Contains(stdErr, "is running") {
-			klog.Error(err, "Failed to configure stonith device", "node", fc.NodeName, "stderr", stdErr)
+		stdOut, stdErr, err = exec.Execute(ctx, cmd)
+		if err != nil {
+			klog.Error(err, "Failed to configure stonith device", "node", fc.NodeName, "stdout", tools.RedactPasswords(stdOut), "stderr", tools.RedactPasswords(stdErr))
+			return fmt.Errorf("failed to configure pacemaker fencing for node %s: %v", fc.NodeName, err)
+		}
+		if err := WaitForResourceStarted(ctx, fc.FencingID, DefaultResourceWaitTimeout); err != nil {
+			klog.Error(err, "Stonith device did not reach started state", "node", fc.NodeName)
 			return fmt.Errorf("failed to configure pacemaker fencing for node %s: %v", fc.NodeName, err)
 		}
 		klog.Info(fmt.Sprintf("Pacemaker fencing for node %s configured", fc.NodeName))
@@ -245,9 +248,6 @@ func getStonithCommand(sc StonithConfig, fc fencingConfig) string {
 	} else {
 		cmd += ` ssl_insecure="0"`
 	}
-
-	// wait for command execution, so we can check if the device is running
-	cmd += " --wait=120"
 
 	return cmd
 }

--- a/pkg/tnf/pkg/pcs/fencing_test.go
+++ b/pkg/tnf/pkg/pcs/fencing_test.go
@@ -272,7 +272,7 @@ func TestGetStonithCommand(t *testing.T) {
 					SystemsUri: "redfish/v1/Systems/abc",
 				},
 			},
-			want: `/usr/sbin/pcs stonith create node1_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.1" ipport="8000" systems_uri="redfish/v1/Systems/abc" pcmk_host_list="node1" pcmk_delay_base="" ssl_insecure="0" --wait=120`,
+			want: `/usr/sbin/pcs stonith create node1_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.1" ipport="8000" systems_uri="redfish/v1/Systems/abc" pcmk_host_list="node1" pcmk_delay_base="" ssl_insecure="0"`,
 		},
 		{
 			name: "stonith command with ssl_insecure",
@@ -289,7 +289,7 @@ func TestGetStonithCommand(t *testing.T) {
 					SslInsecure: "",
 				},
 			},
-			want: `/usr/sbin/pcs stonith create node2_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.2" ipport="8000" systems_uri="redfish/v1/Systems/def" pcmk_host_list="node2" pcmk_delay_base="" ssl_insecure="1" --wait=120`,
+			want: `/usr/sbin/pcs stonith create node2_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.2" ipport="8000" systems_uri="redfish/v1/Systems/def" pcmk_host_list="node2" pcmk_delay_base="" ssl_insecure="1"`,
 		},
 		{
 			name: "stonith command with ipv6",
@@ -306,7 +306,7 @@ func TestGetStonithCommand(t *testing.T) {
 					SslInsecure: "",
 				},
 			},
-			want: `/usr/sbin/pcs stonith create node2_redfish fence_redfish username="admin" password="pass123" ip="[1234:1234:1234::1234]" ipport="8000" systems_uri="redfish/v1/Systems/def" pcmk_host_list="node2" pcmk_delay_base="" ssl_insecure="1" --wait=120`,
+			want: `/usr/sbin/pcs stonith create node2_redfish fence_redfish username="admin" password="pass123" ip="[1234:1234:1234::1234]" ipport="8000" systems_uri="redfish/v1/Systems/def" pcmk_host_list="node2" pcmk_delay_base="" ssl_insecure="1"`,
 		},
 		{
 			name: "stonith command with pcmk_delay_base",
@@ -323,7 +323,7 @@ func TestGetStonithCommand(t *testing.T) {
 					PcmkDelayBase: "10s",
 				},
 			},
-			want: `/usr/sbin/pcs stonith create node1_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.1" ipport="8000" systems_uri="redfish/v1/Systems/abc" pcmk_host_list="node1" pcmk_delay_base="10s" ssl_insecure="0" --wait=120`,
+			want: `/usr/sbin/pcs stonith create node1_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.1" ipport="8000" systems_uri="redfish/v1/Systems/abc" pcmk_host_list="node1" pcmk_delay_base="10s" ssl_insecure="0"`,
 		},
 		{
 			name: "stonith command with both ssl_insecure and pcmk_delay_base",
@@ -341,7 +341,7 @@ func TestGetStonithCommand(t *testing.T) {
 					PcmkDelayBase: "10s",
 				},
 			},
-			want: `/usr/sbin/pcs stonith create node3_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.3" ipport="8000" systems_uri="redfish/v1/Systems/ghi" pcmk_host_list="node3" pcmk_delay_base="10s" ssl_insecure="1" --wait=120`,
+			want: `/usr/sbin/pcs stonith create node3_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.3" ipport="8000" systems_uri="redfish/v1/Systems/ghi" pcmk_host_list="node3" pcmk_delay_base="10s" ssl_insecure="1"`,
 		},
 		{
 			name: "stonith command with existing device",
@@ -363,7 +363,7 @@ func TestGetStonithCommand(t *testing.T) {
 					SslInsecure: "",
 				},
 			},
-			want: `/usr/sbin/pcs stonith update node2_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.2" ipport="8000" systems_uri="redfish/v1/Systems/def" pcmk_host_list="node2" pcmk_delay_base="" ssl_insecure="1" --wait=120`,
+			want: `/usr/sbin/pcs stonith update node2_redfish fence_redfish username="admin" password="pass123" ip="192.168.111.2" ipport="8000" systems_uri="redfish/v1/Systems/def" pcmk_host_list="node2" pcmk_delay_base="" ssl_insecure="1"`,
 		},
 	}
 

--- a/pkg/tnf/pkg/pcs/status.go
+++ b/pkg/tnf/pkg/pcs/status.go
@@ -1,0 +1,80 @@
+package pcs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/exec"
+)
+
+const (
+	// DefaultResourceWaitTimeout is used after stonith create/update (replaces --wait=120).
+	DefaultResourceWaitTimeout = 2 * time.Minute
+	// EtcdClusterIdleWait is the pcs status wait duration after etcd resource updates (replaces --wait=300).
+	EtcdClusterIdleWait  = "5min"
+	resourcePollInterval = 2 * time.Second
+)
+
+// WaitForClusterIdle waits until Pacemaker has no pending actions, up to timeout.
+// timeout is a pcs duration string such as "2min" or "5min".
+func WaitForClusterIdle(ctx context.Context, timeout string) error {
+	cmd := fmt.Sprintf("/usr/sbin/pcs status wait %s", timeout)
+	stdOut, stdErr, err := exec.Execute(ctx, cmd)
+	if err != nil {
+		return fmt.Errorf("pcs status wait failed: stdout=%s stderr=%s: %w", stdOut, stdErr, err)
+	}
+	return nil
+}
+
+// IsResourceStarted reports whether pcs considers the resource started.
+// pcs status query prints "True"/"False" and exits non-zero when the predicate is false.
+func IsResourceStarted(ctx context.Context, resourceID string) (bool, error) {
+	cmd := fmt.Sprintf("/usr/sbin/pcs status query resource %s is-state started", resourceID)
+	stdOut, stdErr, err := exec.Execute(ctx, cmd)
+	out := strings.TrimSpace(stdOut)
+	if err != nil {
+		// Predicate false typically returns a non-zero exit with "False" on stdout.
+		if strings.EqualFold(out, "False") {
+			return false, nil
+		}
+		return false, fmt.Errorf("pcs status query resource %s failed: stdout=%s stderr=%s: %w", resourceID, stdOut, stdErr, err)
+	}
+	return strings.EqualFold(out, "True"), nil
+}
+
+// WaitForResourceStarted polls until the resource is started or timeout elapses.
+// Unlike pcs status wait, this does not require the whole cluster to be idle, so
+// unrelated pending actions (e.g. etcd start/stop) do not block stonith verification.
+func WaitForResourceStarted(ctx context.Context, resourceID string, timeout time.Duration) error {
+	klog.Infof("Waiting up to %s for resource %s to be started", timeout, resourceID)
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		started, err := IsResourceStarted(ctx, resourceID)
+		if err != nil {
+			lastErr = err
+		} else if started {
+			klog.Infof("Resource %s is started", resourceID)
+			return nil
+		} else {
+			lastErr = fmt.Errorf("resource %s is not started yet", resourceID)
+		}
+
+		if time.Now().After(deadline) {
+			if lastErr != nil {
+				return fmt.Errorf("timed out waiting for resource %s to start: %w", resourceID, lastErr)
+			}
+			return fmt.Errorf("timed out waiting for resource %s to start", resourceID)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(resourcePollInterval):
+		}
+	}
+}

--- a/pkg/tnf/update-setup/runner.go
+++ b/pkg/tnf/update-setup/runner.go
@@ -145,12 +145,22 @@ func RunTnfUpdateSetup() error {
 	commands = []string{
 		// Force new cluster on next etcd restart on this node
 		fmt.Sprintf("crm_attribute --lifetime reboot --node %s --name \"force_new_cluster\" --update %s", currentNodeName, currentNodeName),
-		// Update etcd resource
-		fmt.Sprintf("/usr/sbin/pcs resource update etcd node_ip_map=\"%s:%s;%s:%s\" --wait=300", cfg.NodeName1, cfg.NodeIP1, cfg.NodeName2, cfg.NodeIP2),
+		// Update etcd resource (--wait deprecated in pcs 0.12; settle via status wait/query below)
+		fmt.Sprintf("/usr/sbin/pcs resource update etcd node_ip_map=\"%s:%s;%s:%s\"", cfg.NodeName1, cfg.NodeIP1, cfg.NodeName2, cfg.NodeIP2),
 	}
 	err = runCommands(ctx, commands)
 	if err != nil {
 		return err
+	}
+	if err := pcs.WaitForClusterIdle(ctx, pcs.EtcdClusterIdleWait); err != nil {
+		return fmt.Errorf("cluster did not settle after etcd resource update: %w", err)
+	}
+	started, err := pcs.IsResourceStarted(ctx, "etcd")
+	if err != nil {
+		return fmt.Errorf("failed to query etcd resource state after update: %w", err)
+	}
+	if !started {
+		return fmt.Errorf("etcd resource is not started after update")
 	}
 
 	// remove old node from etcd members


### PR DESCRIPTION
Treat only non-zero exits as failures so deprecation/progress on stderr does not skip constraint settle or abort setup, use clone meta --future, and replace deprecated --wait with status wait/query helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster resource updates by removing deprecated wait options.
  * Added reliable confirmation that fencing, etcd, and kubelet resources reach the started state.
  * Added clearer error reporting when updates fail, time out, or leave resources stopped.
  * Improved handling of cluster settling before completing etcd updates.

* **Reliability**
  * Added polling and timeout support for resource startup and cluster idle status.
  * Enhanced fencing and clone configuration for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->