### PR TITLE
OCPBUGS-105240: TNF: wait for etcd-bootstrap member removal before setup

### DIFF
--- a/pkg/operator/ceohelpers/external_etcd_status.go
+++ b/pkg/operator/ceohelpers/external_etcd_status.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	OperatorConditionEtcdRunningInCluster               = "EtcdRunningInCluster"
+	OperatorConditionEtcdBootstrapMemberRemoved         = "EtcdBootstrapMemberRemoved"
 	OperatorConditionExternalEtcdReadyForTransition     = "ExternalEtcdReadyForTransition"
 	OperatorConditionExternalEtcdHasCompletedTransition = "ExternalEtcdHasCompletedTransition"
 )
@@ -86,6 +87,31 @@ func IsEtcdRunningInCluster(ctx context.Context, operatorClient v1helpers.Static
 	}
 
 	return etcdRunningInCluster, nil
+}
+
+// IsEtcdBootstrapMemberRemoved checks if the etcd-bootstrap member has been
+// removed from the etcd cluster by examining the operator status for the
+// EtcdBootstrapMemberRemoved condition. Unlike EtcdRunningInCluster, which is
+// set before the bootstrap member is removed, this condition is only set once
+// the member removal has been confirmed.
+func IsEtcdBootstrapMemberRemoved(ctx context.Context, operatorClient v1helpers.StaticPodOperatorClient) (bool, error) {
+	_, opStatus, _, err := operatorClient.GetStaticPodOperatorState()
+	if err != nil {
+		klog.Errorf("failed to get static pod operator state: %v", err)
+		return false, err
+	}
+
+	if opStatus == nil {
+		klog.V(2).Info("static pod operator status not yet populated; bootstrap member removal unknown")
+		return false, nil
+	}
+
+	bootstrapMemberRemoved := v1helpers.IsOperatorConditionTrue(opStatus.Conditions, OperatorConditionEtcdBootstrapMemberRemoved)
+	if bootstrapMemberRemoved {
+		klog.V(4).Infof("etcd-bootstrap member has been removed")
+	}
+
+	return bootstrapMemberRemoved, nil
 }
 
 // HasExternalEtcdCompletedTransition checks if the transition to external etcd process is completed

--- a/pkg/tnf/operator/job_controllers.go
+++ b/pkg/tnf/operator/job_controllers.go
@@ -469,5 +469,21 @@ func waitForEtcdBootstrapCompleted(ctx context.Context, operatorClient v1helpers
 			return fmt.Errorf("failed to wait for bootstrap to complete: %w", err)
 		}
 	}
+
+	// EtcdRunningInCluster is set before the bootstrap member is removed, as
+	// it signals bootkube that it can proceed with bootstrap teardown. TNF
+	// setup must not start pacemaker while etcd-bootstrap is still a member:
+	// podman-etcd requires exactly 2 members and deadlocks on 3
+	// (OCPBUGS-105240). EtcdBootstrapMemberRemoved is only set once the
+	// member is confirmed gone, so gate on it as well. Returning an error
+	// here is safe: the caller retries with backoff.
+	bootstrapMemberRemoved, err := ceohelpers.IsEtcdBootstrapMemberRemoved(ctx, operatorClient)
+	if err != nil {
+		return fmt.Errorf("failed to check if etcd-bootstrap member is removed: %w", err)
+	}
+	if !bootstrapMemberRemoved {
+		return fmt.Errorf("etcd-bootstrap member has not been removed yet")
+	}
+
 	return nil
 }


### PR DESCRIPTION
## What

Gates TNF setup on the `EtcdBootstrapMemberRemoved` operator condition, in
addition to `EtcdRunningInCluster`, before starting the TNF job controllers.
Adds `ceohelpers.IsEtcdBootstrapMemberRemoved`, mirroring
`IsEtcdRunningInCluster`.

## Why

`EtcdRunningInCluster` is set by the bootstrap teardown controller before the
etcd-bootstrap member is removed — it is the signal bootkube watches to proceed
with bootstrap teardown, and member removal is deferred until after teardown
completes. TNF setup previously keyed only on this condition, so pacemaker
could start while etcd-bootstrap was still a member. The podman-etcd resource
agent requires exactly 2 members and deadlocks on 3 ("found 3 members, need
2"), leaving master-1's etcd unable to start (OCPBUGS-105240).

`EtcdBootstrapMemberRemoved` is only set once the member is confirmed removed,
so waiting for both conditions closes the window. If it is not yet set, the
gate returns an error and relies on the existing job controller startup
backoff to retry.

The change is scoped to the TNF path only. bootkube's wait-for-ceo gate
(\`bootstrapteardown.done()\`) is intentionally unchanged: it must continue to
fire on \`EtcdRunningInCluster\` alone, since member removal happens only after
bootstrap teardown.

## Testing

**Forced-timing verification (PR #1685):**
Injected a 3-minute \`time.Sleep\` between \`IsBootstrapComplete\` and
\`MemberRemove()\` in \`removeBootstrap()\` to force the race window open
deterministically. Results:

- Gate correctly blocked TNF setup: CEO log shows repeated
  \`"failed to setup TNF job controllers, will retry: … etcd-bootstrap member
  has not been removed yet"\` during the delay window
- After the delay, bootstrap member was removed, \`EtcdBootstrapMemberRemoved\`
  set to True, gate passed, TNF job controllers started successfully
- \`TNFJobControllersDegraded\` cleared to False with
  \`"TNF job controllers setup completed successfully"\`
- Final cluster state: 2 etcd members available, no "found 3 members" in
  pacemaker logs, all TNF jobs (auth, setup, fencing, after-setup) running

**Clean install (this PR only, no delay):**
Deployed TNF fencing cluster with #1672 payload — all cluster operators
Available, both nodes Ready, etcd healthy, pacemaker setup completed normally.

**CI regression:**
- configmap-scale: passes (no non-TNF code paths touched; \`waitforceo.go\`
  byte-identical to main)
- Unit tests: existing \`TestRemoveBootstrap\` and \`TestCanRemoveEtcdBootstrap\`
  pass