### PR TITLE
[WIP][DNM]: OCPBUGS-105240: test-only delay MemberRemove to reproduce bootstrap race

### DIFF
--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
@@ -60,7 +60,8 @@ func NewBootstrapTeardownController(
 }
 
 func (c *BootstrapTeardownController) sync(ctx context.Context, _ factory.SyncContext) error {
-	timeoutCtx, cancelFunc := context.WithTimeout(ctx, 1*time.Minute)
+	// TEST ONLY (OCPBUGS-105240): extend timeout from 1m to 10m to accommodate the 5m sleep in removeBootstrap(). DO NOT MERGE.
+	timeoutCtx, cancelFunc := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancelFunc()
 
 	scalingStrategy, err := ceohelpers.GetBootstrapScalingStrategy(c.operatorClient, c.namespaceLister, c.infrastructureLister)
@@ -142,6 +143,13 @@ func (c *BootstrapTeardownController) removeBootstrap(ctx context.Context, safeT
 	if updateErr != nil {
 		return fmt.Errorf("error while updating EnoughEtcdMembers: %w", updateErr)
 	}
+
+	// TEST ONLY (OCPBUGS-105240): delay bootstrap member removal by 5 minutes
+	// to hold the race window open between EtcdRunningInCluster=True and MemberRemove().
+	// This forces the TNF pacemaker startup deadlock deterministically.
+	// DO NOT MERGE.
+	klog.Warningf("TEST ONLY (OCPBUGS-105240): delaying bootstrap member removal by 5 minutes to reproduce race condition")
+	time.Sleep(5 * time.Minute)
 
 	// check to see if bootstrapping is complete
 	if isBootstrapComplete, err := bootstrap.IsBootstrapComplete(c.configmapLister); !isBootstrapComplete || err != nil {


### PR DESCRIPTION
## DO NOT MERGE

Test-only reproducer for OCPBUGS-105240. Injects a 5-minute `time.Sleep` between `EtcdRunningInCluster=True` and `MemberRemove()` in `removeBootstrap()` to hold the race window open and force the TNF pacemaker startup deadlock deterministically.

## Usage with cluster-bot

**Reproduce the deadlock (PR A alone):**
```
cluster-bot build openshift/cluster-etcd-operator#<this-PR>
```
Deploy the resulting payload on a TNF fencing cluster. Expected: deadlock every time — pacemaker sees 3 etcd members, logs "found 3 members, need 2".

**Verify the fix (PR A + fix PR together):**
```
cluster-bot build openshift/cluster-etcd-operator#<this-PR>,openshift/cluster-etcd-operator#1672
```
Expected: TNF gate stays closed during the 5-minute delay, then proceeds to clean install after the bootstrap member is removed.

## Related

- Fix PR: https://github.com/openshift/cluster-etcd-operator/pull/1672
- Bug: https://issues.redhat.com/browse/OCPBUGS-105240

/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bootstrap teardown operations now allow up to ten minutes to complete, reducing failures during slower shutdowns.

* **Tests**
  * Added a controlled delay to teardown test scenarios before completion checks and bootstrap member removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->