### PR TITLE
OCPEDGE-2118: Fix pcs stderr handling

### DIFF
--- a/pkg/tnf/pkg/pcs/cluster.go
+++ b/pkg/tnf/pkg/pcs/cluster.go
@@ -60,9 +60,12 @@ func GetCIB(ctx context.Context) (string, error) {
 	stdOut, stdErr, err := exec.Execute(ctx, "/usr/sbin/pcs cluster cib")
 	// redact passwords!
 	stdOut = tools.RedactPasswords(stdOut)
-	if err != nil || len(stdErr) > 0 {
-		klog.Error(err, "Failed to get final pcs cib", "stdout", stdOut, "stderr", stdErr, "err", err)
+	if err != nil {
+		klog.Error(err, "Failed to get final pcs cib", "stdout", stdOut, "stderr", tools.RedactPasswords(stdErr))
 		return "", err
+	}
+	if len(stdErr) > 0 {
+		klog.Warningf("pcs cluster cib produced stderr: %s", tools.RedactPasswords(stdErr))
 	}
 	return stdOut, nil
 }

--- a/pkg/tnf/pkg/pcs/etcd.go
+++ b/pkg/tnf/pkg/pcs/etcd.go
@@ -16,9 +16,12 @@ func ConfigureEtcd(ctx context.Context, cfg config.ClusterConfig) error {
 	klog.Info("Checking pcs resources")
 
 	stdOut, stdErr, err := exec.Execute(ctx, "/usr/sbin/pcs resource status")
-	if err != nil || len(stdErr) > 0 {
-		klog.Error(err, "Failed to get pcs resource status", "stdout", stdOut, "stderr", stdErr, "err", err)
+	if err != nil {
+		klog.Error(err, "Failed to get pcs resource status", "stdout", stdOut, "stderr", stdErr)
 		return err
+	}
+	if len(stdErr) > 0 {
+		klog.Warningf("pcs resource status produced stderr: %s", stdErr)
 	}
 	if !strings.Contains(stdOut, "etcd") {
 		klog.Info("Creating etcd resource")
@@ -29,9 +32,12 @@ func ConfigureEtcd(ctx context.Context, cfg config.ClusterConfig) error {
 		cmd := fmt.Sprintf("/usr/sbin/pcs resource create etcd ocf:heartbeat:podman-etcd node_ip_map=\"%s:%s;%s:%s\" drop_in_dependency=true clone interleave=true notify=true meta migration-threshold=60",
 			cfg.NodeName1, cfg.NodeIP1, cfg.NodeName2, cfg.NodeIP2)
 		stdOut, stdErr, err = exec.Execute(ctx, cmd)
-		if err != nil || len(stdErr) > 0 {
-			klog.Error(err, "Failed to create etcd resource", "stdout", stdOut, "stderr", stdErr, "err", err)
+		if err != nil {
+			klog.Error(err, "Failed to create etcd resource", "stdout", stdOut, "stderr", stdErr)
 			return err
+		}
+		if len(stdErr) > 0 {
+			klog.Warningf("pcs resource create produced stderr: %s", stdErr)
 		}
 	}
 	return nil
@@ -41,16 +47,22 @@ func ConfigureEtcd(ctx context.Context, cfg config.ClusterConfig) error {
 func ConfigureConstraints(ctx context.Context) (bool, error) {
 	klog.Info("Checking pcs constraints")
 	stdOut, stdErr, err := exec.Execute(ctx, "/usr/sbin/pcs constraint")
-	if err != nil || len(stdErr) > 0 {
-		klog.Error(err, "Failed to get pcs resource status", "stdout", stdOut, "stderr", stdErr, "err", err)
+	if err != nil {
+		klog.Error(err, "Failed to list pcs constraints", "stdout", stdOut, "stderr", stdErr)
 		return false, err
+	}
+	if len(stdErr) > 0 {
+		klog.Warningf("pcs constraint produced stderr: %s", stdErr)
 	}
 	if !strings.Contains(stdOut, "etcd") {
 		klog.Info("Configuring etcd constraints")
 		stdOut, stdErr, err = exec.Execute(ctx, "/usr/sbin/pcs constraint order kubelet-clone then etcd-clone && /usr/sbin/pcs constraint colocation add etcd-clone with kubelet-clone")
-		if err != nil || len(stdErr) > 0 {
-			klog.Error(err, "Failed to configure etcd constraints", "stdout", stdOut, "stderr", stdErr, "err", err)
+		if err != nil {
+			klog.Error(err, "Failed to configure etcd constraints", "stdout", stdOut, "stderr", stdErr)
 			return false, err
+		}
+		if len(stdErr) > 0 {
+			klog.Warningf("pcs constraint configuration produced stderr: %s", stdErr)
 		}
 		return true, nil
 	}

--- a/pkg/tnf/pkg/pcs/fencing.go
+++ b/pkg/tnf/pkg/pcs/fencing.go
@@ -113,9 +113,12 @@ func ConfigureFencing(ctx context.Context, kubeClient kubernetes.Interface, node
 		// verify credentials by getting the current BMC status
 		klog.Infof("Verifying fencing credentials for node %s", fc.NodeName)
 		stdOut, stdErr, err := exec.Execute(ctx, getStatusCommand(fc))
-		if err != nil || len(stdErr) > 0 {
-			klog.Error(err, "Failed to verify fencing credentials", "stdout", stdOut, "stderr", stdErr, "err", err)
+		if err != nil {
+			klog.Error(err, "Failed to verify fencing credentials", "stdout", tools.RedactPasswords(stdOut), "stderr", tools.RedactPasswords(stdErr))
 			return fmt.Errorf("failed to verify fencing credentials for node %s: %v", fc.NodeName, err)
+		}
+		if len(stdErr) > 0 {
+			klog.Warningf("Fencing status check for node %s produced stderr: %s", fc.NodeName, tools.RedactPasswords(stdErr))
 		}
 		klog.Info(fmt.Sprintf("Fencing credentials for node %s are valid, status command returned %q", fc.NodeName, stdOut))
 


### PR DESCRIPTION
## Summary

- **pcs stderr handling**: removes `len(stdErr) > 0` from error conditions in `etcd.go`, `cluster.go`, and `fencing.go`. Newer pcs versions (Pacemaker 3.0.1+ on RHEL 10) emit deprecation warnings and informational messages to stderr on success (e.g. `Adding kubelet-clone etcd-clone (kind: Mandatory)`), which were incorrectly treated as failures. Now only non-zero exit codes are treated as errors; stderr is logged as a warning
- **Password redaction**: stderr warning logs in `cluster.go` (GetCIB) and `fencing.go` (ConfigureFencing) use `tools.RedactPasswords()` before logging

## Evidence

From a `5.0.0-0.nightly` cluster-bot deployment, the setup job logs show pcs commands succeeding (exit code 0) but being logged as errors due to stderr content:

```
E0810 08:35:52 <nil>Failed to configure etcd constraints  stdout  stderr Adding kubelet-clone etcd-clone (kind: Mandatory) (Options: first-action=start then-action=start)
```

## Test plan

- [x] `go build ./pkg/tnf/...` compiles
- [x] `go test ./pkg/tnf/pkg/pcs/...` all tests pass
- [x] Deployed on cluster-bot TNF cluster — pcs commands succeed without false-positive error logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)