### PR TITLE
OCPBUGS-104851: feat: add cert-watcher DaemonSet to restart etcd on CA bundle rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 cluster-etcd-operator
-tnf-monitor
-tnf-setup-runner
+/tnf-monitor
+/tnf-setup-runner
 /cluster-etcd-operator-tests-ext
 cluster-etcd-operator-tests-ext.gz
 

--- a/bindata/etcd/cluster-restore-tnf.sh
+++ b/bindata/etcd/cluster-restore-tnf.sh
@@ -108,10 +108,12 @@ function cleanup_podman_etcd_attributes() {
   crm_attribute --delete --name "standalone_node" || true
   crm_attribute --delete --name "learner_node" || true
   crm_attribute --delete --name "force_new_cluster" --lifetime reboot --node "${NODENAME}" || true
+  crm_attribute --delete --name "restart_no_leave" --lifetime reboot --node "${NODENAME}" || true
 
   peer_node_name=$(get_peer_node_name)
   if [ "$(echo "$peer_node_name" | wc -w)" -eq 1 ]; then
     crm_attribute --delete --name "force_new_cluster" --lifetime reboot --node "${peer_node_name}" || true
+    crm_attribute --delete --name "restart_no_leave" --lifetime reboot --node "${peer_node_name}" || true
   else
     echo "Warning: could not find peer node name. If restore fails, manually run on the peer node, and try again:" >&2
     echo "  crm_attribute --delete --name force_new_cluster --lifetime reboot --node \"\$(hostname)\"" >&2

--- a/bindata/tnfdeployment/cert-watcher-daemonset.yaml
+++ b/bindata/tnfdeployment/cert-watcher-daemonset.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: tnf-cert-watcher
+  namespace: openshift-etcd
+  labels:
+    app.kubernetes.io/name: tnf-cert-watcher
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tnf-cert-watcher
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tnf-cert-watcher
+      annotations:
+        openshift.io/required-scc: "privileged"
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: cert-watcher
+          image: <injected>
+          imagePullPolicy: IfNotPresent
+          command: ["tnf-monitor", "watch-certs", "--cert-dir=/certs/configmaps/etcd-all-bundles"]
+          terminationMessagePolicy: FallbackToLogsOnError
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+          volumeMounts:
+            - name: etcd-certs
+              mountPath: /certs
+              readOnly: true
+      hostIPC: false
+      hostNetwork: false
+      hostPID: true
+      serviceAccountName: tnf-setup-manager
+      priorityClassName: system-node-critical
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/memory-pressure
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/pid-pressure
+          operator: Exists
+          effect: NoSchedule
+      volumes:
+        - name: etcd-certs
+          hostPath:
+            path: /etc/kubernetes/static-pod-resources/etcd-certs
+            type: Directory

--- a/cmd/tnf-monitor/main.go
+++ b/cmd/tnf-monitor/main.go
@@ -47,6 +47,7 @@ func NewTnfMonitorCommand() *cobra.Command {
 	logs.AddFlags(cmd.PersistentFlags())
 
 	cmd.AddCommand(NewCollectCommand())
+	cmd.AddCommand(NewWatchCertsCommand())
 
 	return cmd
 }

--- a/cmd/tnf-monitor/watch_certs.go
+++ b/cmd/tnf-monitor/watch_certs.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/tnf/certwatch"
+)
+
+func NewWatchCertsCommand() *cobra.Command {
+	var certDir string
+
+	cmd := &cobra.Command{
+		Use:   "watch-certs",
+		Short: "Watch CA bundle files and restart etcd when they change",
+		Long: `Polls CA bundle certificate files on disk and restarts the local
+etcd instance via Pacemaker when the files change. Sets restart_no_leave
+before restarting to prevent force_new_cluster during CA rotation.
+
+Runs as a long-lived process (DaemonSet). Requires hostPID and privileged
+security context for nsenter access to Pacemaker and podman.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			shutdownHandler := server.SetupSignalHandler()
+			go func() {
+				defer cancel()
+				<-shutdownHandler
+				klog.Info("Received SIGTERM or SIGINT signal, shutting down cert watcher")
+			}()
+
+			return certwatch.Run(ctx, certDir)
+		},
+	}
+
+	cmd.Flags().StringVar(&certDir, "cert-dir", "", "Path to the CA bundle directory to watch (required)")
+	cmd.MarkFlagRequired("cert-dir")
+
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
@@ -62,7 +63,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/fgprof v0.9.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/pkg/tnf/certwatch/watcher.go
+++ b/pkg/tnf/certwatch/watcher.go
@@ -1,0 +1,290 @@
+package certwatch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/exec"
+	"github.com/openshift/cluster-etcd-operator/pkg/tnf/pkg/pacemaker"
+)
+
+const (
+	// FallbackPollInterval is a safety-net poll in case fsnotify misses an
+	// event (e.g. the directory is replaced atomically via symlink swap).
+	FallbackPollInterval = 1 * time.Minute
+	healthTimeout        = 5 * time.Minute
+	healthPollInterval   = 5 * time.Second
+	// debounceWindow coalesces rapid successive writes into a single restart.
+	debounceWindow = 2 * time.Second
+)
+
+// Run watches CA bundle files in certDir for changes and restarts etcd
+// on the local node when they change. It uses fsnotify for instant
+// detection with a periodic fallback. No Kubernetes API access is
+// needed — it reads cert files from a hostPath mount and acts via nsenter.
+func Run(ctx context.Context, certDir string) error {
+	hostname, err := getHostname(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get hostname: %w", err)
+	}
+	klog.Infof("Starting cert watcher on node %s, watching %s", hostname, certDir)
+
+	baseline, err := hashDir(certDir)
+	if err != nil {
+		return fmt.Errorf("failed to hash initial cert directory: %w", err)
+	}
+	if baseline == "" {
+		return fmt.Errorf("cert directory %s is empty, refusing to start with empty baseline", certDir)
+	}
+	klog.Infof("Recorded baseline cert hash: %s", baseline)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create fsnotify watcher: %w", err)
+	}
+	defer watcher.Close()
+
+	if err := watcher.Add(certDir); err != nil {
+		return fmt.Errorf("failed to watch %s: %w", certDir, err)
+	}
+
+	fallback := time.NewTicker(FallbackPollInterval)
+	defer fallback.Stop()
+
+	var debounce *time.Timer
+	debounceCh := make(<-chan time.Time)
+
+	for {
+		select {
+		case <-ctx.Done():
+			klog.Info("Cert watcher shutting down")
+			return nil
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return fmt.Errorf("fsnotify watcher closed")
+			}
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+				klog.V(4).Infof("fsnotify event: %s", event)
+				if debounce == nil {
+					debounce = time.NewTimer(debounceWindow)
+					debounceCh = debounce.C
+				} else {
+					debounce.Reset(debounceWindow)
+				}
+			}
+
+		case watchErr, ok := <-watcher.Errors:
+			if !ok {
+				return fmt.Errorf("fsnotify error channel closed")
+			}
+			klog.Warningf("fsnotify error: %v", watchErr)
+
+		case <-debounceCh:
+			debounce = nil
+			debounceCh = make(<-chan time.Time)
+			baseline, err = checkAndRestart(ctx, certDir, baseline, hostname)
+			if err != nil {
+				klog.Errorf("Failed to handle cert change: %v", err)
+			}
+
+		case <-fallback.C:
+			baseline, err = checkAndRestart(ctx, certDir, baseline, hostname)
+			if err != nil {
+				klog.Errorf("Failed to handle cert change (fallback): %v", err)
+			}
+		}
+	}
+}
+
+// checkAndRestart compares the current cert hash against baseline and
+// restarts etcd if they differ. Each node restarts independently when it
+// detects the change. The health check guards against restarting while
+// the peer is already down, but does not guarantee strict serialization.
+// restart_no_leave is set on the local node only to prevent the OCF agent
+// from running force_new_cluster on the restart it is about to perform.
+func checkAndRestart(ctx context.Context, certDir, baseline, hostname string) (string, error) {
+	current, err := hashDir(certDir)
+	if err != nil {
+		return baseline, fmt.Errorf("failed to hash cert directory: %w", err)
+	}
+	if current == baseline || current == "" {
+		return baseline, nil
+	}
+
+	if !isClusterHealthy(ctx) {
+		klog.Infof("Cert change detected but etcd cluster not fully healthy, deferring restart to next poll")
+		return baseline, nil
+	}
+
+	klog.Infof("CA bundle changed (old: %s, new: %s), restarting etcd on %s", baseline, current, hostname)
+
+	if err := setRestartNoLeave(ctx, hostname); err != nil {
+		return baseline, fmt.Errorf("failed to set restart_no_leave: %w", err)
+	}
+	defer clearRestartNoLeave(ctx, hostname)
+
+	if err := restartEtcdContainer(ctx); err != nil {
+		return baseline, fmt.Errorf("failed to restart etcd container: %w", err)
+	}
+
+	if err := waitForEtcdHealthy(ctx); err != nil {
+		klog.Errorf("etcd did not become healthy after restart: %v", err)
+		return baseline, nil
+	}
+
+	if hasPacemakerFailcount(ctx) {
+		clearPacemakerFailcount(ctx)
+	}
+
+	klog.Infof("Updated baseline cert hash to: %s", current)
+	return current, nil
+}
+
+func hashDir(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+
+	h := sha256.New()
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return "", err
+		}
+		h.Write([]byte(name))
+		h.Write(data)
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func getHostname(ctx context.Context) (string, error) {
+	stdout, _, err := exec.Execute(ctx, "hostname")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stdout), nil
+}
+
+func setRestartNoLeave(ctx context.Context, hostname string) error {
+	cmd := fmt.Sprintf(`crm_attribute --lifetime reboot --node "%s" --name restart_no_leave --update true`, hostname)
+	if _, _, err := exec.Execute(ctx, cmd); err != nil {
+		return fmt.Errorf("crm_attribute failed: %w", err)
+	}
+	klog.Infof("Set restart_no_leave on %s", hostname)
+	return nil
+}
+
+func clearRestartNoLeave(ctx context.Context, hostname string) {
+	cmd := fmt.Sprintf(`crm_attribute --lifetime reboot --node "%s" --name restart_no_leave --delete`, hostname)
+	if _, _, err := exec.Execute(ctx, cmd); err != nil {
+		klog.Warningf("Failed to clear restart_no_leave on %s: %v", hostname, err)
+		return
+	}
+	klog.Infof("Cleared restart_no_leave on %s", hostname)
+}
+
+func restartEtcdContainer(ctx context.Context) error {
+	if _, _, err := exec.Execute(ctx, "podman restart etcd"); err != nil {
+		return fmt.Errorf("podman restart etcd failed: %w", err)
+	}
+	klog.Info("etcd container restarted via podman")
+	return nil
+}
+
+func hasPacemakerFailcount(ctx context.Context) bool {
+	stdout, _, err := exec.Execute(ctx, "pcs status xml")
+	if err != nil {
+		klog.Warningf("Failed to get pcs status xml: %v", err)
+		return false
+	}
+	var status pacemaker.PacemakerResult
+	if err := xml.Unmarshal([]byte(stdout), &status); err != nil {
+		klog.Warningf("Failed to parse pcs status xml: %v", err)
+		return false
+	}
+	for _, node := range status.NodeHistory.Node {
+		for _, rh := range node.ResourceHistory {
+			if rh.ID == "etcd" && rh.FailCount == "INFINITY" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func clearPacemakerFailcount(ctx context.Context) {
+	klog.Info("Resetting etcd-clone failcount")
+	if _, _, err := exec.Execute(ctx, "pcs resource failcount reset etcd-clone"); err != nil {
+		klog.Warningf("Failed to reset etcd-clone failcount: %v", err)
+	}
+}
+
+type endpointHealth struct {
+	Endpoint string `json:"endpoint"`
+	Health   bool   `json:"health"`
+}
+
+func isClusterHealthy(ctx context.Context) bool {
+	stdout, _, err := exec.Execute(ctx, "podman exec etcd etcdctl endpoint health --cluster -w json")
+	if err != nil {
+		return false
+	}
+	var endpoints []endpointHealth
+	if err := json.Unmarshal([]byte(stdout), &endpoints); err != nil {
+		klog.Warningf("Failed to parse etcd health JSON: %v", err)
+		return false
+	}
+	if len(endpoints) == 0 {
+		return false
+	}
+	for _, ep := range endpoints {
+		if !ep.Health {
+			return false
+		}
+	}
+	return true
+}
+
+func waitForEtcdHealthy(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, healthTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(healthPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for etcd health")
+		case <-ticker.C:
+			if isClusterHealthy(ctx) {
+				klog.Info("etcd cluster healthy after restart")
+				return nil
+			}
+			klog.V(4).Info("etcd health check not yet passing")
+		}
+	}
+}

--- a/pkg/tnf/operator/cert_watcher.go
+++ b/pkg/tnf/operator/cert_watcher.go
@@ -1,0 +1,128 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
+)
+
+const (
+	certWatcherName = "tnf-cert-watcher"
+	certHostPath    = "/etc/kubernetes/static-pod-resources/etcd-certs"
+)
+
+// ensureCertWatcherDaemonSet creates or updates the cert-watcher DaemonSet.
+// The DaemonSet runs on each control plane node and watches CA bundle files
+// on disk. When they change, it sets restart_no_leave and restarts the local
+// etcd — preventing force_new_cluster during CA rotation.
+func (c *pacemakerLifecycleManager) ensureCertWatcherDaemonSet(ctx context.Context) error {
+	desired := buildCertWatcherDaemonSet()
+
+	existing, err := c.kubeClient.AppsV1().DaemonSets(operatorclient.TargetNamespace).Get(ctx, certWatcherName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		klog.Infof("Creating cert-watcher DaemonSet")
+		_, err = c.kubeClient.AppsV1().DaemonSets(operatorclient.TargetNamespace).Create(ctx, desired, metav1.CreateOptions{})
+		return err
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get cert-watcher DaemonSet: %w", err)
+	}
+
+	existing.Spec.Template = desired.Spec.Template
+	klog.Infof("Updating cert-watcher DaemonSet")
+	_, err = c.kubeClient.AppsV1().DaemonSets(operatorclient.TargetNamespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+func buildCertWatcherDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      certWatcherName,
+			Namespace: operatorclient.TargetNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": certWatcherName,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name": certWatcherName,
+				},
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/name": certWatcherName,
+					},
+					Annotations: map[string]string{
+						"openshift.io/required-scc": "privileged",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:                     "cert-watcher",
+						Image:                    os.Getenv("OPERATOR_IMAGE"),
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						Command:                  []string{"tnf-monitor", "watch-certs", "--cert-dir=/certs/configmaps/etcd-all-bundles"},
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    *parseQuantity("10m"),
+								corev1.ResourceMemory: *parseQuantity("32Mi"),
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:               ptr.To(true),
+							AllowPrivilegeEscalation: ptr.To(true),
+						},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "etcd-certs",
+							MountPath: "/certs",
+							ReadOnly:  true,
+						}},
+					}},
+					HostPID:                       true,
+					ServiceAccountName:            "tnf-setup-manager",
+					PriorityClassName:             "system-node-critical",
+					TerminationGracePeriodSeconds: ptr.To(int64(10)),
+					NodeSelector: map[string]string{
+						"node-role.kubernetes.io/master": "",
+					},
+					Tolerations: []corev1.Toleration{
+						{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Key: "node.kubernetes.io/memory-pressure", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Key: "node.kubernetes.io/disk-pressure", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Key: "node.kubernetes.io/pid-pressure", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+					},
+					Volumes: []corev1.Volume{{
+						Name: "etcd-certs",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: certHostPath,
+								Type: ptr.To(corev1.HostPathDirectory),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func parseQuantity(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}

--- a/pkg/tnf/operator/job_controllers.go
+++ b/pkg/tnf/operator/job_controllers.go
@@ -250,6 +250,13 @@ func startTnfJobcontrollers(
 		fencingJobConfigFunc := createFencingJobConfigFunc(lifecycleManager, kubeInformersForNamespaces)
 		jobs.RunClusterJobController(ctx, tools.JobTypeFencing, schedulableNodesFunc, fencingAffectedNodesFunc, fencingJobConfigFunc, 3, controllerContext, operatorClient, kubeClient, kubeInformersForNamespaces, jobs.DefaultConditions)
 
+		// Cert watcher DaemonSet: watches CA bundle files on disk and restarts
+		// the local etcd when they change. Runs independently of the operator
+		// and API server — prevents force_new_cluster during CA rotation.
+		if err := lifecycleManager.ensureCertWatcherDaemonSet(ctx); err != nil {
+			return fmt.Errorf("failed to ensure cert-watcher DaemonSet: %w", err)
+		}
+
 		// Start status collector (only after transition is complete, when Pacemaker exists)
 		lifecycleManager.runPacemakerStatusCollectorCronJob(ctx)
 

--- a/pkg/tnf/pkg/pacemaker/xml_types.go
+++ b/pkg/tnf/pkg/pacemaker/xml_types.go
@@ -121,6 +121,7 @@ type NodeHistoryNode struct {
 
 type ResourceHistory struct {
 	ID               string             `xml:"id,attr"`
+	FailCount        string             `xml:"fail-count,attr"`
 	OperationHistory []OperationHistory `xml:"operation_history"`
 }
 


### PR DESCRIPTION
## Summary

- Adds a **cert-watcher DaemonSet** to TNF deployments that monitors CA bundle
  certificate files on disk and restarts etcd when they change, preventing
  `force_new_cluster` during CA rotation
- Adds a `watch-certs` subcommand to the `tnf-monitor` binary with fsnotify-based
  file watching and a 1-minute fallback poll
- Includes health-check serialization to prevent simultaneous restarts in the
  2-node etcd cluster

## Problem

In TNF deployments, etcd is managed by Pacemaker and runs as a podman container
outside of Kubernetes. When the etcd CA bundle is rotated (e.g., during
certificate rotation), etcd does not automatically reload the new CA certificates.

The kube-apiserver presents a client certificate signed by the **new** CA, but etcd
still trusts only the **old** CA — causing etcd to reject API server connections with
`remote error: tls: unknown certificate authority`. This results in kube-apiserver
entering CrashLoopBackOff and complete loss of API availability.

## Solution

A lightweight DaemonSet (`tnf-cert-watcher`) runs on each control-plane node and:

1. **Detects** CA bundle changes via `fsnotify` (with 2-second debounce) and a
   1-minute fallback poll for atomic directory replacements
2. **Serializes** restarts across the 2-node cluster by checking all etcd members
   are healthy before proceeding — preventing both nodes from restarting
   simultaneously and losing quorum
3. **Protects** against `force_new_cluster` by setting `restart_no_leave` on the
   local node via `crm_attribute` before restarting
4. **Restarts** etcd via `podman restart etcd` (SIGTERM preserves cluster membership)
5. **Recovers** by waiting for etcd health (up to 5 min) and cleaning up any
   Pacemaker failure state

### Key design decisions

| Decision | Rationale |
|----------|-----------|
| Mount stable parent dir, not leaf configmap dir | Kubernetes atomically replaces configmap dirs via symlink swap, invalidating leaf bind mounts |
| `podman restart` instead of `pcs resource restart` | `pcs resource restart` runs the OCF agent's stop then start actions. But that's problemativ: the OCF stop action stops the container, and during the stop→start transition, the OCF monitor on the peer node can fire, see the member is down, and mark it as FAILED. Additionally, it is a silent no-op when the resource is unmanaged |
| `restart_no_leave` on local node only | Multiple holders cause `force_new_cluster holders changed after decision` errors in the OCF agent |
| Defer restart if cluster unhealthy | Prevents cascading Pacemaker failures where both nodes end up FAILED |
| Keep old baseline on health timeout | Ensures retry on next poll cycle instead of silently accepting a bad state |

