### PR TITLE
OCPBUGS-109740: Fix tnf_cluster_in_service during per-node maintenance

### DIFF
--- a/pkg/tnf/pkg/pacemaker/statuscollector.go
+++ b/pkg/tnf/pkg/pacemaker/statuscollector.go
@@ -484,11 +484,21 @@ func getNodeAddresses(configNode ClusterConfigNode) []pacmkrv1.PacemakerNodeAddr
 	return addresses
 }
 
-// isClusterInMaintenance returns true if cluster-wide maintenance mode is enabled
-// (pcs property set maintenance-mode=true). Node-level maintenance (pcs node maintenance <node>)
-// is handled separately via buildNodeConditions.
+// isClusterInMaintenance returns true if the cluster is in maintenance, either
+// via the cluster-level property or because every node is individually in maintenance.
 func isClusterInMaintenance(result *PacemakerResult) bool {
-	return result.Summary.ClusterOptions.MaintenanceMode == "true"
+	if result.Summary.ClusterOptions.MaintenanceMode == "true" {
+		return true
+	}
+	if len(result.Nodes.Node) == 0 {
+		return false
+	}
+	for _, node := range result.Nodes.Node {
+		if node.Maintenance != "true" {
+			return false
+		}
+	}
+	return true
 }
 
 // processResourcesForState populates resourceState map. Fencing agents are handled separately.

--- a/pkg/tnf/pkg/pacemaker/statuscollector_test.go
+++ b/pkg/tnf/pkg/pacemaker/statuscollector_test.go
@@ -812,11 +812,6 @@ func TestBuildClusterConditions(t *testing.T) {
 }
 
 func TestIsClusterInMaintenance(t *testing.T) {
-	// isClusterInMaintenance only checks cluster-level maintenance mode.
-	// Node-level maintenance is handled separately per-node and does NOT
-	// cause the function to return true. This distinction is important:
-	// - Cluster maintenance (pcs property set maintenance-mode=true) affects ALL nodes
-	// - Node maintenance (pcs node maintenance <node>) affects only that specific node
 	tests := []struct {
 		name                   string
 		clusterMaintenanceMode string
@@ -836,24 +831,34 @@ func TestIsClusterInMaintenance(t *testing.T) {
 			expectedResult:         false,
 		},
 		{
-			// Node-level maintenance does NOT trigger cluster-level maintenance
-			name:                   "cluster_level_maintenance_mode_false_one_node_in_maintenance",
+			name:                   "one_node_in_maintenance",
 			clusterMaintenanceMode: "false",
 			nodeMaintenanceModes:   []string{"true", "false"},
 			expectedResult:         false,
 		},
 		{
-			name:                   "cluster_level_maintenance_mode_empty_nodes_not_in_maintenance",
+			name:                   "all_nodes_individually_in_maintenance",
+			clusterMaintenanceMode: "false",
+			nodeMaintenanceModes:   []string{"true", "true"},
+			expectedResult:         true,
+		},
+		{
+			name:                   "cluster_level_maintenance_mode_empty",
 			clusterMaintenanceMode: "",
 			nodeMaintenanceModes:   []string{"false", "false"},
 			expectedResult:         false,
 		},
 		{
-			// Cluster maintenance is what matters, node state is irrelevant
 			name:                   "both_cluster_and_node_in_maintenance",
 			clusterMaintenanceMode: "true",
 			nodeMaintenanceModes:   []string{"true", "false"},
 			expectedResult:         true,
+		},
+		{
+			name:                   "no_nodes",
+			clusterMaintenanceMode: "false",
+			nodeMaintenanceModes:   []string{},
+			expectedResult:         false,
 		},
 	}
 
@@ -901,6 +906,16 @@ func TestBuildClusterStatus_ClusterConditionScenarios(t *testing.T) {
 		{
 			name:                    "cluster_maintenance",
 			xmlFile:                 "cluster_maintenance.xml",
+			expectedNodeCount:       2,
+			expectedClusterHealthy:  metav1.ConditionFalse,
+			expectedNodeCountStatus: metav1.ConditionTrue,
+			expectedNodeCountReason: pacmkrv1.ClusterNodeCountAsExpectedReasonAsExpected,
+			expectedInServiceStatus: ptr(metav1.ConditionFalse),
+			expectedInServiceReason: pacmkrv1.ClusterInServiceReasonInMaintenance,
+		},
+		{
+			name:                    "all_nodes_individually_in_maintenance",
+			xmlFile:                 "all_nodes_maintenance.xml",
 			expectedNodeCount:       2,
 			expectedClusterHealthy:  metav1.ConditionFalse,
 			expectedNodeCountStatus: metav1.ConditionTrue,

--- a/pkg/tnf/pkg/pacemaker/testdata/all_nodes_maintenance.xml
+++ b/pkg/tnf/pkg/pacemaker/testdata/all_nodes_maintenance.xml
@@ -1,0 +1,11 @@
+<pacemaker-result api-version="2.38">
+  <summary>
+    <cluster_options maintenance-mode="false"/>
+  </summary>
+  <nodes>
+    <node name="master-0" id="1" online="true" maintenance="true" type="member"/>
+    <node name="master-1" id="2" online="true" maintenance="true" type="member"/>
+  </nodes>
+  <resources/>
+  <node_attributes/>
+</pacemaker-result>


### PR DESCRIPTION
## Summary

- Fix `tnf_cluster_in_service` incorrectly staying `1` when all nodes are placed in maintenance individually via `pcs node maintenance --all`
- Expand `isClusterInMaintenance` to also detect when every node has its per-node maintenance flag set, since this does not set the cluster-level `maintenance-mode` property
- This ensures `TNFClusterInMaintenance` fires correctly instead of two noisy per-node `TNFNodeInMaintenance` alerts

## Test plan

- [x] Unit tests for `isClusterInMaintenance` covering: cluster-level property, all nodes individually in maintenance, single node in maintenance, no nodes, empty property
- [x] XML integration test with new `all_nodes_maintenance.xml` fixture verifying end-to-end cluster condition output
- [x] All existing TNF tests pass
- [ ] On-cluster verification: `pcs node maintenance --all` → check `tnf_cluster_in_service == 0`

Fixes: https://redhat.atlassian.net/browse/OCPEDGE-2901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved maintenance status detection for clusters where all nodes are individually in maintenance mode.
  * Correctly preserves non-maintenance status for empty node lists.
  * Ensures clusters with every node in maintenance are reported as unhealthy and out of service.
* **Tests**
  * Expanded coverage for single-node, multi-node, empty-list, and combined maintenance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->