### PR TITLE
OCPBUGS-111074: Register TNF taint alert for node-lost events

### DIFF
--- a/pkg/tnf/pkg/pcs/alerts.go
+++ b/pkg/tnf/pkg/pcs/alerts.go
@@ -31,6 +31,14 @@ var alertConfigs = []alertConfig{
 		path:      "/var/lib/pacemaker/alerts/tnf-taint-alert.sh",
 		selectXML: "<select_fencing/>",
 	},
+	// Node-lost uses the same script as fencing. Graceful ACPI shutdown takes
+	// the peer Offline without a STONITH completion, so select_fencing alone
+	// never taints and DaemonSet endpoints (e.g. DNS) stay Ready on the dead node.
+	{
+		id:        "tnf-taint-lost-alert",
+		path:      "/var/lib/pacemaker/alerts/tnf-taint-alert.sh",
+		selectXML: "<select_nodes/>",
+	},
 	{
 		id:        "tnf-untaint-alert",
 		path:      "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh",

--- a/pkg/tnf/pkg/pcs/alerts_test.go
+++ b/pkg/tnf/pkg/pcs/alerts_test.go
@@ -5,12 +5,13 @@ import (
 )
 
 func TestAlertConfigs(t *testing.T) {
-	if len(alertConfigs) != 2 {
-		t.Fatalf("expected 2 alert configs, got %d", len(alertConfigs))
+	if len(alertConfigs) != 3 {
+		t.Fatalf("expected 3 alert configs, got %d", len(alertConfigs))
 	}
 
 	expectedConfigs := []alertConfig{
 		{id: "tnf-taint-alert", path: "/var/lib/pacemaker/alerts/tnf-taint-alert.sh", selectXML: "<select_fencing/>"},
+		{id: "tnf-taint-lost-alert", path: "/var/lib/pacemaker/alerts/tnf-taint-alert.sh", selectXML: "<select_nodes/>"},
 		{id: "tnf-untaint-alert", path: "/var/lib/pacemaker/alerts/tnf-untaint-alert.sh", selectXML: "<select_nodes/>"},
 	}
 


### PR DESCRIPTION
Graceful ACPI shutdown never emits STONITH, so select_fencing alone never taints. Add tnf-taint-lost-alert on select_nodes so the existing taint script runs on membership loss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pacemaker alerts for node-lost events.
  * Alerts now support selecting affected nodes and use a dedicated node-lost alert configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->