### PR TITLE
OCPBUGS-105882: Remove orphaned etcd members even during a revision rollout

### DIFF
--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -123,6 +123,21 @@ func (c *clusterMemberRemovalController) sync(ctx context.Context, syncCtx facto
 		return nil
 	}
 
+	// Only proceed if the machine API is functional.
+	if isFunctional, err := c.machineAPIChecker.IsFunctional(); err != nil {
+		return err
+	} else if !isFunctional {
+		return nil
+	}
+
+	// Remove members with no backing Machine or Node unconditionally: they are already
+	// non-functional and safe to clean up regardless of revision stability. Leaving them
+	// causes stale entries in the etcd-endpoints configmap.
+	var errs []error
+	if err := c.removeMemberWithoutMachine(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
 	// Removing multiple members in the middle of a revision rollout can cause API unavailability
 	// when simultaneously deleting multiple machines with the controlplanemachineset "OnDelete" strategy,
 	// i.e we have multiple machines pending deletion and multiple new replacements added
@@ -132,23 +147,16 @@ func (c *clusterMemberRemovalController) sync(ctx context.Context, syncCtx facto
 	// the etcd pod is reinstalled to the latest revision.
 	// This is different from when the member is indefinitely unhealthy when the revision is stable.
 	//
-	// Additionally the EtcdEndpointsController pauses while a revision rollout is in progress
-	// So initially if the etcd-endpoints configmap is updated from 3->4 when the first replacement machine
-	// is added to the membership, a revision rollout will start and the configmap won't update in this period.
-	// But the ClusterMemberRemovalController will still delete a seemingly unhealthy machine during rollout
-	// The API servers on the old revision will neither see the new replacement etcd endpoint, and will also
-	// be using a removed member's endpoint.
-	//
 	// Moreover the EtcdEndpointsController uses the live etcd membership list to make scale down considerations for etcd quorum so the etcd-endpoints configmap always lags behind it.
 	//
 	// So the EtcdEndpointsController skips until the revision is stable so we remove members one at a time and unhealthy members are truly unhealthy
 	revisionStable, err := ceohelpers.IsRevisionStable(c.operatorClient)
 	if err != nil {
-		return fmt.Errorf("couldn't determine stability of revisions: %w", err)
+		return kerrors.NewAggregate(append(errs, fmt.Errorf("couldn't determine stability of revisions: %w", err)))
 	}
 	if !revisionStable {
-		klog.V(2).Infof("skipping due to revision in progress")
-		return nil
+		klog.V(2).Infof("skipping scale-down due to revision in progress")
+		return kerrors.NewAggregate(errs)
 	}
 
 	// Ensure the live etcd membership matches the etcd-endpoints configmap.
@@ -156,23 +164,12 @@ func (c *clusterMemberRemovalController) sync(ctx context.Context, syncCtx facto
 	// and propagated through a revision rollout.
 	etcdEndpointsUpdated, err := c.isEtcdEndpointsUpdated(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to check if etcd endpoints are updated: %w", err)
+		return kerrors.NewAggregate(append(errs, fmt.Errorf("failed to check if etcd endpoints are updated: %w", err)))
 	}
 	if !etcdEndpointsUpdated {
-		return nil
+		return kerrors.NewAggregate(errs)
 	}
 
-	// only attempt to scale down if the machine API is functional
-	if isFunctional, err := c.machineAPIChecker.IsFunctional(); err != nil {
-		return err
-	} else if !isFunctional {
-		return nil
-	}
-
-	var errs []error
-	if err := c.removeMemberWithoutMachine(ctx); err != nil {
-		errs = append(errs, err)
-	}
 	if err := c.attemptToRemoveLearningMember(ctx, syncCtx.Recorder()); err != nil {
 		errs = append(errs, err)
 	}


### PR DESCRIPTION
I've found this potential issue when working on operator status conditions. This simply narrows a window when things can go wrong since they are inconsistent.

---

When a master node is decommissioned, its etcd member should be removed from the cluster. If a revision rollout starts around the same time, the revisionStable guard introduced in OCPBUGS-74151 blocks the entire sync function, including removeMemberWithoutMachine. The orphaned member — one whose Node and Machine no longer exist — remains in etcd's member list for the duration of the rollout. EtcdEndpointsController mirrors that list into the etcd-endpoints configmap, so the dead IP persists and is picked up by API server configuration.

The revisionStable guard was intended to protect attemptToScaleDown and attemptToRemoveLearningMember, where members can temporarily appear unhealthy during a rollout because their pods are being reinstalled. It was applied as a blanket early return that also covered removeMemberWithoutMachine unintentionally.

removeMemberWithoutMachine only acts on members that have neither a Machine nor a Node resource and are reported as unhealthy — conditions that are independent of rollout state. Moving it before the revisionStable check ensures orphaned members are cleaned up promptly without compromising the safety properties OCPBUGS-74151 established for scale-down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cluster member cleanup when associated Machine and Node resources are missing.
  - Ensured cleanup errors are retained and reported alongside revision stability and endpoint synchronization errors.
  - Improved validation ordering so Machine API availability is checked before subsequent synchronization checks.
  - Prevented errors from being lost when synchronization checks are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->