### PR TITLE
[WIP] DNM: OCPBUGS-105240: verify fix with forced 4m delay before MemberRemove

### DIFF
--- a/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
+++ b/pkg/operator/bootstrapteardown/bootstrap_teardown_controller.go
@@ -60,7 +60,8 @@ func NewBootstrapTeardownController(
 }
 
 func (c *BootstrapTeardownController) sync(ctx context.Context, _ factory.SyncContext) error {
-	timeoutCtx, cancelFunc := context.WithTimeout(ctx, 1*time.Minute)
+	// TEST ONLY (OCPBUGS-105240): extend timeout from 1m to 10m to accommodate the 4m sleep. DO NOT MERGE.
+	timeoutCtx, cancelFunc := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancelFunc()
 
 	scalingStrategy, err := ceohelpers.GetBootstrapScalingStrategy(c.operatorClient, c.namespaceLister, c.infrastructureLister)
@@ -147,6 +148,13 @@ func (c *BootstrapTeardownController) removeBootstrap(ctx context.Context, safeT
 	if isBootstrapComplete, err := bootstrap.IsBootstrapComplete(c.configmapLister); !isBootstrapComplete || err != nil {
 		return err
 	}
+
+	// TEST ONLY (OCPBUGS-105240): delay bootstrap member removal by 3 minutes
+	// to hold the race window open between EtcdRunningInCluster=True and MemberRemove().
+	// DO NOT MERGE.
+	klog.Warningf("TEST ONLY (OCPBUGS-105240): delaying bootstrap member removal by 3 minutes")
+	time.Sleep(3 * time.Minute)
+
 	klog.Warningf("Removing bootstrap member [%x]", bootstrapID)
 	c.eventRecorder.Eventf("Removing bootstrap member", "attempting to remove bootstrap member [%x]", bootstrapID)
 

--- a/pkg/operator/ceohelpers/external_etcd_status.go
+++ b/pkg/operator/ceohelpers/external_etcd_status.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	OperatorConditionEtcdRunningInCluster               = "EtcdRunningInCluster"
+	OperatorConditionEtcdBootstrapMemberRemoved         = "EtcdBootstrapMemberRemoved"
 	OperatorConditionExternalEtcdReadyForTransition     = "ExternalEtcdReadyForTransition"
 	OperatorConditionExternalEtcdHasCompletedTransition = "ExternalEtcdHasCompletedTransition"
 )
@@ -86,6 +87,31 @@ func IsEtcdRunningInCluster(ctx context.Context, operatorClient v1helpers.Static
 	}
 
 	return etcdRunningInCluster, nil
+}
+
+// IsEtcdBootstrapMemberRemoved checks if the etcd-bootstrap member has been
+// removed from the etcd cluster by examining the operator status for the
+// EtcdBootstrapMemberRemoved condition. Unlike EtcdRunningInCluster, which is
+// set before the bootstrap member is removed, this condition is only set once
+// the member removal has been confirmed.
+func IsEtcdBootstrapMemberRemoved(ctx context.Context, operatorClient v1helpers.StaticPodOperatorClient) (bool, error) {
+	_, opStatus, _, err := operatorClient.GetStaticPodOperatorState()
+	if err != nil {
+		klog.Errorf("failed to get static pod operator state: %v", err)
+		return false, err
+	}
+
+	if opStatus == nil {
+		klog.V(2).Info("static pod operator status not yet populated; bootstrap member removal unknown")
+		return false, nil
+	}
+
+	bootstrapMemberRemoved := v1helpers.IsOperatorConditionTrue(opStatus.Conditions, OperatorConditionEtcdBootstrapMemberRemoved)
+	if bootstrapMemberRemoved {
+		klog.V(4).Infof("etcd-bootstrap member has been removed")
+	}
+
+	return bootstrapMemberRemoved, nil
 }
 
 // HasExternalEtcdCompletedTransition checks if the transition to external etcd process is completed

--- a/pkg/tnf/operator/job_controllers.go
+++ b/pkg/tnf/operator/job_controllers.go
@@ -469,5 +469,21 @@ func waitForEtcdBootstrapCompleted(ctx context.Context, operatorClient v1helpers
 			return fmt.Errorf("failed to wait for bootstrap to complete: %w", err)
 		}
 	}
+
+	// EtcdRunningInCluster is set before the bootstrap member is removed, as
+	// it signals bootkube that it can proceed with bootstrap teardown. TNF
+	// setup must not start pacemaker while etcd-bootstrap is still a member:
+	// podman-etcd requires exactly 2 members and deadlocks on 3
+	// (OCPBUGS-105240). EtcdBootstrapMemberRemoved is only set once the
+	// member is confirmed gone, so gate on it as well. Returning an error
+	// here is safe: the caller retries with backoff.
+	bootstrapMemberRemoved, err := ceohelpers.IsEtcdBootstrapMemberRemoved(ctx, operatorClient)
+	if err != nil {
+		return fmt.Errorf("failed to check if etcd-bootstrap member is removed: %w", err)
+	}
+	if !bootstrapMemberRemoved {
+		return fmt.Errorf("etcd-bootstrap member has not been removed yet")
+	}
+
 	return nil
 }


### PR DESCRIPTION
## DO NOT MERGE — verification reproducer for #1672

Contains two commits:
1. **The fix** (cherry-picked from #1672): `ceohelpers.IsEtcdBootstrapMemberRemoved` + gate in `waitForEtcdBootstrapCompleted()`
2. **4-minute delay** injected before `MemberRemove()` in `removeBootstrap()` to force the race window open

## Expected behavior

With the fix, the CEO log should show:
1. `EtcdRunningInCluster` goes True
2. Repeated "failed to setup TNF job controllers, will retry: … etcd-bootstrap member has not been removed yet" for ~4 minutes
3. Member removed after delay
4. "creating TNF job controllers" → install completes
5. No pacemaker "found 3 members" anywhere

## Usage

```
cluster-bot build openshift/cluster-etcd-operator#<this-PR>,4.22
```

Deploy payload on TNF fencing cluster via dev-scripts.

## Related

- Fix PR: #1672
- Bug: https://issues.redhat.com/browse/OCPBUGS-105240
- Previous reproducer (closed): #1673

/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster bootstrap teardown reliability by allowing additional time for synchronization.
  * TNF setup now waits until the etcd bootstrap member is confirmed removed before proceeding.
  * Added clearer handling when bootstrap-member removal status is unavailable or cannot be retrieved.
  * Prevents setup from continuing prematurely, reducing failures during cluster initialization and teardown.
  * Added retry-friendly behavior when removal is delayed or status checks encounter errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->