### PR TITLE
OCPBUGS-105322: fix etcdSignerCAExpiration* alert description wording

### DIFF
--- a/jsonnet/custom.libsonnet
+++ b/jsonnet/custom.libsonnet
@@ -162,7 +162,7 @@
             alert: 'etcdSignerCAExpirationWarning',
             'for': '1h',
             annotations: {
-              description: 'etcd is reporting the signer ca "{{ $labels.name }}" to have less than two years (({{ printf "%.f" $value }} days) of validity left.',
+              description: 'etcd is reporting the signer ca "{{ $labels.name }}" to have less than two years ({{ printf "%.f" $value }} days) of validity left.',
               summary: 'etcd signer ca is about to expire',
             },
             labels: {
@@ -174,7 +174,7 @@
             alert: 'etcdSignerCAExpirationCritical',
             'for': '1h',
             annotations: {
-              description: 'etcd is reporting the signer ca "{{ $labels.name }}" to have less than year  (({{ printf "%.f" $value }} days) of validity left.',
+              description: 'etcd is reporting the signer ca "{{ $labels.name }}" to have less than one year ({{ printf "%.f" $value }} days) of validity left.',
               summary: 'etcd has critical signer ca expiration',
             },
             labels: {

--- a/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
+++ b/manifests/0000_90_etcd-operator_03_prometheusrule.yaml
@@ -198,7 +198,7 @@ spec:
         severity: critical
     - alert: etcdSignerCAExpirationWarning
       annotations:
-        description: etcd is reporting the signer ca "{{ $labels.name }}" to have less than two years (({{ printf "%.f" $value }} days) of validity left.
+        description: etcd is reporting the signer ca "{{ $labels.name }}" to have less than two years ({{ printf "%.f" $value }} days) of validity left.
         summary: etcd signer ca is about to expire
       expr: avg(openshift_etcd_operator_signer_expiration_days) by (name) < 730
       for: 1h
@@ -206,7 +206,7 @@ spec:
         severity: warning
     - alert: etcdSignerCAExpirationCritical
       annotations:
-        description: etcd is reporting the signer ca "{{ $labels.name }}" to have less than year  (({{ printf "%.f" $value }} days) of validity left.
+        description: etcd is reporting the signer ca "{{ $labels.name }}" to have less than one year ({{ printf "%.f" $value }} days) of validity left.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdSignerCAExpirationCritical.md
         summary: etcd has critical signer ca expiration
       expr: avg(openshift_etcd_operator_signer_expiration_days) by (name) < 365


### PR DESCRIPTION
## Summary
- Fix OpenShift-specific `etcdSignerCAExpirationCritical` / `etcdSignerCAExpirationWarning` description text in `jsonnet/custom.libsonnet`.
- Critical: `less than year` → `less than one year`; both alerts: `((… days)` → `(… days)`.
- Regenerate / update `manifests/0000_90_etcd-operator_03_prometheusrule.yaml` to match.
- Cosmetic only: `expr`, `for`, and severity are unchanged. No upstream etcd mixin change (these alerts are CEO-only).

## Test plan
- [x] Diff is description-only for both alerts
- [ ] After merge / on a build with this CEO change:
  ```bash
  oc -n openshift-etcd-operator get prometheusrule etcd-prometheus-rules -o yaml | sed -n '/etcdSignerCAExpiration/,/severity:/p'
  ```

Fixes https://issues.redhat.com/browse/OCPBUGS-105322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected formatting in signer CA expiration alert descriptions.
  * Clarified warning and critical thresholds as less than two years and less than one year, respectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->