### PR TITLE
OCPBUGS-80957: Reset node status when UID changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openshift/api v0.0.0-20260817181206-aa91c5e2b221
 	github.com/openshift/build-machinery-go v0.0.0-20260625204636-d138cd032dd0
 	github.com/openshift/client-go v0.0.0-20260810202730-ddca5e0b7146
-	github.com/openshift/library-go v0.0.0-20260814203017-a0584a625d6d
+	github.com/openshift/library-go v0.0.0-20260821222658-93ac9206ae34
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/openshift/build-machinery-go v0.0.0-20260625204636-d138cd032dd0 h1:q8
 github.com/openshift/build-machinery-go v0.0.0-20260625204636-d138cd032dd0/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260810202730-ddca5e0b7146 h1:fX/gaOPiS2vrYGSAFSeqqoWjj32H+NbMmB5RDjwhCnU=
 github.com/openshift/client-go v0.0.0-20260810202730-ddca5e0b7146/go.mod h1:bhbP5y308NNbImrgArOc9611HIDAMcNWdCCO4tq5ob4=
-github.com/openshift/library-go v0.0.0-20260814203017-a0584a625d6d h1:LQ9jGH1GkmNFnFDBHeNLN5fmm/lyTgtzGNqHN1NG/dw=
-github.com/openshift/library-go v0.0.0-20260814203017-a0584a625d6d/go.mod h1:IrZbEK+wVUMEd+aXzYR2DCCh0p5IaQ7DvycYGP7qIYM=
+github.com/openshift/library-go v0.0.0-20260821222658-93ac9206ae34 h1:8sqxTzwI3yVzDoRLcWDN6a4ntSdOhyHmUcH5rPl3j0w=
+github.com/openshift/library-go v0.0.0-20260821222658-93ac9206ae34/go.mod h1:IrZbEK+wVUMEd+aXzYR2DCCh0p5IaQ7DvycYGP7qIYM=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12 h1:AKx/w1qpS8We43bsRgf8Nll3CGlDHpr/WAXvuedTNZI=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
@@ -69,4 +69,7 @@ const (
 	// NodeControllerDegradedConditionType is true when the operator observed a master node that is not ready.
 	// Note that a node is not ready when its Condition.NodeReady wasn't set to true
 	NodeControllerDegradedConditionType = "NodeControllerDegraded"
+
+	// GuardControllerDegradedConditionType is true when the guard controller observed an error while managing guard pods or PodDisruptionBudgets.
+	GuardControllerDegradedConditionType = "GuardControllerDegraded"
 )

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/pkg/errors"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
@@ -94,6 +96,7 @@ type InstallerController struct {
 	configMapsGetter corev1client.ConfigMapsGetter
 	secretsGetter    corev1client.SecretsGetter
 	podsGetter       corev1client.PodsGetter
+	nodeLister       corev1listers.NodeLister
 	eventRecorder    events.Recorder
 	now              func() time.Time // for test plumbing
 
@@ -179,6 +182,7 @@ func NewInstallerController(
 	secrets []revision.RevisionResource,
 	command []string,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
+	kubeInformersClusterScoped informers.SharedInformerFactory,
 	operatorClient v1helpers.StaticPodOperatorClient,
 	configMapsGetter corev1client.ConfigMapsGetter,
 	secretsGetter corev1client.SecretsGetter,
@@ -197,6 +201,7 @@ func NewInstallerController(
 		configMapsGetter: configMapsGetter,
 		secretsGetter:    secretsGetter,
 		podsGetter:       podsGetter,
+		nodeLister:       kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
 		eventRecorder:    eventRecorder.WithComponentSuffix("installer-controller"),
 		now:              time.Now,
 		startupMonitorEnabled: func() (bool, error) {
@@ -218,7 +223,12 @@ func NewInstallerController(
 			// informers are needed here because their Getter are cached lister based
 			kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
 			kubeInformersForTargetNamespace.Core().V1().ConfigMaps().Informer(),
-			kubeInformersForTargetNamespace.Core().V1().Secrets().Informer())
+			kubeInformersForTargetNamespace.Core().V1().Secrets().Informer(),
+		).
+		WithBareInformers(
+			// Don't need to sync on node changes, just wait for informer cache sync
+			kubeInformersClusterScoped.Core().V1().Nodes().Informer(),
+		)
 
 	return c
 }
@@ -606,6 +616,9 @@ func nodeStatusToNodeStatusApplyConfigurations(nodeStatus operatorv1.NodeStatus)
 		WithLastFailedCount(nodeStatus.LastFailedCount).
 		WithLastFallbackCount(nodeStatus.LastFallbackCount).
 		WithLastFailedRevisionErrors(nodeStatus.LastFailedRevisionErrors...)
+	if nodeStatus.NodeUID != "" {
+		nodeStatusApplyConfiguration = nodeStatusApplyConfiguration.WithNodeUID(nodeStatus.NodeUID)
+	}
 	if nodeStatus.LastFailedTime != nil {
 		nodeStatusApplyConfiguration = nodeStatusApplyConfiguration.WithLastFailedTime(*nodeStatus.LastFailedTime)
 	}
@@ -615,6 +628,7 @@ func nodeStatusToNodeStatusApplyConfigurations(nodeStatus operatorv1.NodeStatus)
 func nodeStatusApplyConfigToOperatorNodeStatus(nodeStatusApplyConfiguration *applyoperatorv1.NodeStatusApplyConfiguration) *operatorv1.NodeStatus {
 	return &operatorv1.NodeStatus{
 		NodeName:                 ptr.Deref(nodeStatusApplyConfiguration.NodeName, ""),
+		NodeUID:                  ptr.Deref(nodeStatusApplyConfiguration.NodeUID, ""),
 		CurrentRevision:          ptr.Deref(nodeStatusApplyConfiguration.CurrentRevision, 0),
 		TargetRevision:           ptr.Deref(nodeStatusApplyConfiguration.TargetRevision, 0),
 		LastFailedRevision:       ptr.Deref(nodeStatusApplyConfiguration.LastFailedRevision, 0),
@@ -1123,6 +1137,25 @@ func (c InstallerController) ensureRequiredResourcesExist(ctx context.Context, r
 	return fmt.Errorf("missing required resources: %v", aggregatedErr)
 }
 
+func (c *InstallerController) shouldSkipNodeStatusUpdate(nodeName, nodeUid string) (bool, error) {
+	if nodeUid == "" {
+		return false, nil
+	}
+	node, err := c.nodeLister.Get(nodeName)
+	if apierrors.IsNotFound(err) {
+		klog.Warningf("Skipping node status update for %s: node not found", nodeName)
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if string(node.UID) != nodeUid {
+		klog.Warningf("Skipping node status update for %s: node UID changed (stored=%s, actual=%s)", nodeName, nodeUid, node.UID)
+		return true, nil
+	}
+	return false, nil
+}
+
 func (c *InstallerController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	operatorSpec, originalOperatorStatus, operatorResourceVersion, err := c.operatorClient.GetStaticPodOperatorState()
 	if err != nil {
@@ -1162,6 +1195,17 @@ func (c *InstallerController) Sync(ctx context.Context, syncCtx factory.SyncCont
 
 	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
 		return nil
+	}
+
+	// Check for stale node status entries with mismatched UID
+	for _, nodeStatus := range originalOperatorStatus.NodeStatuses {
+		if shouldSkip, err := c.shouldSkipNodeStatusUpdate(nodeStatus.NodeName, nodeStatus.NodeUID); err != nil {
+			return errors.Wrapf(err, "error validating uid for node %s", nodeStatus.NodeName)
+		} else if shouldSkip {
+			// Avoid applying node statuses when a stale entry is found
+			// Sync will retrigger when the old node status is removed by the node controller
+			return nil
+		}
 	}
 
 	err = c.ensureRequiredResourcesExistFn(ctx, originalOperatorStatus.LatestAvailableRevision)
@@ -1204,6 +1248,7 @@ func deepCopyNodeStatusWithoutOldFailedState(ns *operatorv1.NodeStatus) *operato
 	if ns.TargetRevision == 0 || ns.TargetRevision != ns.LastFailedRevision {
 		return &operatorv1.NodeStatus{
 			NodeName:        ns.NodeName,
+			NodeUID:         ns.NodeUID,
 			CurrentRevision: ns.CurrentRevision,
 			TargetRevision:  ns.TargetRevision,
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/node/node_controller.go
@@ -84,22 +84,24 @@ func (c *NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) 
 		nodes = append(nodes, extraNodes...)
 	}
 
+	nodeUIDs := map[string]string{}
+	for _, node := range nodes {
+		nodeUIDs[node.Name] = string(node.UID)
+	}
+
 	jsonPatch := jsonpatch.New()
 	var removedNodeStatusesCounter int
 	newTargetNodeStates := []*applyoperatorv1.NodeStatusApplyConfiguration{}
 	// remove entries for missing nodes
 	for i, nodeState := range originalOperatorStatus.NodeStatuses {
-		found := false
-		for _, node := range nodes {
-			if nodeState.NodeName == node.Name {
-				found = true
-			}
-		}
-		if found {
-			newTargetNodeState := applyoperatorv1.NodeStatus().WithNodeName(originalOperatorStatus.NodeStatuses[i].NodeName)
+		currentUID, found := nodeUIDs[nodeState.NodeName]
+		if found && (nodeState.NodeUID == currentUID || nodeState.NodeUID == "") {
+			newTargetNodeState := applyoperatorv1.NodeStatus().
+				WithNodeName(nodeState.NodeName).
+				WithNodeUID(currentUID)
 			newTargetNodeStates = append(newTargetNodeStates, newTargetNodeState)
 		} else {
-			syncCtx.Recorder().Warningf("MasterNodeRemoved", "Observed removal of master node %s", nodeState.NodeName)
+			syncCtx.Recorder().Warningf("MasterNodeRemoved", "Observed removal of master node %s (UID: %s)", nodeState.NodeName, nodeState.NodeUID)
 			// each delete operation is applied to the object,
 			// which modifies the array. Thus, we need to
 			// adjust the indices to find the correct node to remove.
@@ -116,16 +118,19 @@ func (c *NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) 
 	for _, node := range nodes {
 		found := false
 		for _, nodeState := range originalOperatorStatus.NodeStatuses {
+			// NodeUID is intentionally ignored here. Nodes that are replaced with the same name will get added in the next sync
+			// to ensure previous nodeStatus from a stale cache isn't merged in with the fresh status.
 			if nodeState.NodeName == node.Name {
 				found = true
+				break
 			}
 		}
 		if found {
 			continue
 		}
 
-		syncCtx.Recorder().Eventf("MasterNodeObserved", "Observed new master node %s", node.Name)
-		newTargetNodeState := applyoperatorv1.NodeStatus().WithNodeName(node.Name)
+		syncCtx.Recorder().Eventf("MasterNodeObserved", "Observed new master node %s (UID: %s)", node.Name, node.UID)
+		newTargetNodeState := applyoperatorv1.NodeStatus().WithNodeName(node.Name).WithNodeUID(string(node.UID))
 		newTargetNodeStates = append(newTargetNodeStates, newTargetNodeState)
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
@@ -283,6 +283,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 			b.revisionSecrets,
 			b.installCommand,
 			operandInformers,
+			clusterInformers,
 			b.staticPodOperatorClient,
 			configMapClient,
 			secretClient,

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
@@ -301,7 +301,7 @@ func (n *fakeNodeLister) List(selector labels.Selector) ([]*corev1.Node, error) 
 }
 
 func (n *fakeNodeLister) Get(name string) (*corev1.Node, error) {
-	panic("implement me")
+	return n.client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
 }
 
 // NewFakeOperatorClient returns a fake operator client suitable to use in static pod controller unit tests.
@@ -499,6 +499,7 @@ func mergeStaticPodOperatorStatusApplyConfiguration(currentOperatorStatus *v1.Op
 	for _, nodeStatus := range applyConfiguration.NodeStatuses {
 		newNodeStatus := operatorv1.NodeStatus{
 			NodeName:                 ptr.Deref(nodeStatus.NodeName, ""),
+			NodeUID:                  ptr.Deref(nodeStatus.NodeUID, ""),
 			CurrentRevision:          ptr.Deref(nodeStatus.CurrentRevision, 0),
 			TargetRevision:           ptr.Deref(nodeStatus.TargetRevision, 0),
 			LastFailedRevision:       ptr.Deref(nodeStatus.LastFailedRevision, 0),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -441,7 +441,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20260814203017-a0584a625d6d
+# github.com/openshift/library-go v0.0.0-20260821222658-93ac9206ae34
 ## explicit; go 1.26.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
Fixed by the same changes for https://github.com/openshift/cluster-kube-apiserver-operator/pull/2199
Just need to pull in updated static pod controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->