### PR TITLE
OCPBUGS-105882: Remove dead etcd members during a revision rollout

### DIFF
--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller.go
@@ -123,6 +123,29 @@ func (c *clusterMemberRemovalController) sync(ctx context.Context, syncCtx facto
 		return nil
 	}
 
+	// only attempt member removal if the machine API is functional. This is a precondition
+	// for classifying a member as dead: removeUnhealthyMemberWithoutNode decides whether a
+	// member's Machine still exists via the machine lister, which is only meaningful when the
+	// Machine API is functional.
+	if isFunctional, err := c.machineAPIChecker.IsFunctional(); err != nil {
+		return err
+	} else if !isFunctional {
+		return nil
+	}
+
+	var errs []error
+
+	// Remove members whose backing Node is gone and that are reported unhealthy, regardless of
+	// revision stability. A revision rollout never deletes the Node object (it only reinstalls the
+	// static pod), so "Node gone + unhealthy" reliably identifies a genuinely decommissioned member
+	// rather than one that is transiently unhealthy mid-rollout. Such a member is dead: its static
+	// pod cannot be running without a Node. Leaving it in the membership keeps churning the
+	// etcd-endpoints configmap, which keeps rolling revisions, which would otherwise block its own
+	// removal behind the revision gate below (OCPBUGS-105882).
+	if err := c.removeUnhealthyMemberWithoutNode(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
 	// Removing multiple members in the middle of a revision rollout can cause API unavailability
 	// when simultaneously deleting multiple machines with the controlplanemachineset "OnDelete" strategy,
 	// i.e we have multiple machines pending deletion and multiple new replacements added
@@ -132,23 +155,16 @@ func (c *clusterMemberRemovalController) sync(ctx context.Context, syncCtx facto
 	// the etcd pod is reinstalled to the latest revision.
 	// This is different from when the member is indefinitely unhealthy when the revision is stable.
 	//
-	// Additionally the EtcdEndpointsController pauses while a revision rollout is in progress
-	// So initially if the etcd-endpoints configmap is updated from 3->4 when the first replacement machine
-	// is added to the membership, a revision rollout will start and the configmap won't update in this period.
-	// But the ClusterMemberRemovalController will still delete a seemingly unhealthy machine during rollout
-	// The API servers on the old revision will neither see the new replacement etcd endpoint, and will also
-	// be using a removed member's endpoint.
-	//
 	// Moreover the EtcdEndpointsController uses the live etcd membership list to make scale down considerations for etcd quorum so the etcd-endpoints configmap always lags behind it.
 	//
-	// So the EtcdEndpointsController skips until the revision is stable so we remove members one at a time and unhealthy members are truly unhealthy
+	// So the scale-down paths below wait until the revision is stable so we remove members one at a time and unhealthy members are truly unhealthy.
 	revisionStable, err := ceohelpers.IsRevisionStable(c.operatorClient)
 	if err != nil {
-		return fmt.Errorf("couldn't determine stability of revisions: %w", err)
+		return kerrors.NewAggregate(append(errs, fmt.Errorf("couldn't determine stability of revisions: %w", err)))
 	}
 	if !revisionStable {
-		klog.V(2).Infof("skipping due to revision in progress")
-		return nil
+		klog.V(2).Infof("skipping scale-down due to revision in progress")
+		return kerrors.NewAggregate(errs)
 	}
 
 	// Ensure the live etcd membership matches the etcd-endpoints configmap.
@@ -156,23 +172,12 @@ func (c *clusterMemberRemovalController) sync(ctx context.Context, syncCtx facto
 	// and propagated through a revision rollout.
 	etcdEndpointsUpdated, err := c.isEtcdEndpointsUpdated(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to check if etcd endpoints are updated: %w", err)
+		return kerrors.NewAggregate(append(errs, fmt.Errorf("failed to check if etcd endpoints are updated: %w", err)))
 	}
 	if !etcdEndpointsUpdated {
-		return nil
+		return kerrors.NewAggregate(errs)
 	}
 
-	// only attempt to scale down if the machine API is functional
-	if isFunctional, err := c.machineAPIChecker.IsFunctional(); err != nil {
-		return err
-	} else if !isFunctional {
-		return nil
-	}
-
-	var errs []error
-	if err := c.removeMemberWithoutMachine(ctx); err != nil {
-		errs = append(errs, err)
-	}
 	if err := c.attemptToRemoveLearningMember(ctx, syncCtx.Recorder()); err != nil {
 		errs = append(errs, err)
 	}
@@ -323,7 +328,16 @@ func (c *clusterMemberRemovalController) attemptToScaleDown(ctx context.Context,
 	return kerrors.NewAggregate(allErrs)
 }
 
-func (c *clusterMemberRemovalController) removeMemberWithoutMachine(ctx context.Context) error {
+// removeUnhealthyMemberWithoutNode removes etcd members that are dead: their backing Node is gone,
+// their Machine is either absent (true orphan) or pending deletion (a tombstone whose finalization
+// is blocked by the etcd PreDrain hook until the member leaves), and etcd reports them unhealthy.
+//
+// It is safe to run this regardless of revision stability. A revision rollout never deletes the Node
+// object, so a member that is only transiently unhealthy because its static pod is being reinstalled
+// still has a Node and is skipped here. A member with no Node has no running static pod, so it is
+// genuinely dead. Removing an unhealthy member is always quorum-safe: it only lowers etcd's quorum
+// threshold and does not change the count of healthy members, so no explicit quorum check is needed.
+func (c *clusterMemberRemovalController) removeUnhealthyMemberWithoutNode(ctx context.Context) error {
 	etcdEndpointsConfigMap, err := c.configMapListerForTargetNamespace.Get("etcd-endpoints")
 	if err != nil {
 		return err // should not happen
@@ -333,14 +347,6 @@ func (c *clusterMemberRemovalController) removeMemberWithoutMachine(ctx context.
 	}
 	for _, potentialMemberToRemoveIP := range etcdEndpointsConfigMap.Data {
 		memberLocator := potentialMemberToRemoveIP
-		machine, err := c.getMachineForMember(potentialMemberToRemoveIP)
-		if err != nil && err != errNotFound {
-			return fmt.Errorf("unable to get a machine for member: %v, err: %v", memberLocator, err)
-		}
-		if machine != nil {
-			klog.V(4).Infof("cannot remove member: %v because a machine resource still exists (%v/%v)", memberLocator, machine.Name, machine.UID)
-			continue
-		}
 
 		node, err := c.getNodeForMember(potentialMemberToRemoveIP)
 		if err != nil && err != errNotFound {
@@ -351,8 +357,20 @@ func (c *clusterMemberRemovalController) removeMemberWithoutMachine(ctx context.
 			continue
 		}
 
-		// it looks like we have found a member that isn't backed by a machine nor a node
-		// issue a live request to the etcd cluster and remove it from the cluster
+		// The node is gone. Look up the machine by the node's internal IP; a machine pending deletion
+		// keeps its addresses as a tombstone. A machine that still exists and is not pending deletion
+		// means the node loss should be handled by remediation, not by removing the member here.
+		machine, err := ceohelpers.FindMachineByNodeInternalIP(potentialMemberToRemoveIP, c.masterMachineSelector, c.masterMachineLister)
+		if err != nil {
+			return fmt.Errorf("unable to get a machine for member: %v, err: %v", memberLocator, err)
+		}
+		if machine != nil && machine.DeletionTimestamp == nil {
+			klog.V(4).Infof("cannot remove member: %v because a machine resource still exists and is not pending deletion (%v/%v)", memberLocator, machine.Name, machine.UID)
+			continue
+		}
+
+		// it looks like we have found a member whose node is gone and whose machine is absent or
+		// pending deletion, issue a live request to the etcd cluster and remove it from the cluster
 		memberList, err := c.etcdClient.MemberList(ctx)
 		if err != nil {
 			return err
@@ -371,7 +389,7 @@ func (c *clusterMemberRemovalController) removeMemberWithoutMachine(ctx context.
 				return err
 			}
 			if isMemberHealthy {
-				return fmt.Errorf("cannot remove member: %v because it is reported as healthy but it doesn't have a machine nor a node resource", memberLocator)
+				return fmt.Errorf("cannot remove member: %v because it is reported as healthy but its node is gone", memberLocator)
 			}
 
 			memberLocator = fmt.Sprintf("[ url: %v, name: %v, id: %v ]", memberIP, member.Name, member.ID)
@@ -432,35 +450,6 @@ func (c *clusterMemberRemovalController) attemptToRemoveLearningMember(ctx conte
 	}
 
 	return kerrors.NewAggregate(allErrs)
-}
-
-func (c *clusterMemberRemovalController) getMachineForMember(memberInternalIP string) (*machinev1beta1.Machine, error) {
-	node, err := c.getNodeForMember(memberInternalIP)
-	if err != nil && err != errNotFound {
-		return nil, err
-	}
-
-	// node is gone, make sure we don't have a machine with
-	// the same internal IP as the node would have had
-	if node == nil {
-		nodeInternalIP := memberInternalIP
-		machine, err := ceohelpers.FindMachineByNodeInternalIP(nodeInternalIP, c.masterMachineSelector, c.masterMachineLister)
-		if err != nil {
-			return nil, err
-		}
-		return machine, nil
-	}
-
-	machines, err := c.masterMachineLister.List(c.masterMachineSelector)
-	if err != nil {
-		return nil, err
-	}
-	for _, machine := range machines {
-		if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name == node.Name {
-			return machine, nil
-		}
-	}
-	return nil, errNotFound
 }
 
 func (c *clusterMemberRemovalController) getNodeForMember(memberInternalIP string) (*corev1.Node, error) {

--- a/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
+++ b/pkg/operator/clustermemberremovalcontroller/clustermemberremovalcontroller_test.go
@@ -16,6 +16,7 @@ import (
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	machinelistersv1beta1 "github.com/openshift/client-go/machine/listers/machine/v1beta1"
 	"github.com/openshift/cluster-etcd-operator/pkg/etcdcli"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
@@ -23,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -183,8 +185,10 @@ func TestClusterMemberRemovalController(t *testing.T) {
 		initialObjectsForNodeLister      []runtime.Object
 		initialObjectsForMachineLister   []runtime.Object
 		initialEtcdMemberList            []*etcdserverpb.Member
+		fakeEtcdClientOptions            []etcdcli.FakeClientOption
 		validateFn                       func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient)
 		serviceNetwork                   string
+		expectError                      bool
 	}{
 		// scenario 1
 		{
@@ -337,6 +341,50 @@ func TestClusterMemberRemovalController(t *testing.T) {
 				}
 			},
 		},
+
+		// scenario 5: half-orphan - node is gone but the machine is a tombstone (pending deletion)
+		{
+			name:                             "an etcd member whose node is gone and whose machine is pending deletion is removed",
+			serviceNetwork:                   "172.30.0.0/16",
+			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
+			initialObjectsForMachineLister: []runtime.Object{
+				machinePendingDeletionFor("m-1", "10.0.139.78"),
+				machinePendingDeletionFor("m-2", "10.0.139.79"),
+				machinePendingDeletionFor("m-3", "10.0.139.80"),
+			},
+			initialEtcdMemberList: wellKnownEtcdMemberList(),
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 0 {
+					t.Errorf("expected an empty member list, got %v", memberList)
+				}
+			},
+		},
+
+		// scenario 6: node and machine are gone but the member still reports healthy -> not removed, error
+		{
+			name:                             "an etcd member whose node is gone but that reports healthy is not removed and errors",
+			serviceNetwork:                   "172.30.0.0/16",
+			isFunctionalMachineAPIFn:         alwaysTrueIsFunctionalMachineAPIFn,
+			initialObjectsForConfigMapLister: []runtime.Object{wellKnownEtcdEndpointsConfigMap()},
+			initialEtcdMemberList:            wellKnownEtcdMemberList(),
+			// all members report healthy, so the unbacked member must not be removed
+			fakeEtcdClientOptions: []etcdcli.FakeClientOption{etcdcli.WithFakeClusterHealth(&etcdcli.FakeMemberHealth{Healthy: 3})},
+			expectError:           true,
+			validateFn: func(t *testing.T, fakeEtcdClient etcdcli.EtcdClient) {
+				memberList, err := fakeEtcdClient.MemberList(context.TODO())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(memberList) != 3 {
+					t.Errorf("expected all three etcd members to remain, got %v", memberList)
+				}
+			},
+		},
 	}
 
 	for _, scenario := range scenarios {
@@ -373,7 +421,7 @@ func TestClusterMemberRemovalController(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(scenario.initialEtcdMemberList)
+			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(scenario.initialEtcdMemberList, scenario.fakeEtcdClientOptions...)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -389,12 +437,272 @@ func TestClusterMemberRemovalController(t *testing.T) {
 				masterMachineLister:               machineLister,
 				networkLister:                     networkLister,
 			}
-			err = target.removeMemberWithoutMachine(context.TODO())
-			if err != nil {
+			err = target.removeUnhealthyMemberWithoutNode(context.TODO())
+			if scenario.expectError {
+				require.Error(t, err)
+			} else if err != nil {
 				t.Fatal(err)
 			}
 			if scenario.validateFn != nil {
 				scenario.validateFn(t, fakeEtcdClient)
+			}
+		})
+	}
+}
+
+// TestSync exercises the full sync() gate ordering, in particular that dead members (node gone)
+// are removed even while a revision rollout is in progress, while the quorum-sensitive scale-down
+// and learner paths remain gated behind revision stability.
+func TestSync(t *testing.T) {
+	votingMember4 := &etcdserverpb.Member{Name: "m-4", ID: 4, PeerURLs: []string{"https://10.0.139.81:1234"}}
+	learnerMember4 := &etcdserverpb.Member{Name: "m-4", ID: 4, IsLearner: true, PeerURLs: []string{"https://10.0.139.81:1234"}}
+
+	members4 := func() []*etcdserverpb.Member { return append(wellKnownEtcdMemberList(), votingMember4) }
+	membersLearner := func() []*etcdserverpb.Member { return append(wellKnownEtcdMemberList(), learnerMember4) }
+
+	nodes123 := func() []runtime.Object {
+		return []runtime.Object{
+			masterNodeFor("m-1", "10.0.139.78"),
+			masterNodeFor("m-2", "10.0.139.79"),
+			masterNodeFor("m-3", "10.0.139.80"),
+		}
+	}
+	nodes1234 := func() []runtime.Object { return append(nodes123(), masterNodeFor("m-4", "10.0.139.81")) }
+
+	machines123AndPendingM4 := func() []runtime.Object {
+		return append(wellKnownMasterMachines(), machinePendingDeletionFor("m-4", "10.0.139.81"))
+	}
+
+	endpoints4 := map[string]string{"m-1": "10.0.139.78", "m-2": "10.0.139.79", "m-3": "10.0.139.80", "m-4": "10.0.139.81"}
+	endpoints3 := map[string]string{"m-1": "10.0.139.78", "m-2": "10.0.139.79", "m-3": "10.0.139.80"}
+
+	scenarios := []struct {
+		name                 string
+		bootstrapComplete    bool
+		machineAPIFunctional bool
+		revisionStable       bool
+		members              []*etcdserverpb.Member
+		health               *etcdcli.FakeMemberHealth
+		nodes                []runtime.Object
+		machines             []runtime.Object
+		endpoints            map[string]string
+		expectError          bool
+		expectedRemainingIDs []uint64
+	}{
+		{
+			// A: dead member with no node and no machine is removed mid-rollout
+			name:                 "true orphan is removed while a revision rollout is in progress",
+			bootstrapComplete:    true,
+			machineAPIFunctional: true,
+			revisionStable:       false,
+			members:              members4(),
+			health:               &etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1},
+			nodes:                nodes123(),
+			machines:             wellKnownMasterMachines(),
+			endpoints:            endpoints4,
+			expectedRemainingIDs: []uint64{1, 2, 3},
+		},
+		{
+			// J: half-orphan (node gone, machine pending deletion) is removed mid-rollout
+			name:                 "half-orphan with a tombstone machine is removed while a revision rollout is in progress",
+			bootstrapComplete:    true,
+			machineAPIFunctional: true,
+			revisionStable:       false,
+			members:              members4(),
+			health:               &etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1},
+			nodes:                nodes123(),
+			machines:             machines123AndPendingM4(),
+			endpoints:            endpoints4,
+			expectedRemainingIDs: []uint64{1, 2, 3},
+		},
+		{
+			// B: a member pending deletion whose node still exists is not removed during a rollout
+			name:                 "voting member pending deletion with a node is not removed during a rollout",
+			bootstrapComplete:    true,
+			machineAPIFunctional: true,
+			revisionStable:       false,
+			members:              members4(),
+			health:               &etcdcli.FakeMemberHealth{Healthy: 4},
+			nodes:                nodes1234(),
+			machines:             machines123AndPendingM4(),
+			endpoints:            endpoints4,
+			expectedRemainingIDs: []uint64{1, 2, 3, 4},
+		},
+		{
+			// C: a learner pending deletion is not removed during a rollout
+			name:                 "learner pending deletion is not removed during a rollout",
+			bootstrapComplete:    true,
+			machineAPIFunctional: true,
+			revisionStable:       false,
+			members:              membersLearner(),
+			health:               &etcdcli.FakeMemberHealth{Healthy: 4},
+			nodes:                nodes123(),
+			machines:             machines123AndPendingM4(),
+			endpoints:            endpoints3, // learners are excluded from the etcd-endpoints configmap
+			expectedRemainingIDs: []uint64{1, 2, 3, 4},
+		},
+		{
+			// D: with a stable revision and matching endpoints, scale-down removes the member pending deletion
+			name:                 "scale-down removes a member pending deletion when the revision is stable",
+			bootstrapComplete:    true,
+			machineAPIFunctional: true,
+			revisionStable:       true,
+			members:              members4(),
+			health:               &etcdcli.FakeMemberHealth{Healthy: 4},
+			nodes:                nodes1234(),
+			machines:             machines123AndPendingM4(),
+			endpoints:            endpoints4,
+			expectedRemainingIDs: []uint64{1, 2, 3},
+		},
+		{
+			// E: stable revision but the endpoints configmap lags live membership -> nothing removed
+			name:                 "nothing is removed when the etcd-endpoints configmap lags live membership",
+			bootstrapComplete:    true,
+			machineAPIFunctional: true,
+			revisionStable:       true,
+			members:              members4(),
+			health:               &etcdcli.FakeMemberHealth{Healthy: 4},
+			nodes:                nodes123(),
+			machines:             machines123AndPendingM4(),
+			endpoints:            endpoints3, // does not include the 4th live voting member
+			expectedRemainingIDs: []uint64{1, 2, 3, 4},
+		},
+		{
+			// F: machine API not functional -> the whole controller is a no-op, even for a true orphan
+			name:                 "no removal when the machine API is not functional",
+			bootstrapComplete:    true,
+			machineAPIFunctional: false,
+			revisionStable:       false,
+			members:              members4(),
+			health:               &etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1},
+			nodes:                nodes123(),
+			machines:             wellKnownMasterMachines(),
+			endpoints:            endpoints4,
+			expectedRemainingIDs: []uint64{1, 2, 3, 4},
+		},
+		{
+			// G: bootstrap not complete -> the whole controller is a no-op
+			name:                 "no removal when bootstrap is not complete",
+			bootstrapComplete:    false,
+			machineAPIFunctional: true,
+			revisionStable:       false,
+			members:              members4(),
+			health:               &etcdcli.FakeMemberHealth{Healthy: 3, Unhealthy: 1},
+			nodes:                nodes123(),
+			machines:             wellKnownMasterMachines(),
+			endpoints:            endpoints4,
+			expectedRemainingIDs: []uint64{1, 2, 3, 4},
+		},
+		{
+			// H+I: an unbacked member that still reports healthy is not removed and the error is
+			// returned (aggregated) even though the revision is in progress (previously swallowed).
+			name:                 "unbacked but healthy member is not removed and the error is surfaced during a rollout",
+			bootstrapComplete:    true,
+			machineAPIFunctional: true,
+			revisionStable:       false,
+			members:              members4(),
+			health:               &etcdcli.FakeMemberHealth{Healthy: 4}, // IsMemberHealthy reports healthy
+			nodes:                nodes123(),
+			machines:             wellKnownMasterMachines(),
+			endpoints:            endpoints4,
+			expectError:          true,
+			expectedRemainingIDs: []uint64{1, 2, 3, 4},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			fakeMachineAPIChecker := &fakeMachineAPI{isMachineAPIFunctional: func() (bool, error) { return scenario.machineAPIFunctional, nil }}
+
+			// general configmap lister (kube-system/bootstrap for IsBootstrapComplete)
+			generalCMIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			if scenario.bootstrapComplete {
+				require.NoError(t, generalCMIndexer.Add(bootstrapComplete))
+			}
+			generalCMLister := corev1listers.NewConfigMapLister(generalCMIndexer)
+
+			// target-namespace configmap lister (etcd-endpoints)
+			targetCMIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			require.NoError(t, targetCMIndexer.Add(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "etcd-endpoints", Namespace: "openshift-etcd"},
+				Data:       scenario.endpoints,
+			}))
+			targetCMLister := corev1listers.NewConfigMapLister(targetCMIndexer).ConfigMaps("openshift-etcd")
+
+			nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, obj := range scenario.nodes {
+				require.NoError(t, nodeIndexer.Add(obj))
+			}
+			nodeLister := corev1listers.NewNodeLister(nodeIndexer)
+			nodeSelector, err := labels.Parse("node-role.kubernetes.io/master")
+			require.NoError(t, err)
+
+			machineIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, obj := range scenario.machines {
+				require.NoError(t, machineIndexer.Add(obj))
+			}
+			machineLister := machinelistersv1beta1.NewMachineLister(machineIndexer)
+			machineSelector, err := labels.Parse("machine.openshift.io/cluster-api-machine-role=master")
+			require.NoError(t, err)
+
+			networkIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			require.NoError(t, networkIndexer.Add(&configv1.Network{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Spec: configv1.NetworkSpec{ServiceNetwork: []string{"172.30.0.0/16"}}}))
+			networkLister := configv1listers.NewNetworkLister(networkIndexer)
+
+			infraIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			require.NoError(t, infraIndexer.Add(&configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status:     configv1.InfrastructureStatus{ControlPlaneTopology: configv1.HighlyAvailableTopologyMode},
+			}))
+			infraLister := configv1listers.NewInfrastructureLister(infraIndexer)
+
+			var status *operatorv1.StaticPodOperatorStatus
+			if scenario.revisionStable {
+				status = u.StaticPodOperatorStatus(u.WithLatestRevision(1), u.WithNodeStatusAtCurrentRevision(1), u.WithNodeStatusAtCurrentRevision(1), u.WithNodeStatusAtCurrentRevision(1))
+			} else {
+				status = u.StaticPodOperatorStatus(u.WithLatestRevision(2), u.WithNodeStatusAtCurrentRevision(1))
+			}
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(&operatorv1.StaticPodOperatorSpec{
+				OperatorSpec: operatorv1.OperatorSpec{ObservedConfig: runtime.RawExtension{Raw: []byte(wellKnownReplicasCountSet)}},
+			}, status, nil, nil)
+
+			fakeEtcdClient, err := etcdcli.NewFakeEtcdClient(scenario.members, etcdcli.WithFakeClusterHealth(scenario.health))
+			require.NoError(t, err)
+
+			target := clusterMemberRemovalController{
+				operatorClient:                    fakeOperatorClient,
+				etcdClient:                        fakeEtcdClient,
+				machineAPIChecker:                 fakeMachineAPIChecker,
+				configMapLister:                   generalCMLister,
+				configMapListerForTargetNamespace: targetCMLister,
+				masterNodeSelector:                nodeSelector,
+				masterNodeLister:                  nodeLister,
+				masterMachineSelector:             machineSelector,
+				masterMachineLister:               machineLister,
+				networkLister:                     networkLister,
+				infraLister:                       infraLister,
+			}
+
+			recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+			err = target.sync(context.TODO(), factory.NewSyncContext("test", recorder))
+			if scenario.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			memberList, err := fakeEtcdClient.MemberList(context.TODO())
+			require.NoError(t, err)
+			gotIDs := sets.NewInt64()
+			for _, m := range memberList {
+				gotIDs.Insert(int64(m.ID))
+			}
+			wantIDs := sets.NewInt64()
+			for _, id := range scenario.expectedRemainingIDs {
+				wantIDs.Insert(int64(id))
+			}
+			if !gotIDs.Equal(wantIDs) {
+				t.Errorf("unexpected remaining members: got IDs %v, want %v", gotIDs.List(), wantIDs.List())
 			}
 		})
 	}
@@ -1214,6 +1522,18 @@ func wellKnownMasterNode() *corev1.Node {
 	}
 }
 
+func masterNodeFor(name, internalIP string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{"node-role.kubernetes.io/master": ""}},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: internalIP,
+			},
+		}},
+	}
+}
+
 func wellKnownMasterNodeIpv6() *corev1.Node {
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "m-0", Labels: map[string]string{"node-role.kubernetes.io/master": ""}},
@@ -1290,6 +1610,15 @@ func wellKnownMasterMachines() []runtime.Object {
 		machineWithHooksFor("m-2", "10.0.139.79"),
 		machineWithHooksFor("m-3", "10.0.139.80"),
 	}
+}
+
+// machinePendingDeletionFor builds a master machine with the etcd deletion hook and a set
+// DeletionTimestamp, i.e. a tombstone whose finalization is blocked by the PreDrain hook until
+// the etcd member leaves the cluster.
+func machinePendingDeletionFor(name, internalIP string) *machinev1beta1.Machine {
+	m := machineWithHooksFor(name, internalIP)
+	m.DeletionTimestamp = &metav1.Time{}
+	return m
 }
 
 func TestIsEtcdEndpointsUpdated(t *testing.T) {


### PR DESCRIPTION
## What

Remove an etcd member whose backing Node is gone and that etcd reports
unhealthy, even while a static-pod revision rollout is in progress. This runs
ahead of the revision-stability gate; the quorum-sensitive scale-down and
learner-removal paths still wait for revisions to stabilize.

This supersedes #1684. That PR moved orphan removal ahead of the revision gate
but only for members with no Machine, so it missed the case where the Machine is
still present as a tombstone pending deletion. Keying on Node absence instead of
Machine absence covers both.

## Why

After a control-plane node is replaced, the stale (unhealthy) etcd member keeps
the `etcd-endpoints` configmap churning, which keeps rolling new revisions, which
keeps `IsRevisionStable()` false. `ClusterMemberRemovalController.sync()` bailed
out early whenever revisions were unstable, so the member was never removed and
the churn sustained itself. The stale member was both the cause of the
instability and the thing the instability blocked us from removing.

The fix keys removal on **Node absence** rather than Machine absence. A revision
rollout never deletes the Node object (it only reinstalls the static pod), so:

- a member with no Node has no running etcd pod and is genuinely dead, safe to
  remove regardless of revision state;
- a member that is only transiently unhealthy mid-rollout still has its Node and
  is left alone.

The scenario this addresses is the assisted-installer late-binding master
replacement flow: a manual bind/unbind of the host through the Kube API (the
Agent CR). The old Node and Machine are torn down out of band, leaving the
member as a true orphan (no Machine and no Node) or a half-orphan (Machine still
present as a tombstone pending deletion); both are now removed.

MachineHealthCheck / CPMS remediation is unaffected: there the etcd `PreDrain`
hook keeps the Machine and the Node alive until the member is first removed, so
the member still has a Node and continues to be handled by the gated scale-down
path.

Removing an orphan member only lowers etcd's quorum threshold and never removes
a healthy member, so it is always quorum-safe and needs no quorum check. The
Machine-API-functional precondition is retained (it is required to classify
whether a member's Machine still exists).

## Testing

- New `TestSync` table test covering the full gate ordering: dead members
  (true orphan and half-orphan) are removed during a rollout; scale-down and
  learner removal stay gated; machine-API / bootstrap / endpoints-lag gates; and
  that an error from the dead-member removal is surfaced (not swallowed) when the
  revision is unstable.
- `TestClusterMemberRemovalController` updated for the generalized predicate,
  with new cases for the half-orphan and the healthy-but-unbacked error.
- `make build` and `make verify` pass.

## Reference: assisted-installer late-binding unbind flow

`assisted-service` `internal/controller/controllers/agent_controller.go`:
- `unbindHost` — hub-side DB state only.
- `cleanUnboundSpokeNode` → `removeSpokeResources` (spoke-side):
  - deletes the Node from the spoke;
  - finds the Machine via the `machine.openshift.io/machine` annotation on the node;
  - annotates the Machine with `machine.openshift.io/delete-machine: true` and
    `machine.openshift.io/exclude-node-draining: true`;
  - for masters (no MachineSet): calls `Delete` on the Machine (and the BMH).

Assisted does not touch etcd membership/configmaps; it expects the etcd operator
to remove the member once the Node/Machine are gone. Our predicate (Node gone +
Machine absent-or-pending-deletion + member unhealthy) matches both end-states of
this flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unhealthy cluster members when their associated nodes are missing or being deleted.
  * Prevented unsafe member removal during revision rollouts and while etcd membership is out of sync.
  * Added live health checks before removing orphaned members.
  * Preserved accumulated errors to improve reliability and diagnostics.

* **Tests**
  * Expanded coverage for bootstrap states, pending deletions, learner members, quorum health, revision stability, and endpoint synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->