### PR TITLE
OCPBUGS-94106: fall back to intermediate ciphers during etcd bootstrap

### DIFF
--- a/pkg/etcdenvvar/envvarcontroller.go
+++ b/pkg/etcdenvvar/envvarcontroller.go
@@ -48,14 +48,15 @@ type EnvVarController struct {
 	targetImagePullSpec string
 	listeners           []Enqueueable
 
-	infrastructureLister    configv1listers.InfrastructureLister
-	networkLister           configv1listers.NetworkLister
-	configmapLister         corev1listers.ConfigMapLister
-	secretLister            corev1listers.SecretLister
-	masterNodeLister        corev1listers.NodeLister
-	masterNodeLabelSelector labels.Selector
-	etcdLister              operatorv1listers.EtcdLister
-	featureGateAccessor     featuregates.FeatureGateAccess
+	infrastructureLister     configv1listers.InfrastructureLister
+	networkLister            configv1listers.NetworkLister
+	configmapLister          corev1listers.ConfigMapLister
+	bootstrapConfigMapLister corev1listers.ConfigMapLister
+	secretLister             corev1listers.SecretLister
+	masterNodeLister         corev1listers.NodeLister
+	masterNodeLabelSelector  labels.Selector
+	etcdLister               operatorv1listers.EtcdLister
+	featureGateAccessor      featuregates.FeatureGateAccess
 
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue         workqueue.RateLimitingInterface
@@ -82,28 +83,25 @@ func NewEnvVarController(
 	featureGateAccessor featuregates.FeatureGateAccess,
 ) *EnvVarController {
 	c := &EnvVarController{
-		operatorClient:          operatorClient,
-		infrastructureLister:    infrastructureInformer.Lister(),
-		networkLister:           networkInformer.Lister(),
-		configmapLister:         kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Lister(),
-		secretLister:            kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
-		masterNodeLister:        masterNodeLister,
-		masterNodeLabelSelector: masterNodeLabelSelector,
-		targetImagePullSpec:     targetImagePullSpec,
-		etcdLister:              etcdsInformer.Lister(),
-		featureGateAccessor:     featureGateAccessor,
+		operatorClient:           operatorClient,
+		infrastructureLister:     infrastructureInformer.Lister(),
+		networkLister:            networkInformer.Lister(),
+		configmapLister:          kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Lister(),
+		bootstrapConfigMapLister: kubeInformersForNamespaces.InformersFor(operatorclient.KubeSystemNamespace).Core().V1().ConfigMaps().Lister(),
+		secretLister:             kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
+		masterNodeLister:         masterNodeLister,
+		masterNodeLabelSelector:  masterNodeLabelSelector,
+		targetImagePullSpec:      targetImagePullSpec,
+		etcdLister:               etcdsInformer.Lister(),
+		featureGateAccessor:      featureGateAccessor,
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "EnvVarController"),
 		cachesToSync: []cache.InformerSynced{
 			operatorClient.Informer().HasSynced,
 			infrastructureInformer.Informer().HasSynced,
 			networkInformer.Informer().HasSynced,
-			// The EnvVarController reads cipher suites from observedConfig, which is
-			// populated by the ConfigObserver watching the APIServer CR. Waiting for
-			// the APIServer informer cache to sync ensures the ConfigObserver can run
-			// before the EnvVarController reads observedConfig, preventing bootstrap
-			// timing races where observedConfig is still empty.
 			apiServerInformer.Informer().HasSynced,
+			kubeInformersForNamespaces.InformersFor(operatorclient.KubeSystemNamespace).Core().V1().ConfigMaps().Informer().HasSynced,
 			kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Informer().HasSynced,
 			kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Informer().HasSynced,
 			kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer().HasSynced,
@@ -119,6 +117,7 @@ func NewEnvVarController(
 	kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Endpoints().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
+	kubeInformersForNamespaces.InformersFor(operatorclient.KubeSystemNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	etcdsInformer.Informer().AddEventHandler(c.eventHandler())
 	masterNodeInformer.AddEventHandler(c.eventHandler())
 	apiServerInformer.Informer().AddEventHandler(c.eventHandler())
@@ -170,16 +169,17 @@ func (c *EnvVarController) checkEnvVars() error {
 	}
 
 	currEnvVarMap, err := getEtcdEnvVars(envVarContext{
-		targetImagePullSpec:     c.targetImagePullSpec,
-		spec:                    *operatorSpec,
-		status:                  *operatorStatus,
-		configmapLister:         c.configmapLister,
-		masterNodeLister:        c.masterNodeLister,
-		masterNodeLabelSelector: c.masterNodeLabelSelector,
-		infrastructureLister:    c.infrastructureLister,
-		networkLister:           c.networkLister,
-		etcdLister:              c.etcdLister,
-		featureGateAccessor:     c.featureGateAccessor,
+		targetImagePullSpec:      c.targetImagePullSpec,
+		spec:                     *operatorSpec,
+		status:                   *operatorStatus,
+		configmapLister:          c.configmapLister,
+		bootstrapConfigMapLister: c.bootstrapConfigMapLister,
+		masterNodeLister:         c.masterNodeLister,
+		masterNodeLabelSelector:  c.masterNodeLabelSelector,
+		infrastructureLister:     c.infrastructureLister,
+		networkLister:            c.networkLister,
+		etcdLister:               c.etcdLister,
+		featureGateAccessor:      c.featureGateAccessor,
 	})
 	if err != nil {
 		return err

--- a/pkg/etcdenvvar/envvarcontroller_test.go
+++ b/pkg/etcdenvvar/envvarcontroller_test.go
@@ -3,9 +3,11 @@ package etcdenvvar
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/tlshelpers"
+	"github.com/openshift/library-go/pkg/crypto"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -69,17 +71,35 @@ var (
 )
 
 func TestEnvVarController(t *testing.T) {
+	// bootstrapFallbackEnv is defaultEnvResult with the OCPBUGS-94106 bootstrap
+	// fallback ciphers substituted for the observed ones.
+	bootstrapFallbackEnv := map[string]string{}
+	for k, v := range defaultEnvResult {
+		bootstrapFallbackEnv[k] = v
+	}
+	bootstrapFallbackEnv["ETCD_CIPHER_SUITES"] = strings.Join(tlshelpers.SupportedEtcdCiphers(
+		crypto.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers)), ",")
+
 	scenarios := []struct {
-		name            string
-		objects         []runtime.Object
-		staticPodStatus *operatorv1.StaticPodOperatorStatus
-		certSecret      map[string][]byte
-		expectedEnv     map[string]string
-		expectedErr     error
+		name                string
+		objects             []runtime.Object
+		staticPodStatus     *operatorv1.StaticPodOperatorStatus
+		certSecret          map[string][]byte
+		emptyObservedConfig bool
+		bootstrapComplete   bool
+		expectedEnv         map[string]string
+		expectedErr         error
 	}{
 		{
 			name:        "HappyPath",
 			expectedEnv: defaultEnvResult,
+		},
+		{
+			// OCPBUGS-94106: empty observedConfig during bootstrap must fall back
+			// (not degrade), so the first etcd revision is not blocked.
+			name:                "BootstrapFallbackNoDegrade",
+			emptyObservedConfig: true,
+			expectedEnv:         bootstrapFallbackEnv,
 		},
 		{
 			name:            "MissingNodeStatus",
@@ -99,16 +119,20 @@ func TestEnvVarController(t *testing.T) {
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			observedConfig := map[string]any{
-				"servingInfo": map[string]any{
-					"cipherSuites": []string{
-						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-						"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
-				},
+			observedConfigYaml := []byte("{}")
+			if !scenario.emptyObservedConfig {
+				observedConfig := map[string]any{
+					"servingInfo": map[string]any{
+						"cipherSuites": []string{
+							"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+							"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+							"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+					},
+				}
+				marshalled, err := yaml.Marshal(observedConfig)
+				require.NoError(t, err)
+				observedConfigYaml = marshalled
 			}
-			observedConfigYaml, err := yaml.Marshal(observedConfig)
-			require.NoError(t, err)
 
 			if scenario.staticPodStatus == nil {
 				scenario.staticPodStatus = u.StaticPodOperatorStatus(
@@ -173,6 +197,12 @@ func TestEnvVarController(t *testing.T) {
 				u.ClusterConfigConfigMap(1),
 				u.FakeSecret(operatorclient.TargetNamespace, tlshelpers.EtcdAllCertsSecretName, scenario.certSecret),
 			}
+			if scenario.bootstrapComplete {
+				defaultObjects = append(defaultObjects, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: operatorclient.KubeSystemNamespace, Name: "bootstrap"},
+					Data:       map[string]string{"status": "complete"},
+				})
+			}
 
 			fakeKubeClient := fake.NewSimpleClientset(scenario.objects...)
 			eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events(operatorclient.TargetNamespace),
@@ -195,18 +225,19 @@ func TestEnvVarController(t *testing.T) {
 			}))
 
 			controller := EnvVarController{
-				operatorClient:       fakeOperatorClient,
-				eventRecorder:        eventRecorder,
-				configmapLister:      corev1listers.NewConfigMapLister(indexer),
-				secretLister:         corev1listers.NewSecretLister(indexer),
-				infrastructureLister: configv1listers.NewInfrastructureLister(indexer),
-				masterNodeLister:     corev1listers.NewNodeLister(indexer),
-				networkLister:        configv1listers.NewNetworkLister(networkIndexer),
-				etcdLister:           operatorv1listers.NewEtcdLister(etcdIndexer),
-				featureGateAccessor:  backendQuotaFeatureGateAccessor,
+				operatorClient:           fakeOperatorClient,
+				eventRecorder:            eventRecorder,
+				configmapLister:          corev1listers.NewConfigMapLister(indexer),
+				bootstrapConfigMapLister: corev1listers.NewConfigMapLister(indexer),
+				secretLister:             corev1listers.NewSecretLister(indexer),
+				infrastructureLister:     configv1listers.NewInfrastructureLister(indexer),
+				masterNodeLister:         corev1listers.NewNodeLister(indexer),
+				networkLister:            configv1listers.NewNetworkLister(networkIndexer),
+				etcdLister:               operatorv1listers.NewEtcdLister(etcdIndexer),
+				featureGateAccessor:      backendQuotaFeatureGateAccessor,
 			}
 
-			err = controller.sync(context.TODO())
+			err := controller.sync(context.TODO())
 			require.Equal(t, err, scenario.expectedErr)
 
 			m := controller.GetEnvVars()

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-etcd-operator/pkg/tlshelpers"
 	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/bootstrap"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
 
@@ -34,14 +35,15 @@ type envVarContext struct {
 	spec   operatorv1.StaticPodOperatorSpec
 	status operatorv1.StaticPodOperatorStatus
 
-	masterNodeLister        corev1listers.NodeLister
-	masterNodeLabelSelector labels.Selector
-	infrastructureLister    configv1listers.InfrastructureLister
-	networkLister           configv1listers.NetworkLister
-	configmapLister         corev1listers.ConfigMapLister
-	targetImagePullSpec     string
-	etcdLister              operatorv1listers.EtcdLister
-	featureGateAccessor     featuregates.FeatureGateAccess
+	masterNodeLister         corev1listers.NodeLister
+	masterNodeLabelSelector  labels.Selector
+	infrastructureLister     configv1listers.InfrastructureLister
+	networkLister            configv1listers.NetworkLister
+	configmapLister          corev1listers.ConfigMapLister
+	bootstrapConfigMapLister corev1listers.ConfigMapLister
+	targetImagePullSpec      string
+	etcdLister               operatorv1listers.EtcdLister
+	featureGateAccessor      featuregates.FeatureGateAccess
 }
 
 var FixedEtcdEnvVars = map[string]string{
@@ -295,11 +297,8 @@ func getObservedTLSMinVersion(envVarContext envVarContext) (tlsutil.TLSVersion, 
 		return "", fmt.Errorf("couldn't get minTLSVersion from observedConfig: %w", err)
 	}
 
-	// map tls version to string recognized by etcd.
-	// Note: an empty observedMinTLSVersion (e.g. during bootstrap before the
-	// config observer has converged) is tolerated - crypto.TLSVersion("")
-	// returns the default (TLS 1.2) without error, matching the bootstrap
-	// etcd member rendered by pkg/cmd/render/env.go.
+	// map tls version to string recognized by etcd. An empty observedMinTLSVersion
+	// (e.g. during bootstrap) is tolerated: crypto.TLSVersion("") returns TLS 1.2.
 	v, err := crypto.TLSVersion(observedMinTLSVersion)
 	if err != nil {
 		return "", fmt.Errorf("couldn't get minTLSVersion from observedConfig: %w", err)
@@ -335,27 +334,25 @@ func getCipherSuites(envVarContext envVarContext) (map[string]string, error) {
 	actualCipherSuites := tlshelpers.SupportedEtcdCiphers(observedCipherSuites)
 
 	if len(actualCipherSuites) == 0 {
-		// During bootstrap (revision 0) the observedConfig has not converged yet:
-		// the config observer cannot populate servingInfo.cipherSuites until the
-		// control plane (apiserver/etcd) is running, but etcd cannot start until
-		// this controller produces the ETCD_CIPHER_SUITES env var. Hard-erroring
-		// here degrades the operator and blocks the first etcd revision, which can
-		// exceed the installer's 45-minute bootstrap window on slower platforms
-		// (OCPBUGS-94106). Break the deadlock by falling back to the same
-		// TLSProfileIntermediateType ciphers the render path bakes into the
-		// bootstrap etcd member (see pkg/cmd/render/env.go:getTLSCipherSuites), so
-		// etcd runs with an identical cipher set until observedConfig converges.
-		if envVarContext.status.LatestAvailableRevision == 0 {
+		// While bootstrap is in progress, observedConfig may not be populated yet
+		// (config observer can't converge until etcd runs, but etcd needs these env
+		// vars to start). Fall back to the render path's TLSProfileIntermediateType
+		// ciphers instead of degrading, which would block the first revision past
+		// the installer's bootstrap window (OCPBUGS-94106). Once bootstrap completes,
+		// an empty observedConfig is a real failure and must still degrade.
+		bootstrapComplete, err := bootstrap.IsBootstrapComplete(envVarContext.bootstrapConfigMapLister)
+		if err != nil {
+			return nil, fmt.Errorf("unable to determine bootstrap status for cipherSuites fallback: %w", err)
+		}
+		if !bootstrapComplete {
 			profileSpec := v1.TLSProfiles[v1.TLSProfileIntermediateType]
 			fallbackCiphers := crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
 			actualCipherSuites = tlshelpers.SupportedEtcdCiphers(fallbackCiphers)
-			klog.Warning("getCipherSuites: observedConfig has no cipherSuites during bootstrap (revision 0), falling back to TLSProfileIntermediateType ciphers")
+			klog.Warning("getCipherSuites: observedConfig has no cipherSuites during bootstrap, falling back to TLSProfileIntermediateType ciphers")
 		}
 
-		// Past bootstrap (revision > 0) an empty observedConfig is a genuine
-		// convergence failure and must still surface as degraded.
 		if len(actualCipherSuites) == 0 {
-			return nil, fmt.Errorf("no supported cipherSuites found in observedConfig")
+			return nil, fmt.Errorf("no supported cipherSuites not found in observedConfig")
 		}
 	}
 

--- a/pkg/etcdenvvar/etcd_env.go
+++ b/pkg/etcdenvvar/etcd_env.go
@@ -295,7 +295,11 @@ func getObservedTLSMinVersion(envVarContext envVarContext) (tlsutil.TLSVersion, 
 		return "", fmt.Errorf("couldn't get minTLSVersion from observedConfig: %w", err)
 	}
 
-	// map tls version to string recognized by etcd
+	// map tls version to string recognized by etcd.
+	// Note: an empty observedMinTLSVersion (e.g. during bootstrap before the
+	// config observer has converged) is tolerated - crypto.TLSVersion("")
+	// returns the default (TLS 1.2) without error, matching the bootstrap
+	// etcd member rendered by pkg/cmd/render/env.go.
 	v, err := crypto.TLSVersion(observedMinTLSVersion)
 	if err != nil {
 		return "", fmt.Errorf("couldn't get minTLSVersion from observedConfig: %w", err)
@@ -331,7 +335,28 @@ func getCipherSuites(envVarContext envVarContext) (map[string]string, error) {
 	actualCipherSuites := tlshelpers.SupportedEtcdCiphers(observedCipherSuites)
 
 	if len(actualCipherSuites) == 0 {
-		return nil, fmt.Errorf("no supported cipherSuites not found in observedConfig")
+		// During bootstrap (revision 0) the observedConfig has not converged yet:
+		// the config observer cannot populate servingInfo.cipherSuites until the
+		// control plane (apiserver/etcd) is running, but etcd cannot start until
+		// this controller produces the ETCD_CIPHER_SUITES env var. Hard-erroring
+		// here degrades the operator and blocks the first etcd revision, which can
+		// exceed the installer's 45-minute bootstrap window on slower platforms
+		// (OCPBUGS-94106). Break the deadlock by falling back to the same
+		// TLSProfileIntermediateType ciphers the render path bakes into the
+		// bootstrap etcd member (see pkg/cmd/render/env.go:getTLSCipherSuites), so
+		// etcd runs with an identical cipher set until observedConfig converges.
+		if envVarContext.status.LatestAvailableRevision == 0 {
+			profileSpec := v1.TLSProfiles[v1.TLSProfileIntermediateType]
+			fallbackCiphers := crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+			actualCipherSuites = tlshelpers.SupportedEtcdCiphers(fallbackCiphers)
+			klog.Warning("getCipherSuites: observedConfig has no cipherSuites during bootstrap (revision 0), falling back to TLSProfileIntermediateType ciphers")
+		}
+
+		// Past bootstrap (revision > 0) an empty observedConfig is a genuine
+		// convergence failure and must still surface as degraded.
+		if len(actualCipherSuites) == 0 {
+			return nil, fmt.Errorf("no supported cipherSuites found in observedConfig")
+		}
 	}
 
 	observedMinTLSVersion, err := getObservedTLSMinVersion(envVarContext)

--- a/pkg/etcdenvvar/etcd_env_test.go
+++ b/pkg/etcdenvvar/etcd_env_test.go
@@ -13,8 +13,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
+
+// bootstrapConfigMapLister returns a ConfigMapLister containing (or omitting)
+// the kube-system/bootstrap configmap that bootstrap.IsBootstrapComplete reads.
+func bootstrapConfigMapLister(complete bool) corev1listers.ConfigMapLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if complete {
+		_ = indexer.Add(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "bootstrap"},
+			Data:       map[string]string{"status": "complete"},
+		})
+	}
+	return corev1listers.NewConfigMapLister(indexer)
+}
 
 func TestConvertDBSize(t *testing.T) {
 	testCases := []struct {
@@ -56,11 +73,10 @@ func TestConvertDBSize(t *testing.T) {
 	}
 }
 
-// TestGetCipherSuites covers the OCPBUGS-94106 bootstrap fallback: during
-// bootstrap (revision 0) an empty observedConfig must not degrade the operator;
-// instead getCipherSuites falls back to the same TLSProfileIntermediateType
-// ciphers the render path bakes into the bootstrap etcd member. Past bootstrap
-// (revision > 0) an empty observedConfig is still a genuine failure.
+// TestGetCipherSuites covers the OCPBUGS-94106 bootstrap fallback: while bootstrap
+// is in progress an empty observedConfig falls back to the render path's
+// TLSProfileIntermediateType ciphers instead of degrading; once bootstrap is
+// complete an empty observedConfig is a genuine failure.
 func TestGetCipherSuites(t *testing.T) {
 	intermediate := tlshelpers.SupportedEtcdCiphers(
 		crypto.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
@@ -68,35 +84,33 @@ func TestGetCipherSuites(t *testing.T) {
 	require.NotEmpty(t, intermediate, "intermediate profile must yield etcd-supported ciphers")
 
 	testCases := []struct {
-		name           string
-		observedConfig []byte
-		revision       int32
-		wantErr        bool
-		wantCiphers    []string
+		name              string
+		observedConfig    []byte
+		bootstrapComplete bool
+		wantErr           bool
+		wantCiphers       []string
 	}{
 		{
-			name:           "bootstrap revision 0 with nil observedConfig falls back to intermediate ciphers",
+			name:           "bootstrap in progress with nil observedConfig falls back to intermediate ciphers",
 			observedConfig: nil,
-			revision:       0,
 			wantCiphers:    intermediate,
 		},
 		{
-			name:           "bootstrap revision 0 with empty observedConfig falls back to intermediate ciphers",
+			name:           "bootstrap in progress with empty observedConfig falls back to intermediate ciphers",
 			observedConfig: []byte("{}"),
-			revision:       0,
 			wantCiphers:    intermediate,
 		},
 		{
-			name:           "post-bootstrap revision >0 with empty observedConfig errors",
-			observedConfig: []byte("{}"),
-			revision:       3,
-			wantErr:        true,
+			name:              "bootstrap complete with empty observedConfig errors",
+			observedConfig:    []byte("{}"),
+			bootstrapComplete: true,
+			wantErr:           true,
 		},
 		{
-			name:           "observed cipherSuites are used verbatim when present",
-			observedConfig: []byte(`{"servingInfo":{"cipherSuites":["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"],"minTLSVersion":"VersionTLS12"}}`),
-			revision:       3,
-			wantCiphers:    []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+			name:              "observed cipherSuites are used verbatim when present",
+			observedConfig:    []byte(`{"servingInfo":{"cipherSuites":["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"],"minTLSVersion":"VersionTLS12"}}`),
+			bootstrapComplete: true,
+			wantCiphers:       []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
 		},
 	}
 
@@ -108,16 +122,14 @@ func TestGetCipherSuites(t *testing.T) {
 						ObservedConfig: runtime.RawExtension{Raw: tc.observedConfig},
 					},
 				},
-				status: operatorv1.StaticPodOperatorStatus{
-					OperatorStatus: operatorv1.OperatorStatus{
-						LatestAvailableRevision: tc.revision,
-					},
-				},
+				bootstrapConfigMapLister: bootstrapConfigMapLister(tc.bootstrapComplete),
 			}
 
 			got, err := getCipherSuites(ctx)
 			if tc.wantErr {
 				require.Error(t, err)
+				// guard the symptom-matched error string (EtcdBootstrapRev0CipherSuitesOCPBUGS94106)
+				assert.Contains(t, err.Error(), "no supported cipherSuites not found in observedConfig")
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/etcdenvvar/etcd_env_test.go
+++ b/pkg/etcdenvvar/etcd_env_test.go
@@ -1,9 +1,19 @@
 package etcdenvvar
 
 import (
+	"strings"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-etcd-operator/pkg/tlshelpers"
+	"github.com/openshift/library-go/pkg/crypto"
+	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestConvertDBSize(t *testing.T) {
@@ -44,4 +54,90 @@ func TestConvertDBSize(t *testing.T) {
 			assert.Equal(t, tc.exp, GibibytesToBytesString(tc.input))
 		})
 	}
+}
+
+// TestGetCipherSuites covers the OCPBUGS-94106 bootstrap fallback: during
+// bootstrap (revision 0) an empty observedConfig must not degrade the operator;
+// instead getCipherSuites falls back to the same TLSProfileIntermediateType
+// ciphers the render path bakes into the bootstrap etcd member. Past bootstrap
+// (revision > 0) an empty observedConfig is still a genuine failure.
+func TestGetCipherSuites(t *testing.T) {
+	intermediate := tlshelpers.SupportedEtcdCiphers(
+		crypto.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
+	)
+	require.NotEmpty(t, intermediate, "intermediate profile must yield etcd-supported ciphers")
+
+	testCases := []struct {
+		name           string
+		observedConfig []byte
+		revision       int32
+		wantErr        bool
+		wantCiphers    []string
+	}{
+		{
+			name:           "bootstrap revision 0 with nil observedConfig falls back to intermediate ciphers",
+			observedConfig: nil,
+			revision:       0,
+			wantCiphers:    intermediate,
+		},
+		{
+			name:           "bootstrap revision 0 with empty observedConfig falls back to intermediate ciphers",
+			observedConfig: []byte("{}"),
+			revision:       0,
+			wantCiphers:    intermediate,
+		},
+		{
+			name:           "post-bootstrap revision >0 with empty observedConfig errors",
+			observedConfig: []byte("{}"),
+			revision:       3,
+			wantErr:        true,
+		},
+		{
+			name:           "observed cipherSuites are used verbatim when present",
+			observedConfig: []byte(`{"servingInfo":{"cipherSuites":["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"],"minTLSVersion":"VersionTLS12"}}`),
+			revision:       3,
+			wantCiphers:    []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := envVarContext{
+				spec: operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ObservedConfig: runtime.RawExtension{Raw: tc.observedConfig},
+					},
+				},
+				status: operatorv1.StaticPodOperatorStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						LatestAvailableRevision: tc.revision,
+					},
+				},
+			}
+
+			got, err := getCipherSuites(ctx)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, strings.Join(tc.wantCiphers, ","), got["ETCD_CIPHER_SUITES"])
+		})
+	}
+}
+
+// TestGetObservedTLSMinVersionEmptyObservedConfig is a regression guard: an
+// empty observedConfig (e.g. during bootstrap) must not error - crypto.TLSVersion("")
+// returns the default (TLS 1.2), matching the bootstrap etcd member.
+func TestGetObservedTLSMinVersionEmptyObservedConfig(t *testing.T) {
+	ctx := envVarContext{
+		spec: operatorv1.StaticPodOperatorSpec{
+			OperatorSpec: operatorv1.OperatorSpec{
+				ObservedConfig: runtime.RawExtension{Raw: nil},
+			},
+		},
+	}
+	v, err := getObservedTLSMinVersion(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, tlsutil.TLSVersion12, v)
 }


### PR DESCRIPTION
## What

During bootstrap, `getCipherSuites()` (`pkg/etcdenvvar/etcd_env.go`) hard-errors when the operator's `observedConfig.servingInfo.cipherSuites` is still empty. That error sets `EnvVarControllerDegraded=True`, which blocks the InstallerController from creating the first etcd revision:

```
EnvVarControllerDegraded: no supported cipherSuites not found in observedConfig
InstallerControllerDegraded: missing required resources: [... secrets: etcd-all-certs-0]
StaticPodsAvailable: 0 nodes are active; 3 nodes are at revision 0
```

This is a chicken-and-egg race: the config observer cannot populate `servingInfo.cipherSuites` until the control plane is running, but etcd cannot start until this controller produces `ETCD_CIPHER_SUITES`. On slower platforms (observed on the **gcd** sovereign-cloud dev region) the window can exceed the installer's 45-minute bootstrap deadline, causing **intermittent install failures** (~20% of runs).

## Fix

Only at bootstrap (`LatestAvailableRevision == 0`), fall back to the same `TLSProfileIntermediateType` ciphers the render path already bakes into the bootstrap etcd member (`pkg/cmd/render/env.go:getTLSCipherSuites`). This is cryptographically identical to the cipher set the bootstrap etcd is already running, and is self-correcting — once `observedConfig` converges, the observed ciphers take over. Past bootstrap (`revision > 0`) an empty `observedConfig` is still a genuine convergence failure and continues to surface as degraded.

`getObservedTLSMinVersion()` already tolerates an empty `observedConfig` (`crypto.TLSVersion("")` returns the TLS 1.2 default); a clarifying comment was added.

## Why not #1659

The previously merged mitigation (#1659) added the APIServer informer to the `EnvVarController` cache sync. That only waits for the informer **cache** to sync, not for the config observer to **populate** `observedConfig`, so the race persists on slow environments. Waiting harder cannot fix this (the deadlock above); a bootstrap fallback is required. This PR revives the approach originally proposed in #1645, which stalled for process reasons (JIRA target-version validation, review latency) rather than technical ones.

## Testing

- `go test ./pkg/etcdenvvar/...` passes, including new table-driven `TestGetCipherSuites` (bootstrap fallback at revision 0 for nil/empty `observedConfig`; error preserved at revision > 0; observed ciphers used verbatim when present) and `TestGetObservedTLSMinVersionEmptyObservedConfig`.
- Still needed before merge: payload/e2e validation on `e2e-gcd-ovn`, `e2e-gcd-ovn-techpreview`, and `e2e-gcp-ovn-serial` (failure is intermittent ~20%, so several runs are required to demonstrate the fix).

## Evidence

Representative failing run: `periodic-ci-openshift-release-main-ci-5.0-e2e-gcd-ovn-techpreview/2092492579135295488` (payload `5.0.0-0.ci-2026-08-25-144245`, etcd-operator commit downstream of the #1659 merge): the cipher error fired ~1230× over ~12 min (06:51:48 → 07:03:38 UTC), etcd stuck at revision 0, bootstrap timed out at 07:08:19, then recovered a few minutes later.

---
This PR was drafted with AI assistance (opencode / Claude Opus 4.8). Please verify before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS bootstrapping when minimum TLS version information is unavailable by defaulting to TLS 1.2.
  * Added a safe fallback to intermediate-profile cipher suites during initial setup.
  * Preserved validation errors when cipher-suite configuration is missing after bootstrapping.
  * Corrected the cipher-suite configuration error message.
  * Improved bootstrap detection to ensure cipher settings update at the appropriate stage.

* **Tests**
  * Added regression coverage for TLS defaults, bootstrap detection, cipher-suite fallback behavior, and empty configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->